### PR TITLE
Externalize JDK version for github actions as a secret 🚀

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 16
+        java-version: ${{ secrets.JAVA_VERSION }}
     - name: Checkout repository
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 16
+          java-version: ${{ secrets.JAVA_VERSION }}
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
         with:

--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 16
+          java-version: ${{ secrets.JAVA_VERSION }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 16
+          java-version: ${{ secrets.JAVA_VERSION }}
       - uses: actions/checkout@v2
       - name: Check
         run: ./gradlew test


### PR DESCRIPTION
Fixes #70 

Externalizing JDK version would help us to better manage it from a central place. Github secrets in this case.