### PR TITLE
Remove db package-info from application module

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/db/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/db/package-info.java
@@ -1,5 +1,0 @@
-/**
- * This package contains the database management of the application. See
- * {@link org.togetherjava.tjbot.db.Database} to get started.
- */
-package org.togetherjava.tjbot.db;


### PR DESCRIPTION
The file was duplicated. This PR just removes it from the old place in the application module.