### PR TITLE
Less spammy dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,8 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Closes #183 

- monthly
- only major updates (no patch, no minor)
- up to 10 at a time (default was 5)