### PR TITLE
Migrate mute, unmute commands

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/Application.java
+++ b/application/src/main/java/org/togetherjava/tjbot/Application.java
@@ -2,6 +2,7 @@ package org.togetherjava.tjbot;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.requests.GatewayIntent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.Commands;
@@ -77,14 +78,11 @@ public enum Application {
             Database database = new Database("jdbc:sqlite:" + databasePath.toAbsolutePath());
 
             JDA jda = JDABuilder.createDefault(token)
-                .addEventListeners(new CommandSystem(database))
+                .enableIntents(GatewayIntent.GUILD_MEMBERS)
                 .build();
+            jda.addEventListener(new CommandSystem(jda, database));
             jda.awaitReady();
             logger.info("Bot is ready");
-
-            // TODO This should be moved into some proper command system instead (see GH issue #235
-            // which adds support for routines)
-            new ModAuditLogRoutine(jda, database).start();
 
             Runtime.getRuntime().addShutdownHook(new Thread(Application::onShutdown));
         } catch (LoginException e) {

--- a/application/src/main/java/org/togetherjava/tjbot/Application.java
+++ b/application/src/main/java/org/togetherjava/tjbot/Application.java
@@ -9,7 +9,6 @@ import org.togetherjava.tjbot.commands.Commands;
 import org.togetherjava.tjbot.commands.system.CommandSystem;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.db.Database;
-import org.togetherjava.tjbot.routines.ModAuditLogRoutine;
 
 import javax.security.auth.login.LoginException;
 import java.io.IOException;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Commands.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Commands.java
@@ -57,8 +57,8 @@ public enum Commands {
         commands.add(new UnbanCommand(actionsStore));
         commands.add(new FreeCommand());
         commands.add(new AuditCommand(actionsStore));
-        commands.add(new MuteCommand());
-        commands.add(new UnmuteCommand());
+        commands.add(new MuteCommand(actionsStore));
+        commands.add(new UnmuteCommand(actionsStore));
 
         return commands;
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Commands.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Commands.java
@@ -1,5 +1,6 @@
 package org.togetherjava.tjbot.commands;
 
+import net.dv8tion.jda.api.JDA;
 import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.basic.DatabaseCommand;
 import org.togetherjava.tjbot.commands.basic.PingCommand;
@@ -12,6 +13,7 @@ import org.togetherjava.tjbot.commands.tags.TagManageCommand;
 import org.togetherjava.tjbot.commands.tags.TagSystem;
 import org.togetherjava.tjbot.commands.tags.TagsCommand;
 import org.togetherjava.tjbot.db.Database;
+import org.togetherjava.tjbot.routines.ModAuditLogRoutine;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -22,7 +24,7 @@ import java.util.Collection;
  * pick it up from and register it with the system.
  * <p>
  * To add a new slash command, extend the commands returned by
- * {@link #createSlashCommands(Database)}.
+ * {@link #createSlashCommands(JDA, Database)}.
  */
 public enum Commands {
     ;
@@ -33,13 +35,19 @@ public enum Commands {
      * Calling this method multiple times will result in multiple commands being created, which
      * generally should be avoided.
      *
+     * @param jda the JDA instance commands will be registered at
      * @param database the database of the application, which commands can use to persist data
      * @return a collection of all slash commands
      */
-    public static @NotNull Collection<SlashCommand> createSlashCommands(
+    public static @NotNull Collection<SlashCommand> createSlashCommands(@NotNull JDA jda,
             @NotNull Database database) {
         TagSystem tagSystem = new TagSystem(database);
         ModerationActionsStore actionsStore = new ModerationActionsStore(database);
+
+        // TODO This should be moved into some proper command system instead (see GH issue #235
+        // which adds support for routines)
+        new ModAuditLogRoutine(jda, database).start();
+
         // NOTE The command system can add special system relevant commands also by itself,
         // hence this list may not necessarily represent the full list of all commands actually
         // available.

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Commands.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Commands.java
@@ -57,6 +57,8 @@ public enum Commands {
         commands.add(new UnbanCommand(actionsStore));
         commands.add(new FreeCommand());
         commands.add(new AuditCommand(actionsStore));
+        commands.add(new MuteCommand());
+        commands.add(new UnmuteCommand());
 
         return commands;
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Commands.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Commands.java
@@ -48,6 +48,10 @@ public enum Commands {
         // which adds support for routines)
         new ModAuditLogRoutine(jda, database).start();
 
+        // TODO This should be moved into some proper command system instead (see GH issue #236
+        // which adds support for listeners)
+        jda.addEventListener(new RejoinMuteListener(actionsStore));
+
         // NOTE The command system can add special system relevant commands also by itself,
         // hence this list may not necessarily represent the full list of all commands actually
         // available.

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
@@ -215,7 +215,15 @@ enum ModerationUtils {
         /**
          * When a user kicks another user.
          */
-        KICK("kicked");
+        KICK("kicked"),
+        /**
+         * When a user mutes another user.
+         */
+        MUTE("muted"),
+        /**
+         * When a user unmutes another user.
+         */
+        UNMUTE("unmuted");
 
         private final String verb;
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
@@ -86,6 +86,41 @@ enum ModerationUtils {
     }
 
     /**
+     * Checks whether the given author and bot can interact with the given role. For example whether
+     * they have enough permissions to add or remove this role to users.
+     * <p>
+     * If not, it will handle the situation and respond to the user.
+     *
+     * @param bot the bot attempting to interact with the user
+     * @param author the author triggering the command
+     * @param role the role to interact with
+     * @param event the event used to respond to the user
+     * @return Whether the author and bot can interact with the role
+     */
+    @SuppressWarnings("BooleanMethodNameMustStartWithQuestion")
+    static boolean handleCanInteractWithRole(@NotNull Member bot, @NotNull Member author,
+            @NotNull Role role, @NotNull Interaction event) {
+        if (!author.canInteract(role)) {
+            event
+                .reply("The role %s is too powerful for you to interact with."
+                    .formatted(role.getAsMention()))
+                .setEphemeral(true)
+                .queue();
+            return false;
+        }
+
+        if (!bot.canInteract(role)) {
+            event
+                .reply("The role %s is too powerful for me to interact with."
+                    .formatted(role.getAsMention()))
+                .setEphemeral(true)
+                .queue();
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * Checks whether the given bot has enough permission to execute the given action. For example
      * whether it has enough permissions to ban users.
      * <p>

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
@@ -8,15 +8,18 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.togetherjava.tjbot.config.Config;
 
 import java.awt.*;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 /**
  * Utility class offering helpers revolving around user moderation, such as banning or kicking.
  */
-enum ModerationUtils {
+public enum ModerationUtils {
     ;
 
     private static final Logger logger = LoggerFactory.getLogger(ModerationUtils.class);
@@ -26,6 +29,8 @@ enum ModerationUtils {
      */
     private static final int REASON_MAX_LENGTH = 512;
     static final Color AMBIENT_COLOR = Color.decode("#895FE8");
+    public static final Predicate<String> isMuteRole =
+            Pattern.compile(Config.getInstance().getMutedRolePattern()).asMatchPredicate();
 
     /**
      * Checks whether the given reason is valid. If not, it will handle the situation and respond to
@@ -308,6 +313,16 @@ enum ModerationUtils {
             .setTimestamp(Instant.now())
             .setColor(AMBIENT_COLOR)
             .build();
+    }
+
+    /**
+     * Gets the role used to mute a member in a guild.
+     *
+     * @param guild the guild to get the muted role from
+     * @return the muted role, if found
+     */
+    public static @NotNull Optional<Role> getMutedRole(@NotNull Guild guild) {
+        return guild.getRoles().stream().filter(role -> isMuteRole.test(role.getName())).findAny();
     }
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
@@ -1,12 +1,13 @@
 package org.togetherjava.tjbot.commands.moderation;
 
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.events.GenericEvent;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.Interaction;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
+import net.dv8tion.jda.api.utils.Result;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -55,9 +56,8 @@ public final class MuteCommand extends SlashCommandAdapter {
         event.reply("The user is already muted.").setEphemeral(true).queue();
     }
 
-    private void muteUser(@NotNull Member target, @NotNull Member author, @NotNull String reason,
-            @NotNull Guild guild, @NotNull SlashCommandEvent event) {
-        User targetUser = target.getUser();
+    private static RestAction<Boolean> sendDm(@NotNull ISnowflake target, @NotNull String reason,
+            @NotNull Guild guild, @NotNull GenericEvent event) {
         String dmMessage =
                 """
                         Hey there, sorry to tell you but unfortunately you have been muted in the server %s.
@@ -66,25 +66,37 @@ public final class MuteCommand extends SlashCommandAdapter {
                         The reason for the mute is: %s
                         """
                     .formatted(guild.getName(), reason);
-
-        event.getJDA()
-            .openPrivateChannelById(targetUser.getId())
+        return event.getJDA()
+            .openPrivateChannelById(target.getId())
             .flatMap(channel -> channel.sendMessage(dmMessage))
             .mapToResult()
-            .flatMap(sendDmResult -> {
-                logger.info("'{}' ({}) muted the user '{}' ({}) in guild '{}' for reason '{}'.",
-                        author.getUser().getAsTag(), author.getId(), targetUser.getAsTag(),
-                        targetUser.getId(), guild.getName(), reason);
-                return guild.addRoleToMember(target, getMutedRole(guild).orElseThrow())
-                    .reason(reason)
-                    .map(muteResult -> sendDmResult.isSuccess());
-            })
-            .map(hasSentDm -> {
-                String dmNotice =
-                        Boolean.TRUE.equals(hasSentDm) ? "" : "(Unable to send them a DM.)";
-                return ModerationUtils.createActionResponse(author.getUser(),
-                        ModerationUtils.Action.MUTE, targetUser, dmNotice, reason);
-            })
+            .map(Result::isSuccess);
+    }
+
+    private static @NotNull MessageEmbed sendFeedback(boolean hasSentDm, @NotNull Member target,
+            @NotNull Member author, @NotNull String reason) {
+        String dmNoticeText = "";
+        if (!hasSentDm) {
+            dmNoticeText = "(Unable to send them a DM.)";
+        }
+        return ModerationUtils.createActionResponse(author.getUser(), ModerationUtils.Action.MUTE,
+                target.getUser(), dmNoticeText, reason);
+    }
+
+    private AuditableRestAction<Void> muteUser(@NotNull Member target, @NotNull Member author,
+            @NotNull String reason, @NotNull Guild guild) {
+        logger.info("'{}' ({}) muted the user '{}' ({}) in guild '{}' for reason '{}'.",
+                author.getUser().getAsTag(), author.getId(), target.getUser().getAsTag(),
+                target.getId(), guild.getName(), reason);
+        return guild.addRoleToMember(target, getMutedRole(guild).orElseThrow()).reason(reason);
+    }
+
+    private void muteUserFlow(@NotNull Member target, @NotNull Member author,
+            @NotNull String reason, @NotNull Guild guild, @NotNull SlashCommandEvent event) {
+        sendDm(target, reason, guild, event)
+            .flatMap(hasSentDm -> muteUser(target, author, reason, guild)
+                .map(banResult -> hasSentDm))
+            .map(hasSentDm -> sendFeedback(hasSentDm, target, author, reason))
             .flatMap(event::replyEmbeds)
             .queue();
     }
@@ -122,7 +134,8 @@ public final class MuteCommand extends SlashCommandAdapter {
         if (!handleChecks(bot, author, target, reason, guild, event)) {
             return;
         }
-        muteUser(Objects.requireNonNull(target), author, reason, guild, event);
+
+        muteUserFlow(Objects.requireNonNull(target), author, reason, guild, event);
     }
 
     private @NotNull Optional<Role> getMutedRole(@NotNull Guild guild) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
@@ -1,0 +1,154 @@
+package org.togetherjava.tjbot.commands.moderation;
+
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.Interaction;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.togetherjava.tjbot.commands.SlashCommandAdapter;
+import org.togetherjava.tjbot.commands.SlashCommandVisibility;
+import org.togetherjava.tjbot.config.Config;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+/**
+ * This command can mute users. Muting can also be paired with a reason. The command will also try
+ * to DM the user to inform them about the action and the reason.
+ * <p>
+ * The command fails if the user triggering it is lacking permissions to either mute other users or
+ * to mute the specific given user (for example a moderator attempting to mute an admin).
+ */
+public final class MuteCommand extends SlashCommandAdapter {
+    private static final Logger logger = LoggerFactory.getLogger(MuteCommand.class);
+    private static final String TARGET_OPTION = "user";
+    private static final String REASON_OPTION = "reason";
+    private static final String COMMAND_NAME = "mute";
+    private static final String ACTION_VERB = "mute";
+    private final Predicate<String> hasRequiredRole;
+    private final Predicate<String> isMuteRole;
+
+    /**
+     * Constructs an instance.
+     */
+    public MuteCommand() {
+        super(COMMAND_NAME, "Mutes the given user so that they can not send messages anymore",
+                SlashCommandVisibility.GUILD);
+
+        getData().addOption(OptionType.USER, TARGET_OPTION, "The user who you want to mute", true)
+            .addOption(OptionType.STRING, REASON_OPTION, "Why the user should be muted", true);
+
+        hasRequiredRole = Pattern.compile(Config.getInstance().getSoftModerationRolePattern())
+            .asMatchPredicate();
+        isMuteRole = Pattern.compile(Config.getInstance().getMutedRolePattern()).asMatchPredicate();
+    }
+
+    private static void handleAbsentTarget(@NotNull Interaction event) {
+        event.reply("I can not mute the given user since they are not part of the guild anymore.")
+            .setEphemeral(true)
+            .queue();
+    }
+
+    private static void handleAlreadyMutedTarget(@NotNull Interaction event) {
+        event.reply("The user is already muted.").setEphemeral(true).queue();
+    }
+
+    private void muteUser(@NotNull Member target, @NotNull Member author, @NotNull String reason,
+            @NotNull Guild guild, @NotNull SlashCommandEvent event) {
+        User targetUser = target.getUser();
+        String dmMessage =
+                """
+                        Hey there, sorry to tell you but unfortunately you have been muted in the server %s.
+                        This means you can no longer send any messages in the server until you have been unmuted again.
+                        If you think this was a mistake, please contact a moderator or admin of the server.
+                        The reason for the mute is: %s
+                        """
+                    .formatted(guild.getName(), reason);
+
+        Optional<Role> maybeMutedRole = getMutedRole(guild);
+        if (maybeMutedRole.isEmpty()) {
+            event.reply("Can not mute the user, unable to find a mute role on this server")
+                .setEphemeral(true)
+                .queue();
+            logger.warn("The guild '{}' does not have a mute role.", guild.getName());
+            return;
+        }
+
+        event.getJDA()
+            .openPrivateChannelById(targetUser.getId())
+            .flatMap(channel -> channel.sendMessage(dmMessage))
+            .mapToResult()
+            .flatMap(sendDmResult -> {
+                logger.info("'{}' ({}) muted the user '{}' ({}) in guild '{}' for reason '{}'.",
+                        author.getUser().getAsTag(), author.getId(), targetUser.getAsTag(),
+                        targetUser.getId(), guild.getName(), reason);
+                return guild.addRoleToMember(target, maybeMutedRole.orElseThrow())
+                    .reason(reason)
+                    .map(muteResult -> sendDmResult.isSuccess());
+            })
+            .map(hasSentDm -> {
+                String dmNotice =
+                        Boolean.TRUE.equals(hasSentDm) ? "" : "(Unable to send them a DM.)";
+                return ModerationUtils.createActionResponse(author.getUser(),
+                        ModerationUtils.Action.MUTE, targetUser, dmNotice, reason);
+            })
+            .flatMap(event::replyEmbeds)
+            .queue();
+    }
+
+    @SuppressWarnings({"BooleanMethodNameMustStartWithQuestion", "MethodWithTooManyParameters"})
+    private boolean handleChecks(@NotNull Member bot, @NotNull Member author,
+            @Nullable Member target, @NotNull CharSequence reason, @NotNull Guild guild,
+            @NotNull Interaction event) {
+        // Member doesn't exist if attempting to mute a user who is not part of the guild anymore.
+        if (target == null) {
+            handleAbsentTarget(event);
+            return false;
+        }
+        if (!ModerationUtils.handleCanInteractWithTarget(ACTION_VERB, bot, author, target, event)) {
+            return false;
+        }
+        if (!ModerationUtils.handleHasAuthorRole(ACTION_VERB, hasRequiredRole, author, event)) {
+            return false;
+        }
+        if (!ModerationUtils.handleHasBotPermissions(ACTION_VERB, Permission.MANAGE_ROLES, bot,
+                guild, event)) {
+            return false;
+        }
+        if (target.getRoles().stream().map(Role::getName).anyMatch(isMuteRole)) {
+            handleAlreadyMutedTarget(event);
+            return false;
+        }
+        return ModerationUtils.handleReason(reason, event);
+    }
+
+    @Override
+    public void onSlashCommand(@NotNull SlashCommandEvent event) {
+        Member target = Objects.requireNonNull(event.getOption(TARGET_OPTION), "The target is null")
+            .getAsMember();
+        Member author = Objects.requireNonNull(event.getMember(), "The author is null");
+        String reason = Objects.requireNonNull(event.getOption(REASON_OPTION), "The reason is null")
+            .getAsString();
+
+        Guild guild = Objects.requireNonNull(event.getGuild());
+        Member bot = guild.getSelfMember();
+
+        if (!handleChecks(bot, author, target, reason, guild, event)) {
+            return;
+        }
+        muteUser(Objects.requireNonNull(target), author, reason, guild, event);
+    }
+
+    private @NotNull Optional<Role> getMutedRole(@NotNull Guild guild) {
+        return guild.getRoles().stream().filter(role -> isMuteRole.test(role.getName())).findAny();
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
@@ -17,7 +17,6 @@ import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/RejoinMuteListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/RejoinMuteListener.java
@@ -1,0 +1,84 @@
+package org.togetherjava.tjbot.commands.moderation;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.IPermissionHolder;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Reapplies existing mutes to users who have left and rejoined a guild.
+ * <p>
+ * Mutes are realized with roles and roles are removed upon leaving a guild, making it possible for
+ * users to otherwise bypass a mute by simply leaving and rejoining a guild. This class listens for
+ * join events and reapplies the mute role in case the user is supposed to be muted still (according
+ * to the {@link ModerationActionsStore}).
+ */
+public final class RejoinMuteListener extends ListenerAdapter {
+    private static final Logger logger = LoggerFactory.getLogger(RejoinMuteListener.class);
+
+    private final ModerationActionsStore actionsStore;
+
+    /**
+     * Constructs an instance.
+     *
+     * @param actionsStore used to store actions issued by this command and to retrieve whether a
+     *        user should be muted
+     */
+    public RejoinMuteListener(@NotNull ModerationActionsStore actionsStore) {
+        this.actionsStore = Objects.requireNonNull(actionsStore);
+    }
+
+    private static void muteMember(@NotNull Member member) {
+        Guild guild = member.getGuild();
+        logger.info("Reapplied existing mute to user '{}' ({}) in guild '{}' after rejoining.",
+                member.getUser().getAsTag(), member.getId(), guild.getName());
+
+        guild.addRoleToMember(member, ModerationUtils.getMutedRole(guild).orElseThrow())
+            .reason("Reapplied existing mute after rejoining the server")
+            .queue();
+    }
+
+    @Override
+    public void onGuildMemberJoin(@Nonnull GuildMemberJoinEvent event) {
+        Member member = event.getMember();
+        if (!shouldMemberBeMuted(member)) {
+            return;
+        }
+        muteMember(member);
+    }
+
+    private boolean shouldMemberBeMuted(@NotNull IPermissionHolder member) {
+        List<ActionRecord> actions = actionsStore
+            .getActionsByTargetAscending(member.getGuild().getIdLong(), member.getIdLong());
+        Collections.reverse(actions);
+
+        Optional<ActionRecord> lastMute = actions.stream()
+            .filter(action -> action.actionType() == ModerationUtils.Action.MUTE)
+            .findFirst();
+        if (lastMute.isEmpty()) {
+            // User was never muted
+            return false;
+        }
+
+        Optional<ActionRecord> lastUnmute = actions.stream()
+            .filter(action -> action.actionType() == ModerationUtils.Action.UNMUTE)
+            .findFirst();
+        if (lastUnmute.isEmpty()) {
+            // User was never unmuted
+            return true;
+        }
+
+        // The last issued action takes priority
+        return lastMute.orElseThrow().issuedAt().isAfter(lastUnmute.orElseThrow().issuedAt());
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/RejoinMuteListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/RejoinMuteListener.java
@@ -10,10 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Reapplies existing mutes to users who have left and rejoined a guild.
@@ -58,8 +55,8 @@ public final class RejoinMuteListener extends ListenerAdapter {
     }
 
     private boolean shouldMemberBeMuted(@NotNull IPermissionHolder member) {
-        List<ActionRecord> actions = actionsStore
-            .getActionsByTargetAscending(member.getGuild().getIdLong(), member.getIdLong());
+        List<ActionRecord> actions = new ArrayList<>(actionsStore
+            .getActionsByTargetAscending(member.getGuild().getIdLong(), member.getIdLong()));
         Collections.reverse(actions);
 
         Optional<ActionRecord> lastMute = actions.stream()

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnmuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnmuteCommand.java
@@ -1,0 +1,153 @@
+package org.togetherjava.tjbot.commands.moderation;
+
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.Interaction;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.togetherjava.tjbot.commands.SlashCommandAdapter;
+import org.togetherjava.tjbot.commands.SlashCommandVisibility;
+import org.togetherjava.tjbot.config.Config;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+/**
+ * This command can unmute muted users. Unmuting can also be paired with a reason. The command will
+ * also try to DM the user to inform them about the action and the reason.
+ * <p>
+ * The command fails if the user triggering it is lacking permissions to either unmute other users
+ * or to unmute the specific given user (for example a moderator attempting to unmute an admin).
+ */
+public final class UnmuteCommand extends SlashCommandAdapter {
+    private static final Logger logger = LoggerFactory.getLogger(UnmuteCommand.class);
+    private static final String TARGET_OPTION = "user";
+    private static final String REASON_OPTION = "reason";
+    private static final String COMMAND_NAME = "unmute";
+    private static final String ACTION_VERB = "unmute";
+    private final Predicate<String> hasRequiredRole;
+    private final Predicate<String> isMuteRole;
+
+    /**
+     * Constructs an instance.
+     */
+    public UnmuteCommand() {
+        super(COMMAND_NAME,
+                "Unmutes the given already muted user so that they can send messages again",
+                SlashCommandVisibility.GUILD);
+
+        getData().addOption(OptionType.USER, TARGET_OPTION, "The user who you want to unmute", true)
+            .addOption(OptionType.STRING, REASON_OPTION, "Why the user should be unmuted", true);
+
+        hasRequiredRole = Pattern.compile(Config.getInstance().getSoftModerationRolePattern())
+            .asMatchPredicate();
+        isMuteRole = Pattern.compile(Config.getInstance().getMutedRolePattern()).asMatchPredicate();
+    }
+
+    private static void handleAbsentTarget(@NotNull Interaction event) {
+        event.reply("I can not unmute the given user since they are not part of the guild anymore.")
+            .setEphemeral(true)
+            .queue();
+    }
+
+    private static void handleNotMutedTarget(@NotNull Interaction event) {
+        event.reply("The user is not muted.").setEphemeral(true).queue();
+    }
+
+    private void unmuteUser(@NotNull Member target, @NotNull Member author, @NotNull String reason,
+            @NotNull Guild guild, @NotNull SlashCommandEvent event) {
+        User targetUser = target.getUser();
+        String dmMessage = """
+                Hey there, you have been unmuted in the server %s.
+                This means you can now send messages in the server again.
+                The reason for the unmute is: %s
+                """.formatted(guild.getName(), reason);
+
+        Optional<Role> maybeMutedRole = getMutedRole(guild);
+        if (maybeMutedRole.isEmpty()) {
+            event.reply("Can not unmute the user, unable to find a mute role on this server")
+                .setEphemeral(true)
+                .queue();
+            logger.warn("The guild '{}' does not have a mute role.", guild.getName());
+            return;
+        }
+
+        event.getJDA()
+            .openPrivateChannelById(targetUser.getId())
+            .flatMap(channel -> channel.sendMessage(dmMessage))
+            .mapToResult()
+            .flatMap(sendDmResult -> {
+                logger.info("'{}' ({}) unmuted the user '{}' ({}) in guild '{}' for reason '{}'.",
+                        author.getUser().getAsTag(), author.getId(), targetUser.getAsTag(),
+                        targetUser.getId(), guild.getName(), reason);
+
+                return guild.removeRoleFromMember(target, maybeMutedRole.orElseThrow())
+                    .reason(reason)
+                    .map(unmuteResult -> sendDmResult.isSuccess());
+            })
+            .map(hasSentDm -> {
+                String dmNotice =
+                        Boolean.TRUE.equals(hasSentDm) ? "" : "(Unable to send them a DM.)";
+                return ModerationUtils.createActionResponse(author.getUser(),
+                        ModerationUtils.Action.UNMUTE, targetUser, dmNotice, reason);
+            })
+            .flatMap(event::replyEmbeds)
+            .queue();
+    }
+
+    @SuppressWarnings({"BooleanMethodNameMustStartWithQuestion", "MethodWithTooManyParameters"})
+    private boolean handleChecks(@NotNull Member bot, @NotNull Member author,
+            @Nullable Member target, @NotNull CharSequence reason, @NotNull Guild guild,
+            @NotNull Interaction event) {
+        // Member doesn't exist if attempting to mute a user who is not part of the guild anymore.
+        if (target == null) {
+            handleAbsentTarget(event);
+            return false;
+        }
+        if (!ModerationUtils.handleCanInteractWithTarget(ACTION_VERB, bot, author, target, event)) {
+            return false;
+        }
+        if (!ModerationUtils.handleHasAuthorRole(ACTION_VERB, hasRequiredRole, author, event)) {
+            return false;
+        }
+        if (!ModerationUtils.handleHasBotPermissions(ACTION_VERB, Permission.MANAGE_ROLES, bot,
+                guild, event)) {
+            return false;
+        }
+        if (target.getRoles().stream().map(Role::getName).noneMatch(isMuteRole)) {
+            handleNotMutedTarget(event);
+            return false;
+        }
+        return ModerationUtils.handleReason(reason, event);
+    }
+
+    @Override
+    public void onSlashCommand(@NotNull SlashCommandEvent event) {
+        Member target = Objects.requireNonNull(event.getOption(TARGET_OPTION), "The target is null")
+            .getAsMember();
+        Member author = Objects.requireNonNull(event.getMember(), "The author is null");
+        String reason = Objects.requireNonNull(event.getOption(REASON_OPTION), "The reason is null")
+            .getAsString();
+
+        Guild guild = Objects.requireNonNull(event.getGuild());
+        Member bot = guild.getSelfMember();
+
+        if (!handleChecks(bot, author, target, reason, guild, event)) {
+            return;
+        }
+        unmuteUser(Objects.requireNonNull(target), author, reason, guild, event);
+    }
+
+    private @NotNull Optional<Role> getMutedRole(@NotNull Guild guild) {
+        return guild.getRoles().stream().filter(role -> isMuteRole.test(role.getName())).findAny();
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnmuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnmuteCommand.java
@@ -72,15 +72,6 @@ public final class UnmuteCommand extends SlashCommandAdapter {
                 The reason for the unmute is: %s
                 """.formatted(guild.getName(), reason);
 
-        Optional<Role> maybeMutedRole = getMutedRole(guild);
-        if (maybeMutedRole.isEmpty()) {
-            event.reply("Can not unmute the user, unable to find a mute role on this server")
-                .setEphemeral(true)
-                .queue();
-            logger.warn("The guild '{}' does not have a mute role.", guild.getName());
-            return;
-        }
-
         event.getJDA()
             .openPrivateChannelById(targetUser.getId())
             .flatMap(channel -> channel.sendMessage(dmMessage))
@@ -90,7 +81,7 @@ public final class UnmuteCommand extends SlashCommandAdapter {
                         author.getUser().getAsTag(), author.getId(), targetUser.getAsTag(),
                         targetUser.getId(), guild.getName(), reason);
 
-                return guild.removeRoleFromMember(target, maybeMutedRole.orElseThrow())
+                return guild.removeRoleFromMember(target, getMutedRole(guild).orElseThrow())
                     .reason(reason)
                     .map(unmuteResult -> sendDmResult.isSuccess());
             })
@@ -108,12 +99,25 @@ public final class UnmuteCommand extends SlashCommandAdapter {
     private boolean handleChecks(@NotNull Member bot, @NotNull Member author,
             @Nullable Member target, @NotNull CharSequence reason, @NotNull Guild guild,
             @NotNull Interaction event) {
+        Optional<Role> maybeMutedRole = getMutedRole(guild);
+        if (maybeMutedRole.isEmpty()) {
+            event.reply("Can not mute the user, unable to find a mute role on this server")
+                .setEphemeral(true)
+                .queue();
+            logger.warn("The guild '{}' does not have a mute role.", guild.getName());
+            return false;
+        }
+
         // Member doesn't exist if attempting to mute a user who is not part of the guild anymore.
         if (target == null) {
             handleAbsentTarget(event);
             return false;
         }
         if (!ModerationUtils.handleCanInteractWithTarget(ACTION_VERB, bot, author, target, event)) {
+            return false;
+        }
+        if (!ModerationUtils.handleCanInteractWithRole(bot, author, maybeMutedRole.orElseThrow(),
+                event)) {
             return false;
         }
         if (!ModerationUtils.handleHasAuthorRole(ACTION_VERB, hasRequiredRole, author, event)) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnmuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnmuteCommand.java
@@ -1,6 +1,5 @@
 package org.togetherjava.tjbot.commands.moderation;
 
-import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
@@ -53,12 +52,6 @@ public final class UnmuteCommand extends SlashCommandAdapter {
         isMuteRole = Pattern.compile(Config.getInstance().getMutedRolePattern()).asMatchPredicate();
     }
 
-    private static void handleAbsentTarget(@NotNull Interaction event) {
-        event.reply("I can not unmute the given user since they are not part of the guild anymore.")
-            .setEphemeral(true)
-            .queue();
-    }
-
     private static void handleNotMutedTarget(@NotNull Interaction event) {
         event.reply("The user is not muted.").setEphemeral(true).queue();
     }
@@ -99,39 +92,19 @@ public final class UnmuteCommand extends SlashCommandAdapter {
     private boolean handleChecks(@NotNull Member bot, @NotNull Member author,
             @Nullable Member target, @NotNull CharSequence reason, @NotNull Guild guild,
             @NotNull Interaction event) {
-        Optional<Role> maybeMutedRole = getMutedRole(guild);
-        if (maybeMutedRole.isEmpty()) {
-            event.reply("Can not mute the user, unable to find a mute role on this server")
-                .setEphemeral(true)
-                .queue();
-            logger.warn("The guild '{}' does not have a mute role.", guild.getName());
+        if (!ModerationUtils.handleRoleChangeChecks(getMutedRole(guild).orElse(null), ACTION_VERB,
+                target, bot, author, guild, hasRequiredRole, reason, event)) {
             return false;
         }
-
-        // Member doesn't exist if attempting to mute a user who is not part of the guild anymore.
-        if (target == null) {
-            handleAbsentTarget(event);
-            return false;
-        }
-        if (!ModerationUtils.handleCanInteractWithTarget(ACTION_VERB, bot, author, target, event)) {
-            return false;
-        }
-        if (!ModerationUtils.handleCanInteractWithRole(bot, author, maybeMutedRole.orElseThrow(),
-                event)) {
-            return false;
-        }
-        if (!ModerationUtils.handleHasAuthorRole(ACTION_VERB, hasRequiredRole, author, event)) {
-            return false;
-        }
-        if (!ModerationUtils.handleHasBotPermissions(ACTION_VERB, Permission.MANAGE_ROLES, bot,
-                guild, event)) {
-            return false;
-        }
-        if (target.getRoles().stream().map(Role::getName).noneMatch(isMuteRole)) {
+        if (Objects.requireNonNull(target)
+            .getRoles()
+            .stream()
+            .map(Role::getName)
+            .noneMatch(isMuteRole)) {
             handleNotMutedTarget(event);
             return false;
         }
-        return ModerationUtils.handleReason(reason, event);
+        return true;
     }
 
     @Override

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnmuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnmuteCommand.java
@@ -17,7 +17,6 @@ import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/CommandSystem.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/CommandSystem.java
@@ -1,5 +1,6 @@
 package org.togetherjava.tjbot.commands.system;
 
+import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.TextChannel;
@@ -55,11 +56,12 @@ public final class CommandSystem extends ListenerAdapter implements SlashCommand
      * <p>
      * Commands are fetched from {@link Commands}.
      *
+     * @param jda the JDA instance that this command system will be used with
      * @param database the database that commands may use to persist data
      */
     @SuppressWarnings("ThisEscapedInObjectConstruction")
-    public CommandSystem(@NotNull Database database) {
-        nameToSlashCommands = Commands.createSlashCommands(database)
+    public CommandSystem(@NotNull JDA jda, @NotNull Database database) {
+        nameToSlashCommands = Commands.createSlashCommands(jda, database)
             .stream()
             .collect(Collectors.toMap(SlashCommand::getName, Function.identity()));
 


### PR DESCRIPTION
### Overview

Partially implements #64 . Adds commands:
* `/mute user reason`
* `/unmute user reason`

![muted_unmuted](https://user-images.githubusercontent.com/13614011/140735744-14ffe283-cd5f-4f91-9fa6-4b755ecd74cd.png)

The commands are fairly simple and follow the pattern introduced by #244 . That said, the branch is based on that branch and hence also blocked by its release.

---
### Notes

This PR slightly changes the initialization process of the bot by moving routines and listeners down into `Commands.java` (instead of `Application.java`). This is a temporary change that is unfortuantely required, since they need access to systems such as `TagSystem` or `ModAuditLogStore`, and also the `JDA` instance (which is now also passed down through `CommandSystem`).

All of this will be made nicer anyways with #235 and #236 , so I wouldnt bother too much for now.

---
### Bot permission change

The bot needs to listen to user-join events, which requires the privileged **Server Members Intent** to be enabled (already enabled it on our bots and added it to the config, since it doesnt harm - but we have to tell contributors in an announcement).

![setting](https://camo.githubusercontent.com/801b52097633129db42f3ca763ccd0b71bc51cc65dce6054c5a711395dfa3a21/68747470733a2f2f692e696d6775722e636f6d2f4e6f4f67746b4b2e706e67)

---
### Checklist

Basic
* [x] Mute a user
* [x] Unmute a user

DM
* [x] Mute a user who has disabled DMs
* [x] Mute a user who has enabled DMs
* [x] Unmute a user who has disabled DMs
* [x] Unmute a user who has enabled DMs

Foreign users
* [x] Attempt to mute a user who is not in the guild
* [x] Attempt to unmute a user who is not in the guild

Logic
* [x] Attempt to mute an already muted user
* [x] Attempt to unmute an user who is not muted yet

Permissions
* [x] Mute with the bot not having role permissions
* [x] Unmute with the bot not having role permissions
* [x] Mute with the author not having the soft moderation role
* [x] Unmute with the author not having the soft moderation role
* [x] Mute with the bot being lower in the hierarchy than the target
* [x] Unmute with the bot being lower in the hierarchy than the target
* [x] Mute with the bot being lower in the hierarchy than the muted role
* [x] Unmute with the bot being lower in the hierarchy than the muted role
* [x] Mute with the author being lower in the hierarchy than the target
* [x] Unmute with the author being lower in the hierarchy than the target
* [x] Mute with the author being lower in the hierarchy than the muted role
* [x] Unmute with the author being lower in the hierarchy than the muted role

Rejoin
* [x] Mute user, then leave and rejoin, user should be muted again
* [x] Mute user, then unmute. Then leave and rejoin, user should not be muted
* [x] Mute user, then leave. Unmute and rejoin, user should not be muted
* [x] Mute user, then leave. Unmute and mute. Then rejoin, user should be muted again

---
### TODO

* [x] If user leaves and joins the server back, they would be unmuted again. The role has to be applied again by the bot (use database, listen to join event, ...)