### PR TITLE
Fixes a bug with DB paths that have no parents

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/Application.java
+++ b/application/src/main/java/org/togetherjava/tjbot/Application.java
@@ -68,7 +68,10 @@ public enum Application {
     public static void runBot(String token, Path databasePath) {
         logger.info("Starting bot...");
         try {
-            Files.createDirectories(databasePath.getParent());
+            Path parentDatabasePath = databasePath.toAbsolutePath().getParent();
+            if (parentDatabasePath != null) {
+                Files.createDirectories(parentDatabasePath);
+            }
             Database database = new Database("jdbc:sqlite:" + databasePath.toAbsolutePath());
 
             JDA jda = JDABuilder.createDefault(token)
@@ -86,9 +89,8 @@ public enum Application {
         } catch (SQLException e) {
             logger.error("Failed to create database", e);
         } catch (IOException e) {
-            logger.error(
-                    "Failed to create Path to the Database at: " + databasePath.toAbsolutePath(),
-                    e);
+            logger.error("Failed to create path to the database at: {}",
+                    databasePath.toAbsolutePath(), e);
         }
     }
 


### PR DESCRIPTION
When using a DB path that has no direct parents, for example a relative path in the same directory like `local-database.db` (as recommended by the tutorial), the old code crashed since `getParent()` returned `null`.

This fixes it by:
1. using the absolute path before `getParent()`
2. checking the result of `getParent()` for `null`

(also fixed a minor linter issue with the log message)