### PR TITLE
Run workflows with pull requests's version

### DIFF
--- a/.github/workflows/basic-checks.yml
+++ b/.github/workflows/basic-checks.yml
@@ -1,6 +1,9 @@
 name: Basic checks
 
-on: [pull_request_target]
+on: [pull_request]
+
+env:
+  JAVA_VERSION: 16
 
 jobs:
   spotless:
@@ -10,7 +13,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ secrets.JAVA_VERSION }}
+          java-version: ${{ env.JAVA_VERSION }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
@@ -24,7 +27,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ secrets.JAVA_VERSION }}
+          java-version: ${{ env.JAVA_VERSION }}
       - uses: actions/checkout@v2
       - name: Check
         run: ./gradlew test
@@ -40,7 +43,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ secrets.JAVA_VERSION }}
+          java-version: ${{ env.JAVA_VERSION }}
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 20 * * 4'
 
+env:
+  JAVA_VERSION: 16
+
 jobs:
   analyze:
     name: Analyze
@@ -27,7 +30,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: ${{ secrets.JAVA_VERSION }}
+        java-version: ${{ env.JAVA_VERSION }}
     - name: Checkout repository
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,6 +1,9 @@
 name: Docker Verify
 
-on: [pull_request_target]
+on: [pull_request]
+
+env:
+  JAVA_VERSION: 16
 
 jobs:
   docker:
@@ -10,7 +13,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ secrets.JAVA_VERSION }}
+          java-version: ${{ env.JAVA_VERSION }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'develop'
 
+env:
+  JAVA_VERSION: 16
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -12,7 +15,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ secrets.JAVA_VERSION }}
+          java-version: ${{ env.JAVA_VERSION }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0


### PR DESCRIPTION
This ensures we notice a gradle/workflow change is broken *before* it is merged. We originally didn't do that so we could de-duplicate the java version, but it is not worth the cost.