### PR TITLE
Skip SonarCloud on fork PRs

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -14,6 +14,8 @@ jobs:
   sonar:
     name: SonarCloud
     runs-on: ubuntu-latest
+    # Skip this on PRs from forks as it will fail anyways as it needs secrets
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Previously SonarCloud's analysis was run for every PR but always failed on forks as they did not have access to the relevant secrets. This PR skips SonarCloud's analysis on PRs from forks.