### PR TITLE
Fix or mute sonarlint rule violations

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/DatabaseListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/DatabaseListener.java
@@ -31,6 +31,7 @@ import java.util.Optional;
  * }
  * </pre>
  */
+// TODO: Remove this class after #127 has been merged
 public final class DatabaseListener extends ListenerAdapter {
 
     private static final Logger logger = LoggerFactory.getLogger(DatabaseListener.class);
@@ -132,7 +133,9 @@ public final class DatabaseListener extends ListenerAdapter {
         String key = data[1];
 
         try {
-            Optional<StorageRecord> foundValue = database.read(context -> {
+            // The lambda needs to be a block so the return type can distinguish between the two
+            // read/write methods. This feels like a sonar bug.
+            Optional<StorageRecord> foundValue = database.read(context -> { // NOSONAR
                 return Optional.ofNullable(context.selectFrom(Storage.STORAGE)
                     .where(Storage.STORAGE.KEY.eq(key))
                     .fetchOne());

--- a/application/src/main/java/org/togetherjava/tjbot/commands/example/CommandExample.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/example/CommandExample.java
@@ -1,5 +1,6 @@
 package org.togetherjava.tjbot.commands.example;
 
+import java.util.List;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.ButtonClickEvent;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
@@ -14,12 +15,11 @@ import net.dv8tion.jda.api.interactions.components.Component;
 import net.dv8tion.jda.api.requests.restaction.CommandCreateAction;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
-
 /**
  * Example command
  *
  */
+// TODO: Remove this class after #127 has been merged
 public class CommandExample extends AbstractCommand {
 
     /**
@@ -62,6 +62,7 @@ public class CommandExample extends AbstractCommand {
      * @param event A {@link SlashCommandEvent} to respond to.
      */
     @Override
+    @SuppressWarnings({"squid:S1854", "squid:S1481"})
     public void onSlashCommand(SlashCommandEvent event) {
         // * gets the option as a user
         User userToMention = event.getOption("user").getAsUser();

--- a/application/src/main/java/org/togetherjava/tjbot/commands/example/SubCommandExample.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/example/SubCommandExample.java
@@ -71,28 +71,23 @@ public class SubCommandExample extends AbstractCommand {
      */
     @Override
     public void onSlashCommand(SlashCommandEvent event) {
-
         // * get the subcommand
-        switch (event.getSubcommandName()) {
-            // * if it's "ping", run the ping command.
-            case "ping" -> {
-                User userToPing = event.getOption("user").getAsUser();
+        String subcommandName = event.getSubcommandName();
 
-                event.reply(userToPing.getAsMention() + " pinging like this is useless ;)")
-                    .setEphemeral(true)
-                    .queue();
-            }
+        if ("ping".equals(subcommandName)) {
+            User userToPing = event.getOption("user").getAsUser();
 
-            // * if it's "Hello", run the hello command.
-            case "hello" -> {
-                OptionMapping userOption = event.getOption("user");
+            event.reply(userToPing.getAsMention() + " pinging like this is useless ;)")
+                .setEphemeral(true)
+                .queue();
+        } else if ("hello".equals(subcommandName)) {
+            OptionMapping userOption = event.getOption("user");
 
-                if (userOption == null) {
-                    event.reply("Hello!").queue();
-                } else {
-                    User userToPing = userOption.getAsUser();
-                    event.reply("Hello " + userToPing.getAsMention() + "!").queue();
-                }
+            if (userOption == null) {
+                event.reply("Hello!").queue();
+            } else {
+                User userToPing = userOption.getAsUser();
+                event.reply("Hello " + userToPing.getAsMention() + "!").queue();
             }
         }
     }


### PR DESCRIPTION
This is in preparation for #123 and fixes all current sonarlint violations *except* `TODO` which should likely be disabled in #123.