### PR TITLE
Fix Database flyway migration path

### DIFF
--- a/database/src/main/java/org/togetherjava/tjbot/db/Database.java
+++ b/database/src/main/java/org/togetherjava/tjbot/db/Database.java
@@ -46,10 +46,8 @@ public final class Database {
         SQLiteDataSource dataSource = new SQLiteDataSource(sqliteConfig);
         dataSource.setUrl(jdbcUrl);
 
-        Flyway flyway = Flyway.configure()
-            .dataSource(dataSource)
-            .locations("/org/togetherjava/tjbot/db")
-            .load();
+        Flyway flyway =
+                Flyway.configure().dataSource(dataSource).locations("classpath:/db/").load();
         flyway.migrate();
 
         dslContext = DSL.using(dataSource.getConnection(), SQLDialect.SQLITE);


### PR DESCRIPTION
Previously the path wasn't set correctly and consequently no migrations were applied at runtime.