### PR TITLE
Make Tag-Manage based on roles

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagManageCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagManageCommand.java
@@ -122,9 +122,7 @@ public final class TagManageCommand extends SlashCommandAdapter {
 
     @Override
     public void onSlashCommand(@NotNull SlashCommandEvent event) {
-        Member member = Objects.requireNonNull(event.getMember());
-
-        if (member.getRoles().stream().map(Role::getName).noneMatch(hasRequiredRole)) {
+        if (!hasTagManageRole(Objects.requireNonNull(event.getMember()))) {
             event.reply("Tags can only be managed by users with a corresponding role.")
                 .setEphemeral(true)
                 .queue();
@@ -280,6 +278,10 @@ public final class TagManageCommand extends SlashCommandAdapter {
             throw new AssertionError("Unknown tag status '%s'".formatted(requiredTagStatus));
         }
         return false;
+    }
+
+    private boolean hasTagManageRole(@NotNull Member member) {
+        return member.getRoles().stream().map(Role::getName).anyMatch(hasRequiredRole);
     }
 
     private enum TagStatus {

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -27,6 +27,7 @@ public final class Config {
     private final String mutedRolePattern;
     private final String heavyModerationRolePattern;
     private final String softModerationRolePattern;
+    private final String tagManageRolePattern;
 
     @SuppressWarnings("ConstructorWithTooManyParameters")
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
@@ -37,7 +38,8 @@ public final class Config {
             @JsonProperty("modAuditLogChannelPattern") String modAuditLogChannelPattern,
             @JsonProperty("mutedRolePattern") String mutedRolePattern,
             @JsonProperty("heavyModerationRolePattern") String heavyModerationRolePattern,
-            @JsonProperty("softModerationRolePattern") String softModerationRolePattern) {
+            @JsonProperty("softModerationRolePattern") String softModerationRolePattern,
+            @JsonProperty("tagManageRolePattern") String tagManageRolePattern) {
         this.token = token;
         this.databasePath = databasePath;
         this.projectWebsite = projectWebsite;
@@ -46,6 +48,7 @@ public final class Config {
         this.mutedRolePattern = mutedRolePattern;
         this.heavyModerationRolePattern = heavyModerationRolePattern;
         this.softModerationRolePattern = softModerationRolePattern;
+        this.tagManageRolePattern = tagManageRolePattern;
     }
 
     /**
@@ -145,5 +148,15 @@ public final class Config {
      */
     public String getSoftModerationRolePattern() {
         return softModerationRolePattern;
+    }
+
+    /**
+     * Gets the REGEX pattern used to identify roles that are allowed to use the tag-manage command,
+     * such as creating or editing tags.
+     *
+     * @return the REGEX pattern
+     */
+    public String getTagManageRolePattern() {
+        return tagManageRolePattern;
     }
 }


### PR DESCRIPTION
### Overview

Implements and closes #253 .

This will make the `/tag-manage` command based on roles instead of the `MESSAGE_MANAGE` permission.

That way we have more granular control over who can use it and, in particular, **grant it as a perk to roles such as Top Helpers** or others (without giving them the extended permissions on Discord itself, such as message deletion).

### Config changes

This changes the config and adds a new entry to it:
```json
"tagManageRolePattern": "Moderator|Staff Assistant|Top Helpers .+"
```