### PR TITLE
Align chopped down chains at "." character

### DIFF
--- a/meta/formatting/google-style-eclipse.xml
+++ b/meta/formatting/google-style-eclipse.xml
@@ -76,7 +76,7 @@
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="82"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
@@ -89,7 +89,7 @@
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="100"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation.count_dependent" value="16|4|48"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation.count_dependent" value="16|4|82"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>

--- a/src/main/java/org/togetherjava/tjbot/Main.java
+++ b/src/main/java/org/togetherjava/tjbot/Main.java
@@ -26,10 +26,9 @@ public enum Main {
 
         logger.info("Starting bot...");
         try {
-            JDA jda = JDABuilder
-                    .createDefault(token)
-                    .addEventListeners(new PingPongListener())
-                    .build();
+            JDA jda = JDABuilder.createDefault(token)
+                                .addEventListeners(new PingPongListener())
+                                .build();
             jda.awaitReady();
             logger.info("Bot is ready");
         } catch (LoginException e) {


### PR DESCRIPTION
This keeps the first method call on the same line and aligns on the
".":

```java
JDA jda = JDABuilder.createDefault(token)
                    .addEventListeners(new PingPongListener())
                    .build();
```
instead of
```java
JDA jda = JDABuilder
        .createDefault(token)
        .addEventListeners(new PingPongListener())
        .build();
```