### PR TITLE
Added .DS_STORE to gitignore (mac users)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ logviewer/types.d.ts
 logviewer/pnpm-lock.yaml
 logviewer/webpack.config.js
 logviewer/webpack.generated.js
+.DS_Store


### PR DESCRIPTION
`.DS_STORE` is a metafile usually seen on MAC. According to a quick google research, it should be put on gitignore

(we have one contributor using MAC already who spot this problem)