### PR TITLE
Changed VC-Activity message

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
@@ -213,8 +213,7 @@ public final class VcActivityCommand extends SlashCommandAdapter {
                 %s wants to start %s.
                 Feel free to join by clicking %s , enjoy!
                 If it says the activity ended, click on the URL instead.
-                 """.formatted(Objects.requireNonNull(event.getMember()).getEffectiveName(),
-                applicationName, invite.getUrl()));
+                 """.formatted(event.getUser().getAsTag(), applicationName, invite.getUrl()));
     }
 
     private static void handleErrors(@NotNull SlashCommandEvent event,

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
@@ -169,34 +169,45 @@ public final class VcActivityCommand extends SlashCommandAdapter {
 
 
         String applicationId;
+        String applicationName;
 
         if (applicationOption != null) {
-            applicationId = VC_APPLICATION_TO_ID.get(applicationOption.getAsString());
+            applicationName = applicationOption.getAsString();
+            applicationId = VC_APPLICATION_TO_ID.get(applicationName);
         } else {
             applicationId = idOption.getAsString();
+            applicationName = applicationId;
+
+            // Get the application name from the ID
+            for (var entry : VC_APPLICATION_TO_ID.entrySet()) {
+                if (applicationId.equals(entry.getValue())) {
+                    applicationName = entry.getKey();
+                    break;
+                }
+            }
         }
 
-        handleSubcommand(event, voiceChannel, applicationId, maxUses, maxAge);
+        handleSubcommand(event, voiceChannel, applicationId, maxUses, maxAge, applicationName);
     }
 
     private static void handleSubcommand(@NotNull SlashCommandEvent event,
             @NotNull VoiceChannel voiceChannel, @NotNull String applicationId,
-            @Nullable Integer maxUses, @Nullable Integer maxAge) {
+            @Nullable Integer maxUses, @Nullable Integer maxAge, @NotNull String applicationName) {
 
         voiceChannel.createInvite()
             .setTargetApplication(applicationId)
             .setMaxUses(maxUses)
             .setMaxAge(maxAge)
-            .flatMap(invite -> replyInvite(event, invite))
+            .flatMap(invite -> replyInvite(event, invite, applicationName))
             .queue(null, throwable -> handleErrors(event, throwable));
     }
 
     private static @NotNull ReplyAction replyInvite(@NotNull SlashCommandEvent event,
-            @NotNull Invite invite) {
+            @NotNull Invite invite, @NotNull String applicationName) {
         return event.reply("""
-                I wish you a lot of fun, here's the invite: %s
-                If it says the activity ended, click on the URL instead.
-                 """.formatted(invite.getUrl()));
+                %s wants to start %s.
+                Feel free to join by clicking %s, enjoy!
+                 """.formatted(event.getMember(), applicationName, invite.getUrl()));
     }
 
     private static void handleErrors(@NotNull SlashCommandEvent event,

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
@@ -185,7 +185,8 @@ public final class VcActivityCommand extends SlashCommandAdapter {
         handleSubcommand(event, voiceChannel, applicationId, maxUses, maxAge, applicationName);
     }
 
-    private static <K, V> @NotNull Optional<K> getKeyByValue(@NotNull Map<K, V> map, @NotNull V value) {
+    private static <K, V> @NotNull Optional<K> getKeyByValue(@NotNull Map<K, V> map,
+            @NotNull V value) {
         for (Map.Entry<K, V> entry : map.entrySet()) {
             if (value.equals(entry.getKey())) {
                 return Optional.of(entry.getKey());

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
@@ -23,6 +23,7 @@ import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Implements the {@code vc-activity} command. Creates VC activities.
@@ -176,18 +177,22 @@ public final class VcActivityCommand extends SlashCommandAdapter {
             applicationId = VC_APPLICATION_TO_ID.get(applicationName);
         } else {
             applicationId = idOption.getAsString();
-            applicationName = "an activity";
 
-            // Get the application name from the ID
-            for (var entry : VC_APPLICATION_TO_ID.entrySet()) {
-                if (applicationId.equals(entry.getValue())) {
-                    applicationName = entry.getKey();
-                    break;
-                }
-            }
+            applicationName =
+                    getKeyByValue(VC_APPLICATION_TO_ID, applicationId).orElse("an activity");
         }
 
         handleSubcommand(event, voiceChannel, applicationId, maxUses, maxAge, applicationName);
+    }
+
+    private static <K, V> Optional<K> getKeyByValue(@NotNull Map<K, V> map, @NotNull V value) {
+        for (Map.Entry<K, V> entry : map.entrySet()) {
+            if (value.equals(entry.getKey())) {
+                return Optional.of(entry.getKey());
+            }
+        }
+
+        return Optional.empty();
     }
 
     private static void handleSubcommand(@NotNull SlashCommandEvent event,

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
@@ -185,7 +185,7 @@ public final class VcActivityCommand extends SlashCommandAdapter {
         handleSubcommand(event, voiceChannel, applicationId, maxUses, maxAge, applicationName);
     }
 
-    private static <K, V> Optional<K> getKeyByValue(@NotNull Map<K, V> map, @NotNull V value) {
+    private static <K, V> @NotNull Optional<K> getKeyByValue(@NotNull Map<K, V> map, @NotNull V value) {
         for (Map.Entry<K, V> entry : map.entrySet()) {
             if (value.equals(entry.getKey())) {
                 return Optional.of(entry.getKey());

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
@@ -176,7 +176,7 @@ public final class VcActivityCommand extends SlashCommandAdapter {
             applicationId = VC_APPLICATION_TO_ID.get(applicationName);
         } else {
             applicationId = idOption.getAsString();
-            applicationName = applicationId;
+            applicationName = "an activity";
 
             // Get the application name from the ID
             for (var entry : VC_APPLICATION_TO_ID.entrySet()) {
@@ -206,8 +206,10 @@ public final class VcActivityCommand extends SlashCommandAdapter {
             @NotNull Invite invite, @NotNull String applicationName) {
         return event.reply("""
                 %s wants to start %s.
-                Feel free to join by clicking %s, enjoy!
-                 """.formatted(event.getMember(), applicationName, invite.getUrl()));
+                Feel free to join by clicking %s , enjoy!
+                If it says the activity ended, click on the URL instead.
+                 """.formatted(Objects.requireNonNull(event.getMember()).getEffectiveName(),
+                applicationName, invite.getUrl()));
     }
 
     private static void handleErrors(@NotNull SlashCommandEvent event,


### PR DESCRIPTION
This is in reference to #247 

I have changed the reply message to:
![image](https://user-images.githubusercontent.com/52386683/141879251-b460afe0-bb45-4d33-ad7e-476d3a42b353.png)


I'm not sure why it's displaying the link embed instead of the invite with buttons. (below)

![image](https://user-images.githubusercontent.com/52386683/141879451-aff8d9b1-544f-40bd-95a9-f2722dc7c1f8.png)

I've had a look around and couldn't seem to find much information about controlling what gets displayed. I think it would look nicer with the buttons instead of the embedded link, I'm just unsure how to change it.

Another thing I played around with was mentioning the user. I couldn't decide if the bot should mention them or just use their name. I ended up going with mentioning them but am happy to change it if needed.