### PR TITLE
UX tag system - Suggest tags if typo

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagCommand.java
@@ -39,7 +39,7 @@ public final class TagCommand extends SlashCommandAdapter {
     @Override
     public void onSlashCommand(@NotNull SlashCommandEvent event) {
         String id = Objects.requireNonNull(event.getOption(ID_OPTION)).getAsString();
-        if (tagSystem.isUnknownTagAndHandle(id, event)) {
+        if (tagSystem.handleIsUnknownTag(id, event)) {
             return;
         }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagManageCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagManageCommand.java
@@ -140,7 +140,7 @@ public final class TagManageCommand extends SlashCommandAdapter {
 
     private void rawTag(@NotNull SlashCommandEvent event) {
         String id = Objects.requireNonNull(event.getOption(ID_OPTION)).getAsString();
-        if (tagSystem.isUnknownTagAndHandle(id, event)) {
+        if (tagSystem.handleIsUnknownTag(id, event)) {
             return;
         }
 
@@ -263,7 +263,7 @@ public final class TagManageCommand extends SlashCommandAdapter {
     private boolean isWrongTagStatusAndHandle(@NotNull TagStatus requiredTagStatus,
             @NotNull String id, @NotNull Interaction event) {
         if (requiredTagStatus == TagStatus.EXISTS) {
-            return tagSystem.isUnknownTagAndHandle(id, event);
+            return tagSystem.handleIsUnknownTag(id, event);
         } else if (requiredTagStatus == TagStatus.NOT_EXISTS) {
             if (tagSystem.hasTag(id)) {
                 event.reply("The tag with id '%s' already exists.".formatted(id))

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagSystem.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagSystem.java
@@ -5,6 +5,7 @@ import net.dv8tion.jda.api.interactions.Interaction;
 import net.dv8tion.jda.api.interactions.components.Button;
 import net.dv8tion.jda.api.interactions.components.ButtonStyle;
 import org.jetbrains.annotations.NotNull;
+import org.togetherjava.tjbot.commands.utils.StringDistances;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.Tags;
 import org.togetherjava.tjbot.db.generated.tables.records.TagsRecord;
@@ -57,12 +58,16 @@ public final class TagSystem {
      * @param event the event to send messages with
      * @return whether the given tag is unknown to the system
      */
-    boolean isUnknownTagAndHandle(@NotNull String id, @NotNull Interaction event) {
+    @SuppressWarnings("BooleanMethodNameMustStartWithQuestion")
+    boolean handleIsUnknownTag(@NotNull String id, @NotNull Interaction event) {
         if (hasTag(id)) {
             return false;
         }
-        // TODO Add fuzzy string matching suggestions (Levenshtein edit distance)
-        event.reply("Could not find any tag with id '%s'.".formatted(id))
+        String suggestionText = StringDistances.closestMatch(id, getAllIds())
+            .map(", did you perhaps mean '%s'?"::formatted)
+            .orElse(".");
+
+        event.reply("Could not find any tag with id '%s'%s".formatted(id, suggestionText))
             .setEphemeral(true)
             .queue();
         return true;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/StringDistances.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/StringDistances.java
@@ -1,0 +1,146 @@
+package org.togetherjava.tjbot.commands.utils;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+/**
+ * Utility class for computing string distances, for example the edit distance between two words.
+ */
+public enum StringDistances {
+    ;
+
+    /**
+     * Computes the candidate that matches the given query string best.
+     *
+     * It is given that, if the candidates contain the query literally, the query will also be the
+     * returned match. If the candidates do not contain the query literally, the best match will be
+     * determined. The measures for this are unspecified.
+     * 
+     * @param query the query string to find a match for
+     * @param candidates the set of candidates to select a match from
+     * @param <S> the type of the candidates
+     * @return the best matching candidate, or empty iff the candidates are empty
+     */
+    public static <S extends CharSequence> Optional<S> closestMatch(@NotNull CharSequence query,
+            @NotNull Collection<S> candidates) {
+        return candidates.stream()
+            .min(Comparator.comparingInt(candidate -> editDistance(query, candidate)));
+    }
+
+    /**
+     * Attempts to autocomplete the given prefix string by selecting the candidate that matches the
+     * prefix best.
+     *
+     * It is given that, if the candidates contain the query literally, the query will also be the
+     * returned match. If the candidates do not contain the query literally, the best match will be
+     * determined. The measures for this are unspecified.
+     * 
+     * @param prefix the prefix string to find a match for
+     * @param candidates the set of candidates to select a match from
+     * @param <S> the type of the candidates
+     * @return the best matching candidate, or empty iff the candidates are empty
+     */
+    public static <S extends CharSequence> Optional<S> autocomplete(@NotNull CharSequence prefix,
+            @NotNull Collection<S> candidates) {
+        return candidates.stream()
+            .min(Comparator.comparingInt(candidate -> prefixEditDistance(prefix, candidate)));
+    }
+
+    /**
+     * Distance to receive {@code destination} from {@code source} by editing.
+     *
+     * For example {@code editDistance("hello", "hallo")} is {@code 1}.
+     *
+     * @param source the source string to start with
+     * @param destination the destination string to receive by editing the source
+     * @return the edit distance
+     */
+    public static int editDistance(@NotNull CharSequence source,
+            @NotNull CharSequence destination) {
+        // Given by the value in the last row and column
+        int[][] table = computeLevenshteinDistanceTable(source, destination);
+        int rows = table.length;
+        int columns = table[0].length;
+
+        return table[rows - 1][columns - 1];
+    }
+
+    /**
+     * Distance to receive a prefix of {@code destination} from {@code source} by editing that
+     * minimizes the distance.
+     *
+     * For example {@code prefixEditDistance("foa", "foobar")} is {@code 1}.
+     *
+     * @param source the source string to start with
+     * @param destination the destination string to receive a prefix of by editing the source
+     * @return the prefix edit distance
+     */
+    public static int prefixEditDistance(@NotNull CharSequence source,
+            @NotNull CharSequence destination) {
+        // Given by the smallest value in the last row
+        int[][] table = computeLevenshteinDistanceTable(source, destination);
+        int lastRowIndex = table.length - 1;
+
+        return Arrays.stream(table[lastRowIndex]).min().orElseThrow();
+    }
+
+    /**
+     * Computes the Levenshtein distance table for the given strings. See
+     * <a href="https://en.wikipedia.org/wiki/Levenshtein_distance">Levenshtein distance</a> for
+     * details.
+     *
+     * An example for {@code "abc"} to {@code "abcdefg"} would be:
+     * 
+     * <pre>
+     *   | 0 a b c d e f g
+     * -------------------
+     * 0 | 0 1 2 3 4 5 6 7
+     * a | 1 0 1 2 3 4 5 6
+     * b | 2 1 0 1 2 3 4 5
+     * c | 3 2 1 0 1 2 3 4
+     * </pre>
+     * 
+     * @param source the source string to start with
+     * @param destination the destination string to receive by editing the source
+     * @return the levenshtein distance table
+     */
+    private static int @NotNull [][] computeLevenshteinDistanceTable(@NotNull CharSequence source,
+            @NotNull CharSequence destination) {
+        int rows = source.length() + 1;
+        int columns = destination.length() + 1;
+        int[][] table = new int[rows][columns];
+
+        // Initialize first row and column for distances from the empty word to the target word
+        for (int y = 0; y < columns; y++) {
+            table[0][y] = y;
+        }
+        for (int x = 0; x < rows; x++) {
+            table[x][0] = x;
+        }
+
+        // Process row by row, selecting diagonal candidates
+        for (int x = 1; x < rows; x++) {
+            for (int y = 1; y < columns; y++) {
+                // Take minimum of all candidates
+                int upperCandidate = table[x - 1][y] + 1;
+                int leftCandidate = table[x][y - 1] + 1;
+                int diagonalCandidate = table[x - 1][y - 1];
+                if (source.charAt(x - 1) != destination.charAt(y - 1)) {
+                    diagonalCandidate++;
+                }
+
+                int bestCandidate = IntStream.of(upperCandidate, leftCandidate, diagonalCandidate)
+                    .min()
+                    .orElseThrow();
+                table[x][y] = bestCandidate;
+            }
+        }
+
+        return table;
+    }
+}

--- a/application/src/test/java/org/togetherjava/tjbot/commands/utils/StringDistancesTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/utils/StringDistancesTest.java
@@ -1,0 +1,51 @@
+package org.togetherjava.tjbot.commands.utils;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+final class StringDistancesTest {
+
+    @Test
+    void editDistance() {
+        record TestCase(@NotNull String name, int expectedDistance, @NotNull String source,
+                @NotNull String destination) {
+        }
+        List<TestCase> tests = List.of(new TestCase("identity", 0, "-", "-"),
+                new TestCase("empty_identity", 0, "", ""), new TestCase("empty_remove", 1, "a", ""),
+                new TestCase("empty_add", 1, "", "a"), new TestCase("basic", 4, "bloed", "doof"),
+                new TestCase("basic_all", 3, "---", "abc"),
+                new TestCase("prefix", 4, "abc", "abcdefg"),
+                new TestCase("small_diff", 5, "acc", "abcdefg"),
+                new TestCase("swap", 5, "acb", "abcdefg"));
+
+        for (TestCase test : tests) {
+            assertEquals(test.expectedDistance,
+                    StringDistances.editDistance(test.source, test.destination),
+                    "Test '%s' failed".formatted(test.name));
+        }
+    }
+
+    @Test
+    void prefixEditDistance() {
+        record TestCase(@NotNull String name, int expectedDistance, @NotNull String source,
+                @NotNull String destination) {
+        }
+        List<TestCase> tests = List.of(new TestCase("identity", 0, "-", "-"),
+                new TestCase("empty_identity", 0, "", ""), new TestCase("empty_remove", 1, "a", ""),
+                new TestCase("empty_add", 0, "", "a"), new TestCase("basic", 4, "bloed", "doof"),
+                new TestCase("basic_all", 3, "---", "abc"),
+                new TestCase("prefix", 0, "abc", "abcdefg"),
+                new TestCase("small_diff", 1, "acc", "abcdefg"),
+                new TestCase("swap", 1, "acb", "abcdefg"));
+
+        for (TestCase test : tests) {
+            assertEquals(test.expectedDistance,
+                    StringDistances.prefixEditDistance(test.source, test.destination),
+                    "Test '%s' failed".formatted(test.name));
+        }
+    }
+}


### PR DESCRIPTION
### Overview

Implements and closes #250 .

If a user types a tag wrong, for example `/tag hello` instead of `/tag hallo` or similar, the system will now suggest the best matching alternative:

![BplvCXF](https://user-images.githubusercontent.com/13614011/140723260-453efbe5-20aa-49d4-a318-3c0ddb0a7674.png)

This applies to all tag commands:
* `/tag id`
* `/tag-manage raw id`
* `/tag-manage delete id`
* `/tag-manage edit id`
* and more...

### Details

The current implementation is based on [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) and **has unit test coverage**.

The utility is exposed via a new `StringDistances` utility class, which also offers useful related methods for other commands in the future, for example an `autocomplete` method, which could be useful in a search-as-you-type system.

---
### Button idea

To enhance the UX further, I was thinking of adding some sort of `Yes`, `No` buttons, which the user could click instead of having to write the command again.

While this is a cool and also easy idea, I ran into one issue that makes this a bad UX. Namely, the error message and the buttons should be **ephemeral** but the final response, after clicking `Yes` would **not be ephemeral**. This can only be realized by sending a totally new message, and not by simply editing the original message. But then the command has no context for other users, i.e. `"Bob used /tag ..."` is then not displayed.

So this idea **basically fails** due to
* not being able to either change the ephemeral status of an already send message,
* or not being able to resend an existing message (with different attributes),
* or not being able to fake a slash command usage with a bot