### PR TITLE
Automatically deploy develop branch

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -24,3 +24,5 @@ jobs:
           REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
         run: ./gradlew jib
+      - name: Re-Deploy
+        run: "curl -H 'Authorization: Bearer ${{ secrets.WATCHTOWER_TOKEN }}' https://togetherjava.duckdns.org:5003/v1/update"


### PR DESCRIPTION
This PR automatically deploys the `develop` branch of the bot. The docker images for master/develop are not yet separated, but that is needed in the future to also deploy the master branch.