### PR TITLE
Run spotless on compile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ test {
     useJUnitPlatform()
 }
 
+compileJava.dependsOn 'spotlessApply'
 spotless {
     java {
         eclipse().configFile('meta/formatting/google-style-eclipse.xml')


### PR DESCRIPTION
Makes compilation depend on `spotlessApply`, which means code is automatically formatted before each compile/build.