### PR TITLE
Aligning develop with master

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,27 +1,30 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
-labels: bug
+title: "[BUG]"
+labels: 'Type: Bug'
 assignees: ''
 
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is.-->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen.-->
 
 **To Reproduce**
+<!--
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
-
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+-->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem.-->
+
 
 **Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,22 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: enhancement
+title: "[FEATURE]"
+labels: 'Type: Enhancement'
 assignees: ''
 
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is. 
+Ex. I'm always frustrated when [...]
+-->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen.-->
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered.-->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here.-->

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TJ-Bot
 
-[![codefactor](https://img.shields.io/codefactor/grade/github/together-java/tj-bot)](ttps://www.codefactor.io/repository/github/together-java/tj-bot)
+[![codefactor](https://img.shields.io/codefactor/grade/github/together-java/tj-bot)](https://www.codefactor.io/repository/github/together-java/tj-bot)
 ![Java](https://img.shields.io/badge/Java-17%2B-ff696c)
 [![license](https://img.shields.io/github/license/Together-Java/TJ-Bot)](https://github.com/Together-Java/TJ-Bot/blob/master/LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # TJ-Bot
 
+[![codefactor](https://img.shields.io/codefactor/grade/github/together-java/tj-bot)](ttps://www.codefactor.io/repository/github/together-java/tj-bot)
 ![Java](https://img.shields.io/badge/Java-17%2B-ff696c)
 [![license](https://img.shields.io/github/license/Together-Java/TJ-Bot)](https://github.com/Together-Java/TJ-Bot/blob/master/LICENSE)
 


### PR DESCRIPTION
We just introduced `develop` but some old changes slipped into `master` still. This will align the two branches and from there on we start development in `develop` and mirror to `master` only on releases and similar.