### PR TITLE
Bot does not create necessary Directories for the DB

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/Application.java
+++ b/application/src/main/java/org/togetherjava/tjbot/Application.java
@@ -70,7 +70,7 @@ public enum Application {
     public static void runBot(String token, Path databasePath) {
         logger.info("Starting bot...");
         try {
-            Files.createDirectories(databasePath);
+            Files.createDirectories(databasePath.getParent());
             Database database = new Database("jdbc:sqlite:" + databasePath.toAbsolutePath());
 
             JDA jda = JDABuilder.createDefault(token)


### PR DESCRIPTION
Currently the main Bot does not create any necessary Directories to the Path specified in the  `config.json` resulting in not being able to start with just following the wiki.

This 3 Line change fixes this.