### PR TITLE
Add some basic access checks to the example database command

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/DatabaseListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/DatabaseListener.java
@@ -1,5 +1,6 @@
 package org.togetherjava.tjbot;
 
+import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -51,6 +52,15 @@ public final class DatabaseListener extends ListenerAdapter {
             return;
         }
         if (!event.isFromType(ChannelType.TEXT)) {
+            return;
+        }
+        if (event.isWebhookMessage()) {
+            return;
+        }
+        if (event.isFromType(ChannelType.PRIVATE)) {
+            return;
+        }
+        if (!event.getMember().hasPermission(Permission.MESSAGE_MANAGE)) {
             return;
         }
 


### PR DESCRIPTION
If we invite the bot to the server we want to block users from entering arbitrary messages in the database until we have a proper tag system.