### PR TITLE
Add a Boostrap launcher without dependencies to initialize the system

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -30,7 +30,8 @@ jib {
             password = System.getenv('REGISTRY_PASSWORD') ?: ''
         }
     }
-    container{
+    container {
+        mainClass = 'org.togetherjava.tjbot.BootstrapLauncher'
         setCreationTime(java.time.Instant.now().toString())
     }
 }
@@ -60,7 +61,7 @@ dependencies {
 }
 
 application {
-    mainClass = 'org.togetherjava.tjbot.Application'
+    mainClass = 'org.togetherjava.tjbot.BootstrapLauncher'
 }
 
 test {

--- a/application/src/main/java/org/togetherjava/tjbot/Application.java
+++ b/application/src/main/java/org/togetherjava/tjbot/Application.java
@@ -41,8 +41,6 @@ public enum Application {
                     + DEFAULT_CONFIG_PATH + "' will be assumed.");
         }
 
-        setSystemProperties();
-
         Path configPath = Path.of(args.length == 1 ? args[0] : DEFAULT_CONFIG_PATH);
         try {
             Config.load(configPath);
@@ -96,22 +94,4 @@ public enum Application {
         logger.info("Bot has been stopped");
     }
 
-    /**
-     * Sets any system-properties before anything else is touched.
-     */
-    private static void setSystemProperties() {
-        final int cores = Runtime.getRuntime().availableProcessors();
-        if (cores <= 1) {
-            // If we are in a docker container, we officially might just have 1 core
-            // and Java would then set the parallelism of the common ForkJoinPool to 0.
-            // And 0 means no workers, so JDA cannot function, no Callback's on REST-Requests
-            // are executed
-            // NOTE This will likely be fixed with Java 18 or newer, remove afterwards (see
-            // https://bugs.openjdk.java.net/browse/JDK-8274349 and
-            // https://github.com/openjdk/jdk/pull/5784)
-            logger.debug("Available Cores \"{}\", setting Parallelism Flag", cores);
-            // noinspection AccessOfSystemProperties
-            System.setProperty("java.util.concurrent.ForkJoinPool.common.parallelism", "1");
-        }
-    }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/BootstrapLauncher.java
+++ b/application/src/main/java/org/togetherjava/tjbot/BootstrapLauncher.java
@@ -1,0 +1,37 @@
+package org.togetherjava.tjbot;
+
+/**
+ * A bootstrap launcher with minimal dependencies that sets up needed parts and workarounds for the
+ * main logic to take over.
+ */
+public enum BootstrapLauncher {
+
+    ;
+
+    public static void main(String[] args) {
+        setSystemProperties();
+
+        Application.main(args);
+    }
+
+
+    /**
+     * Sets any system-properties before anything else is touched.
+     */
+    @SuppressWarnings("squid:S106") // we can not afford any dependencies, even on a logger
+    private static void setSystemProperties() {
+        final int cores = Runtime.getRuntime().availableProcessors();
+        if (cores <= 1) {
+            // If we are in a docker container, we officially might just have 1 core
+            // and Java would then set the parallelism of the common ForkJoinPool to 0.
+            // And 0 means no workers, so JDA cannot function, no Callback's on REST-Requests
+            // are executed
+            // NOTE This will likely be fixed with Java 18 or newer, remove afterwards (see
+            // https://bugs.openjdk.java.net/browse/JDK-8274349 and
+            // https://github.com/openjdk/jdk/pull/5784)
+            System.out.println("Available Cores \"" + cores + "\", setting Parallelism Flag");
+            // noinspection AccessOfSystemProperties
+            System.setProperty("java.util.concurrent.ForkJoinPool.common.parallelism", "1");
+        }
+    }
+}


### PR DESCRIPTION
The main method previously initialized the logger before setting the system properties, leading to issues with the ForkJoinPool.