### PR TITLE
Improve available commands log

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/CommandSystem.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/CommandSystem.java
@@ -65,7 +65,7 @@ public final class CommandSystem extends ListenerAdapter implements SlashCommand
         nameToSlashCommands.put(RELOAD_COMMAND, new ReloadCommand(this));
 
         if (logger.isInfoEnabled()) {
-            logger.info("Available commands: {}", nameToSlashCommands.values());
+            logger.info("Available commands: {}", nameToSlashCommands.keySet());
         }
     }
 


### PR DESCRIPTION
Improves the log message that comes during startup.

Before:
```java
Available commands: [org.togetherjava.tjbot.commands.system.ReloadCommand@1ad777f, org.togetherjava.tjbot.commands.basic.PingCommand@5bbbdd4b, org.togetherjava.tjbot.commands.basic.DatabaseCommand@438bad7c]
```
After:
```java
Available commands: [reload, ping, db]
```