### PR TITLE
Simplify merge conflicts when adding new commands

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/Commands.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Commands.java
@@ -11,8 +11,8 @@ import org.togetherjava.tjbot.commands.tags.TagSystem;
 import org.togetherjava.tjbot.commands.tags.TagsCommand;
 import org.togetherjava.tjbot.db.Database;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 
 /**
  * Utility class that offers all commands that should be registered by the system. New commands have
@@ -40,8 +40,16 @@ public enum Commands {
         // NOTE The command system can add special system relevant commands also by itself,
         // hence this list may not necessarily represent the full list of all commands actually
         // available.
-        return List.of(new PingCommand(), new DatabaseCommand(database), new TeXCommand(),
-                new TagCommand(tagSystem), new TagManageCommand(tagSystem),
-                new TagsCommand(tagSystem), new VcActivityCommand());
+        Collection<SlashCommand> commands = new ArrayList<>();
+
+        commands.add(new PingCommand());
+        commands.add(new DatabaseCommand(database));
+        commands.add(new TeXCommand());
+        commands.add(new TagCommand(tagSystem));
+        commands.add(new TagManageCommand(tagSystem));
+        commands.add(new TagsCommand(tagSystem));
+        commands.add(new VcActivityCommand());
+
+        return commands;
     }
 }


### PR DESCRIPTION
### Motivation

This is a minor one but it was bugging me for some time already. And when its bugging me, its bugging beginners even more.

When you work on a branch where you added a new command and want to update your branch with `develop` (rebase), but someone added a new command to the list in `Commands` as well, then you get a **merge conflict** (for obvious reasons).

Solving this merge conflict is not difficult but requires quite some attention to not accidentally delete any of the newly added commands. This is mostly because we have multiple commands in the same line, due to us using `List.of(...)` and Spotless forcing a specific formatting on that (instead of having one command per line, individually).

### The Fix

This fixes the problem by simply substituting the `List.of` by a manual old-style `list.add(...)`. There are no real disadvantages to that and we bypass the issue with Spotless forcing a specific formatting (or users not following the pattern). Resulting in one command per line:
```java
commands.add(new FooCommand());
commands.add(new BarCommand());
...
```
That way, merge conflicts simplify heavily and are easier to resolve. In particular for beginners.