### PR TITLE
Create Github releases with a runnable jar on tag push

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -1,0 +1,36 @@
+name: Release JAR
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  JAVA_VERSION: 16
+
+jobs:
+
+  release:
+    name: Build and release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - uses: actions/checkout@v2
+
+      - name: Build shadow jar
+        run: ./gradlew shadowJar
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: application/build/libs/TJ-Bot.jar

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -9,6 +9,7 @@ plugins {
     id 'com.google.cloud.tools.jib' version '3.1.4'
     id "org.flywaydb.flyway" version "7.15.0"
     id 'nu.studer.jooq' version '6.0.1'
+    id 'com.github.johnrengelman.shadow' version '7.0.0'
 }
 
 repositories {
@@ -86,6 +87,16 @@ jooq {
 
 tasks.generateJooq {
     dependsOn("flywayMigrate")
+}
+
+application {
+    mainClass = "org.togetherjava.tjbot.Application"
+}
+
+shadowJar {
+    archiveBaseName.set('TJ-Bot')
+    archiveClassifier.set('')
+    archiveVersion.set('')
 }
 
 var sqliteVersion = "3.36.0.3"

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -89,10 +89,6 @@ tasks.generateJooq {
     dependsOn("flywayMigrate")
 }
 
-application {
-    mainClass = "org.togetherjava.tjbot.Application"
-}
-
 shadowJar {
     archiveBaseName.set('TJ-Bot')
     archiveClassifier.set('')


### PR DESCRIPTION
Closes #102. When a new tag named `v.*.*` is pushed, the new workflow automatically creates a shadow jar and uploads it as a release.

The description of the tag is used for the release notes, so all tags pushed should be *annotated* tags (`git tag -a`).