### PR TITLE
Update gradle to 7.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fixes a number of issue including the issue were gradle did not support java 17 but now with gradle 7.3 java 17 is supported

Fixes the issue https://github.com/Together-Java/TJ-Bot/issues/257

All the fixes can be found here: https://docs.gradle.org/7.3/release-notes.html