### PR TITLE
Migrate temporary ban/mute

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/Commands.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Commands.java
@@ -46,6 +46,7 @@ public enum Commands {
         // TODO This should be moved into some proper command system instead (see GH issue #235
         // which adds support for routines)
         new ModAuditLogRoutine(jda, database).start();
+        new TemporaryModerationRoutine(jda, actionsStore).start();
 
         // TODO This should be moved into some proper command system instead (see GH issue #236
         // which adds support for listeners)

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Commands.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Commands.java
@@ -7,6 +7,7 @@ import org.togetherjava.tjbot.commands.basic.VcActivityCommand;
 import org.togetherjava.tjbot.commands.free.FreeCommand;
 import org.togetherjava.tjbot.commands.mathcommands.TeXCommand;
 import org.togetherjava.tjbot.commands.moderation.*;
+import org.togetherjava.tjbot.commands.moderation.temp.TemporaryModerationRoutine;
 import org.togetherjava.tjbot.commands.tags.TagCommand;
 import org.togetherjava.tjbot.commands.tags.TagManageCommand;
 import org.togetherjava.tjbot.commands.tags.TagSystem;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ActionRecord.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ActionRecord.java
@@ -21,8 +21,8 @@ import java.time.Instant;
  * @param reason the reason why this action was executed
  */
 public record ActionRecord(int caseId, @NotNull Instant issuedAt, long guildId, long authorId,
-        long targetId, @NotNull ModerationUtils.Action actionType,
-        @Nullable Instant actionExpiresAt, @NotNull String reason) {
+        long targetId, @NotNull ModerationAction actionType, @Nullable Instant actionExpiresAt,
+        @NotNull String reason) {
 
     /**
      * Creates the action record that corresponds to the given action entry from the database table.
@@ -34,7 +34,7 @@ public record ActionRecord(int caseId, @NotNull Instant issuedAt, long guildId, 
     static @NotNull ActionRecord of(@NotNull ModerationActionsRecord action) {
         return new ActionRecord(action.getCaseId(), action.getIssuedAt(), action.getGuildId(),
                 action.getAuthorId(), action.getTargetId(),
-                ModerationUtils.Action.valueOf(action.getActionType()), action.getActionExpiresAt(),
+                ModerationAction.valueOf(action.getActionType()), action.getActionExpiresAt(),
                 action.getReason());
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/AuditCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/AuditCommand.java
@@ -71,12 +71,12 @@ public final class AuditCommand extends SlashCommandAdapter {
         String shortSummary = "There are **%d actions** against the user.".formatted(actionAmount);
 
         // Summary of all actions with their count, like "- Warn: 5", descending
-        Map<ModerationUtils.Action, Long> actionTypeToCount = actions.stream()
+        Map<ModerationAction, Long> actionTypeToCount = actions.stream()
             .collect(Collectors.groupingBy(ActionRecord::actionType, Collectors.counting()));
         String typeCountSummary = actionTypeToCount.entrySet()
             .stream()
             .filter(typeAndCount -> typeAndCount.getValue() > 0)
-            .sorted(Map.Entry.<ModerationUtils.Action, Long>comparingByValue().reversed())
+            .sorted(Map.Entry.<ModerationAction, Long>comparingByValue().reversed())
             .map(typeAndCount -> "- **%s**: %d".formatted(typeAndCount.getKey(),
                     typeAndCount.getValue()))
             .collect(Collectors.joining("\n"));

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/BanCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/BanCommand.java
@@ -45,6 +45,7 @@ public final class BanCommand extends SlashCommandAdapter {
     private static final String REASON_OPTION = "reason";
     private static final String COMMAND_NAME = "ban";
     private static final String ACTION_VERB = "ban";
+    @SuppressWarnings("StaticCollection")
     private static final List<String> DURATIONS = List.of(ModerationUtils.PERMANENT_DURATION,
             "1 hour", "3 hours", "1 day", "2 days", "3 days", "7 days", "30 days");
     private final Predicate<String> hasRequiredRole;
@@ -152,6 +153,7 @@ public final class BanCommand extends SlashCommandAdapter {
             .flatMap(event::replyEmbeds);
     }
 
+    @SuppressWarnings("MethodWithTooManyParameters")
     private AuditableRestAction<Void> banUser(@NotNull User target, @NotNull Member author,
             @Nullable ModerationUtils.TemporaryData temporaryData, @NotNull String reason,
             int deleteHistoryDays, @NotNull Guild guild) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/BanCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/BanCommand.java
@@ -118,8 +118,8 @@ public final class BanCommand extends SlashCommandAdapter {
         if (!hasSentDm) {
             dmNoticeText = "\n(Unable to send them a DM.)";
         }
-        return ModerationUtils.createActionResponse(author.getUser(), ModerationUtils.Action.BAN,
-                target, durationText + dmNoticeText, reason);
+        return ModerationUtils.createActionResponse(author.getUser(), ModerationAction.BAN, target,
+                durationText + dmNoticeText, reason);
     }
 
     private static Optional<RestAction<InteractionHook>> handleNotAlreadyBannedResponse(
@@ -190,7 +190,7 @@ public final class BanCommand extends SlashCommandAdapter {
 
         Instant expiresAt = temporaryBanData == null ? null : temporaryBanData.unbanTime;
         actionsStore.addAction(guild.getIdLong(), author.getIdLong(), target.getIdLong(),
-                ModerationUtils.Action.BAN, expiresAt, reason);
+                ModerationAction.BAN, expiresAt, reason);
 
         return guild.ban(target, deleteHistoryDays, reason);
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/BanCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/BanCommand.java
@@ -48,7 +48,7 @@ public final class BanCommand extends SlashCommandAdapter {
     private static final String ACTION_VERB = "ban";
     private static final String PERMANENT_DURATION = "permanent";
     private static final List<String> DURATIONS = List.of(PERMANENT_DURATION, "1 hour", "3 hours",
-            "1 day", "2 days", "3 days", "7 days", "1 month");
+            "1 day", "2 days", "3 days", "7 days", "30 days");
     private final Predicate<String> hasRequiredRole;
     private final ModerationActionsStore actionsStore;
 
@@ -151,15 +151,13 @@ public final class BanCommand extends SlashCommandAdapter {
             return Optional.empty();
         }
 
-        // 1 day, 1 days, 1 month, ...
+        // 1 minute, 1 day, 2 days, ...
         String[] data = durationText.split(" ", 2);
         int duration = Integer.parseInt(data[0]);
         ChronoUnit unit = switch (data[1]) {
             case "minute", "minutes" -> ChronoUnit.MINUTES;
             case "hour", "hours" -> ChronoUnit.HOURS;
             case "day", "days" -> ChronoUnit.DAYS;
-            case "week", "weeks" -> ChronoUnit.WEEKS;
-            case "month", "months" -> ChronoUnit.MONTHS;
             default -> throw new IllegalArgumentException(
                     "Unsupported ban duration: " + durationText);
         };

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/KickCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/KickCommand.java
@@ -92,7 +92,7 @@ public final class KickCommand extends SlashCommandAdapter {
                 target.getId(), guild.getName(), reason);
 
         actionsStore.addAction(guild.getIdLong(), author.getIdLong(), target.getIdLong(),
-                ModerationUtils.Action.KICK, null, reason);
+                ModerationAction.KICK, null, reason);
 
         return guild.kick(target, reason).reason(reason);
     }
@@ -103,7 +103,7 @@ public final class KickCommand extends SlashCommandAdapter {
         if (!hasSentDm) {
             dmNoticeText = "(Unable to send them a DM.)";
         }
-        return ModerationUtils.createActionResponse(author.getUser(), ModerationUtils.Action.KICK,
+        return ModerationUtils.createActionResponse(author.getUser(), ModerationAction.KICK,
                 target.getUser(), dmNoticeText, reason);
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationAction.java
@@ -19,6 +19,10 @@ public enum ModerationAction {
      */
     KICK("kicked"),
     /**
+     * When a user warns another user.
+     */
+    WARN("warned"),
+    /**
      * When a user mutes another user.
      */
     MUTE("muted"),

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationAction.java
@@ -1,0 +1,52 @@
+package org.togetherjava.tjbot.commands.moderation;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * All available moderation actions.
+ */
+public enum ModerationAction {
+    /**
+     * When a user bans another user.
+     */
+    BAN("banned"),
+    /**
+     * When a user unbans another user.
+     */
+    UNBAN("unbanned"),
+    /**
+     * When a user kicks another user.
+     */
+    KICK("kicked"),
+    /**
+     * When a user mutes another user.
+     */
+    MUTE("muted"),
+    /**
+     * When a user unmutes another user.
+     */
+    UNMUTE("unmuted");
+
+    private final String verb;
+
+    /**
+     * Creates an instance with the given verb
+     *
+     * @param verb the verb of the action, as it would be used in a sentence, such as "banned" or
+     *        "kicked"
+     */
+    ModerationAction(@NotNull String verb) {
+        this.verb = verb;
+    }
+
+    /**
+     * Gets the verb of the action, as it would be used in a sentence.
+     * <p>
+     * Such as "banned" or "kicked"
+     *
+     * @return the verb of this action
+     */
+    public @NotNull String getVerb() {
+        return verb;
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationActionsStore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationActionsStore.java
@@ -17,10 +17,9 @@ import java.util.Optional;
  * past events, such as when a user has been banned the last time.
  * <p>
  * Actions have to be added to the store using
- * {@link #addAction(long, long, long, ModerationUtils.Action, Instant, String)} at the time they
- * are executed and can then be retrieved by methods such as
- * {@link #getActionsByTypeAscending(long, ModerationUtils.Action)} or
- * {@link #findActionByCaseId(int)}.
+ * {@link #addAction(long, long, long, ModerationAction, Instant, String)} at the time they are
+ * executed and can then be retrieved by methods such as
+ * {@link #getActionsByTypeAscending(long, ModerationAction)} or {@link #findActionByCaseId(int)}.
  * <p>
  * Be aware that timestamps associated with actions, such as {@link ActionRecord#issuedAt()} are
  * slightly off the timestamps used by Discord.
@@ -58,7 +57,7 @@ public final class ModerationActionsStore {
      * @return a list of all actions with the given type, chronologically ascending
      */
     public @NotNull List<ActionRecord> getActionsByTypeAscending(long guildId,
-            @NotNull ModerationUtils.Action actionType) {
+            @NotNull ModerationAction actionType) {
         Objects.requireNonNull(actionType);
 
         return getActionsFromGuildAscending(guildId,
@@ -95,7 +94,7 @@ public final class ModerationActionsStore {
 
     // FIXME javadoc
     public @NotNull Optional<ActionRecord> findLastActionAgainstTargetByType(long guildId,
-            long targetId, @NotNull ModerationUtils.Action actionType) {
+            long targetId, @NotNull ModerationAction actionType) {
         return Optional.of(database.read(context -> context
             .selectFrom(ModerationActions.MODERATION_ACTIONS)
             .where(ModerationActions.MODERATION_ACTIONS.GUILD_ID.eq(guildId)
@@ -139,7 +138,7 @@ public final class ModerationActionsStore {
      */
     @SuppressWarnings("MethodWithTooManyParameters")
     public int addAction(long guildId, long authorId, long targetId,
-            @NotNull ModerationUtils.Action actionType, @Nullable Instant actionExpiresAt,
+            @NotNull ModerationAction actionType, @Nullable Instant actionExpiresAt,
             @NotNull String reason) {
         Objects.requireNonNull(actionType);
         Objects.requireNonNull(reason);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationActionsStore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationActionsStore.java
@@ -39,7 +39,12 @@ public final class ModerationActionsStore {
         this.database = Objects.requireNonNull(database);
     }
 
-    // FIXME javadoc
+    /**
+     * Gets all already expired actions, measured by the current time, which have been written to
+     * the store, chronologically ascending with the action issued the earliest first.
+     * 
+     * @return a list of all expired actions, chronologically ascending
+     */
     public @NotNull List<ActionRecord> getExpiredActionsAscending() {
         return getActionsAscendingWhere(
                 ModerationActions.MODERATION_ACTIONS.ACTION_EXPIRES_AT.isNotNull()
@@ -92,7 +97,16 @@ public final class ModerationActionsStore {
                 ModerationActions.MODERATION_ACTIONS.AUTHOR_ID.eq(authorId));
     }
 
-    // FIXME javadoc
+    /**
+     * Gets the action of the given type that was issued the latest against the given target, if
+     * present.
+     * 
+     * @param guildId the id of the guild, only actions that happened in the context of that guild
+     *        will be retrieved
+     * @param targetId the id of the target user to filter for
+     * @param actionType the type of the action
+     * @return the last action issued against the given user of the given type, if present
+     */
     public @NotNull Optional<ActionRecord> findLastActionAgainstTargetByType(long guildId,
             long targetId, @NotNull ModerationAction actionType) {
         return database

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationActionsStore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationActionsStore.java
@@ -95,13 +95,15 @@ public final class ModerationActionsStore {
     // FIXME javadoc
     public @NotNull Optional<ActionRecord> findLastActionAgainstTargetByType(long guildId,
             long targetId, @NotNull ModerationAction actionType) {
-        return Optional.of(database.read(context -> context
-            .selectFrom(ModerationActions.MODERATION_ACTIONS)
-            .where(ModerationActions.MODERATION_ACTIONS.GUILD_ID.eq(guildId)
-                .and(ModerationActions.MODERATION_ACTIONS.TARGET_ID.eq(targetId)
-                    .and(ModerationActions.MODERATION_ACTIONS.ACTION_TYPE.eq(actionType.name()))))
-            .orderBy(ModerationActions.MODERATION_ACTIONS.ISSUED_AT.desc())
-            .fetchOne())).map(ActionRecord::of);
+        return database
+            .read(context -> context.selectFrom(ModerationActions.MODERATION_ACTIONS)
+                .where(ModerationActions.MODERATION_ACTIONS.GUILD_ID.eq(guildId)
+                    .and(ModerationActions.MODERATION_ACTIONS.TARGET_ID.eq(targetId))
+                    .and(ModerationActions.MODERATION_ACTIONS.ACTION_TYPE.eq(actionType.name())))
+                .orderBy(ModerationActions.MODERATION_ACTIONS.ISSUED_AT.desc())
+                .limit(1)
+                .fetchOptional())
+            .map(ActionRecord::of);
     }
 
     /**
@@ -111,10 +113,10 @@ public final class ModerationActionsStore {
      * @return the action with the given case id, if present
      */
     public @NotNull Optional<ActionRecord> findActionByCaseId(int caseId) {
-        return Optional
-            .of(database.read(context -> context.selectFrom(ModerationActions.MODERATION_ACTIONS)
+        return database
+            .read(context -> context.selectFrom(ModerationActions.MODERATION_ACTIONS)
                 .where(ModerationActions.MODERATION_ACTIONS.CASE_ID.eq(caseId))
-                .fetchOne()))
+                .fetchOptional())
             .map(ActionRecord::of);
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
@@ -30,10 +30,20 @@ public enum ModerationUtils {
      * {@link Guild#ban(User, int, String)}.
      */
     private static final int REASON_MAX_LENGTH = 512;
-    // FIXME Javadoc
+    /**
+     * Human-readable text representing the duration of a permanent action, will be shown to the
+     * user as option for selection.
+     */
     static final String PERMANENT_DURATION = "permanent";
+    /**
+     * The ambient color used by moderation actions, often used to streamline the color theme of
+     * embeds.
+     */
     static final Color AMBIENT_COLOR = Color.decode("#895FE8");
-    // FIXME Javadoc
+    /**
+     * Matches the name of the role that is used to mute users, as used by {@link MuteCommand} and
+     * similar.
+     */
     public static final Predicate<String> isMuteRole =
             Pattern.compile(Config.getInstance().getMutedRolePattern()).asMatchPredicate();
 
@@ -331,6 +341,15 @@ public enum ModerationUtils {
         return guild.getRoles().stream().filter(role -> isMuteRole.test(role.getName())).findAny();
     }
 
+    /**
+     * Computes a temporary data wrapper representing the action with the given duration.
+     *
+     * @param durationText the duration of the action, either {@code "permanent"} or a time window
+     *        such as {@code 1 day} or {@code 2 minutes}. Supports all units supported by
+     *        {@link Instant#plus(long, TemporalUnit)}.
+     * @return the temporary data represented by the given duration or empty if the duration is
+     *         {@code "permanent"}
+     */
     static @NotNull Optional<TemporaryData> computeTemporaryData(@NotNull String durationText) {
         if (PERMANENT_DURATION.equals(durationText)) {
             return Optional.empty();
@@ -350,6 +369,13 @@ public enum ModerationUtils {
         return Optional.of(new TemporaryData(Instant.now().plus(duration, unit), durationText));
     }
 
+    /**
+     * Wrapper to hold data relevant to temporary actions, for example the time it expires.
+     *
+     * @param expiresAt the time the temporary action expires
+     * @param duration a human-readable text representing the duration of the temporary action, such
+     *        as {@code "1 day"}.
+     */
     record TemporaryData(@NotNull Instant expiresAt, @NotNull String duration) {
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
@@ -298,8 +298,9 @@ public enum ModerationUtils {
      * @param reason an optional reason for why the action is executed, {@code null} if not desired
      * @return the created response
      */
-    static @NotNull MessageEmbed createActionResponse(@NotNull User author, @NotNull Action action,
-            @NotNull User target, @Nullable String extraMessage, @Nullable String reason) {
+    static @NotNull MessageEmbed createActionResponse(@NotNull User author,
+            @NotNull ModerationAction action, @NotNull User target, @Nullable String extraMessage,
+            @Nullable String reason) {
         String description = "%s **%s** (id: %s).".formatted(action.getVerb(), target.getAsTag(),
                 target.getId());
         if (extraMessage != null && !extraMessage.isBlank()) {
@@ -325,57 +326,4 @@ public enum ModerationUtils {
         return guild.getRoles().stream().filter(role -> isMuteRole.test(role.getName())).findAny();
     }
 
-    /**
-     * All available moderation actions.
-     */
-    enum Action {
-        /**
-         * When a user bans another user.
-         */
-        BAN("banned"),
-        /**
-         * When a user unbans another user.
-         */
-        UNBAN("unbanned"),
-        /**
-         * When a user kicks another user.
-         */
-        KICK("kicked"),
-        /**
-         * When a user warns another user.
-         */
-        WARN("warned"),
-        /**
-         * When a user mutes another user.
-         */
-        MUTE("muted"),
-        /**
-         * When a user unmutes another user.
-         */
-        UNMUTE("unmuted");
-
-        private final String verb;
-
-        /**
-         * Creates an instance with the given verb
-         *
-         * @param verb the verb of the action, as it would be used in a sentence, such as "banned"
-         *        or "kicked"
-         */
-        Action(@NotNull String verb) {
-            this.verb = verb;
-        }
-
-        /**
-         * Gets the verb of the action, as it would be used in a sentence.
-         * <p>
-         * Such as "banned" or "kicked"
-         *
-         * @return the verb of this action
-         */
-        @NotNull
-        String getVerb() {
-            return verb;
-        }
-    }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
@@ -102,7 +102,7 @@ public final class MuteCommand extends SlashCommandAdapter {
         if (!hasSentDm) {
             dmNoticeText = "\n(Unable to send them a DM.)";
         }
-        return ModerationUtils.createActionResponse(author.getUser(), ModerationUtils.Action.MUTE,
+        return ModerationUtils.createActionResponse(author.getUser(), ModerationAction.MUTE,
                 target.getUser(), durationText + dmNoticeText, reason);
     }
 
@@ -139,7 +139,7 @@ public final class MuteCommand extends SlashCommandAdapter {
 
         Instant expiresAt = temporaryMuteData == null ? null : temporaryMuteData.unmuteTime;
         actionsStore.addAction(guild.getIdLong(), author.getIdLong(), target.getIdLong(),
-                ModerationUtils.Action.MUTE, expiresAt, reason);
+                ModerationAction.MUTE, expiresAt, reason);
 
         return guild.addRoleToMember(target, ModerationUtils.getMutedRole(guild).orElseThrow())
             .reason(reason);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
@@ -38,6 +38,7 @@ public final class MuteCommand extends SlashCommandAdapter {
     private static final String REASON_OPTION = "reason";
     private static final String COMMAND_NAME = "mute";
     private static final String ACTION_VERB = "mute";
+    @SuppressWarnings("StaticCollection")
     private static final List<String> DURATIONS = List.of("10 minutes", "30 minutes", "1 hour",
             "3 hours", "1 day", "3 days", "7 days", ModerationUtils.PERMANENT_DURATION);
     private final Predicate<String> hasRequiredRole;
@@ -119,6 +120,7 @@ public final class MuteCommand extends SlashCommandAdapter {
             .reason(reason);
     }
 
+    @SuppressWarnings("MethodWithTooManyParameters")
     private void muteUserFlow(@NotNull Member target, @NotNull Member author,
             @Nullable ModerationUtils.TemporaryData temporaryData, @NotNull String reason,
             @NotNull Guild guild, @NotNull SlashCommandEvent event) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
@@ -40,8 +40,8 @@ public final class MuteCommand extends SlashCommandAdapter {
     private static final String COMMAND_NAME = "mute";
     private static final String ACTION_VERB = "mute";
     private static final String PERMANENT_DURATION = "permanent";
-    private static final List<String> DURATIONS = List.of(PERMANENT_DURATION, "1 hour", "3 hours",
-            "1 day", "2 days", "3 days", "7 days", "1 month");
+    private static final List<String> DURATIONS = List.of("10 minutes", "30 minutes", "1 hour",
+            "3 hours", "1 day", "3 days", "7 days", PERMANENT_DURATION);
     private final Predicate<String> hasRequiredRole;
     private final ModerationActionsStore actionsStore;
 
@@ -106,21 +106,20 @@ public final class MuteCommand extends SlashCommandAdapter {
                 target.getUser(), durationText + dmNoticeText, reason);
     }
 
+    // FIXME Code duplication with BanCommand, get rid of it
     private static @NotNull Optional<TemporaryMuteData> computeTemporaryMuteData(
             @NotNull String durationText) {
         if (PERMANENT_DURATION.equals(durationText)) {
             return Optional.empty();
         }
 
-        // 1 day, 1 days, 1 month, ...
+        // 1 minute, 1 day, 2 days, ...
         String[] data = durationText.split(" ", 2);
         int duration = Integer.parseInt(data[0]);
         ChronoUnit unit = switch (data[1]) {
             case "minute", "minutes" -> ChronoUnit.MINUTES;
             case "hour", "hours" -> ChronoUnit.HOURS;
             case "day", "days" -> ChronoUnit.DAYS;
-            case "week", "weeks" -> ChronoUnit.WEEKS;
-            case "month", "months" -> ChronoUnit.MONTHS;
             default -> throw new IllegalArgumentException(
                     "Unsupported mute duration: " + durationText);
         };

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
@@ -5,6 +5,7 @@ import net.dv8tion.jda.api.events.GenericEvent;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.Interaction;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.utils.Result;
@@ -16,7 +17,11 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -30,9 +35,13 @@ import java.util.regex.Pattern;
 public final class MuteCommand extends SlashCommandAdapter {
     private static final Logger logger = LoggerFactory.getLogger(MuteCommand.class);
     private static final String TARGET_OPTION = "user";
+    private static final String DURATION_OPTION = "duration";
     private static final String REASON_OPTION = "reason";
     private static final String COMMAND_NAME = "mute";
     private static final String ACTION_VERB = "mute";
+    private static final String PERMANENT_DURATION = "permanent";
+    private static final List<String> DURATIONS = List.of(PERMANENT_DURATION, "1 hour", "3 hours",
+            "1 day", "2 days", "3 days", "7 days", "1 month");
     private final Predicate<String> hasRequiredRole;
     private final ModerationActionsStore actionsStore;
 
@@ -45,7 +54,12 @@ public final class MuteCommand extends SlashCommandAdapter {
         super(COMMAND_NAME, "Mutes the given user so that they can not send messages anymore",
                 SlashCommandVisibility.GUILD);
 
+        OptionData durationData = new OptionData(OptionType.STRING, DURATION_OPTION,
+                "the duration of the mute, permanent or temporary", true);
+        DURATIONS.forEach(duration -> durationData.addChoice(duration, duration));
+
         getData().addOption(OptionType.USER, TARGET_OPTION, "The user who you want to mute", true)
+            .addOptions(durationData)
             .addOption(OptionType.STRING, REASON_OPTION, "Why the user should be muted", true);
 
         hasRequiredRole = Pattern.compile(Config.getInstance().getSoftModerationRolePattern())
@@ -57,16 +71,19 @@ public final class MuteCommand extends SlashCommandAdapter {
         event.reply("The user is already muted.").setEphemeral(true).queue();
     }
 
-    private static RestAction<Boolean> sendDm(@NotNull ISnowflake target, @NotNull String reason,
+    private static RestAction<Boolean> sendDm(@NotNull ISnowflake target,
+            @Nullable TemporaryMuteData temporaryMuteData, @NotNull String reason,
             @NotNull Guild guild, @NotNull GenericEvent event) {
+        String durationMessage =
+                temporaryMuteData == null ? "permanently" : "for " + temporaryMuteData.duration;
         String dmMessage =
                 """
-                        Hey there, sorry to tell you but unfortunately you have been muted in the server %s.
+                        Hey there, sorry to tell you but unfortunately you have been muted %s in the server %s.
                         This means you can no longer send any messages in the server until you have been unmuted again.
                         If you think this was a mistake, please contact a moderator or admin of the server.
                         The reason for the mute is: %s
                         """
-                    .formatted(guild.getName(), reason);
+                    .formatted(durationMessage, guild.getName(), reason);
         return event.getJDA()
             .openPrivateChannelById(target.getId())
             .flatMap(channel -> channel.sendMessage(dmMessage))
@@ -75,34 +92,66 @@ public final class MuteCommand extends SlashCommandAdapter {
     }
 
     private static @NotNull MessageEmbed sendFeedback(boolean hasSentDm, @NotNull Member target,
-            @NotNull Member author, @NotNull String reason) {
+            @NotNull Member author, @Nullable TemporaryMuteData temporaryMuteData,
+            @NotNull String reason) {
+        @SuppressWarnings("java:S1192") // this is not the name of the option but the user-friendly
+        // display text
+        String durationText = "The mute duration is: "
+                + (temporaryMuteData == null ? "permanent" : temporaryMuteData.duration);
         String dmNoticeText = "";
         if (!hasSentDm) {
-            dmNoticeText = "(Unable to send them a DM.)";
+            dmNoticeText = "\n(Unable to send them a DM.)";
         }
         return ModerationUtils.createActionResponse(author.getUser(), ModerationUtils.Action.MUTE,
-                target.getUser(), dmNoticeText, reason);
+                target.getUser(), durationText + dmNoticeText, reason);
+    }
+
+    private static @NotNull Optional<TemporaryMuteData> computeTemporaryMuteData(
+            @NotNull String durationText) {
+        if (PERMANENT_DURATION.equals(durationText)) {
+            return Optional.empty();
+        }
+
+        // 1 day, 1 days, 1 month, ...
+        String[] data = durationText.split(" ", 2);
+        int duration = Integer.parseInt(data[0]);
+        ChronoUnit unit = switch (data[1]) {
+            case "minute", "minutes" -> ChronoUnit.MINUTES;
+            case "hour", "hours" -> ChronoUnit.HOURS;
+            case "day", "days" -> ChronoUnit.DAYS;
+            case "week", "weeks" -> ChronoUnit.WEEKS;
+            case "month", "months" -> ChronoUnit.MONTHS;
+            default -> throw new IllegalArgumentException(
+                    "Unsupported mute duration: " + durationText);
+        };
+
+        return Optional.of(new TemporaryMuteData(Instant.now().plus(duration, unit), durationText));
     }
 
     private AuditableRestAction<Void> muteUser(@NotNull Member target, @NotNull Member author,
-            @NotNull String reason, @NotNull Guild guild) {
-        logger.info("'{}' ({}) muted the user '{}' ({}) in guild '{}' for reason '{}'.",
+            @Nullable TemporaryMuteData temporaryMuteData, @NotNull String reason,
+            @NotNull Guild guild) {
+        String durationMessage =
+                temporaryMuteData == null ? "permanently" : "for " + temporaryMuteData.duration;
+        logger.info("'{}' ({}) muted the user '{}' ({}) {} in guild '{}' for reason '{}'.",
                 author.getUser().getAsTag(), author.getId(), target.getUser().getAsTag(),
-                target.getId(), guild.getName(), reason);
+                target.getId(), durationMessage, guild.getName(), reason);
 
+        Instant expiresAt = temporaryMuteData == null ? null : temporaryMuteData.unmuteTime;
         actionsStore.addAction(guild.getIdLong(), author.getIdLong(), target.getIdLong(),
-                ModerationUtils.Action.MUTE, null, reason);
+                ModerationUtils.Action.MUTE, expiresAt, reason);
 
         return guild.addRoleToMember(target, ModerationUtils.getMutedRole(guild).orElseThrow())
             .reason(reason);
     }
 
     private void muteUserFlow(@NotNull Member target, @NotNull Member author,
-            @NotNull String reason, @NotNull Guild guild, @NotNull SlashCommandEvent event) {
-        sendDm(target, reason, guild, event)
-            .flatMap(hasSentDm -> muteUser(target, author, reason, guild)
+            @Nullable TemporaryMuteData temporaryMuteData, @NotNull String reason,
+            @NotNull Guild guild, @NotNull SlashCommandEvent event) {
+        sendDm(target, temporaryMuteData, reason, guild, event)
+            .flatMap(hasSentDm -> muteUser(target, author, temporaryMuteData, reason, guild)
                 .map(banResult -> hasSentDm))
-            .map(hasSentDm -> sendFeedback(hasSentDm, target, author, reason))
+            .map(hasSentDm -> sendFeedback(hasSentDm, target, author, temporaryMuteData, reason))
             .flatMap(event::replyEmbeds)
             .queue();
     }
@@ -134,14 +183,22 @@ public final class MuteCommand extends SlashCommandAdapter {
         Member author = Objects.requireNonNull(event.getMember(), "The author is null");
         String reason = Objects.requireNonNull(event.getOption(REASON_OPTION), "The reason is null")
             .getAsString();
+        String duration =
+                Objects.requireNonNull(event.getOption(DURATION_OPTION), "The duration is null")
+                    .getAsString();
 
         Guild guild = Objects.requireNonNull(event.getGuild());
         Member bot = guild.getSelfMember();
+        Optional<TemporaryMuteData> temporaryMuteData = computeTemporaryMuteData(duration);
 
         if (!handleChecks(bot, author, target, reason, guild, event)) {
             return;
         }
 
-        muteUserFlow(Objects.requireNonNull(target), author, reason, guild, event);
+        muteUserFlow(Objects.requireNonNull(target), author, temporaryMuteData.orElse(null), reason,
+                guild, event);
+    }
+
+    private record TemporaryMuteData(@NotNull Instant unmuteTime, @NotNull String duration) {
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/RejoinMuteListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/RejoinMuteListener.java
@@ -60,7 +60,7 @@ public final class RejoinMuteListener extends ListenerAdapter {
         Collections.reverse(actions);
 
         Optional<ActionRecord> lastMute = actions.stream()
-            .filter(action -> action.actionType() == ModerationUtils.Action.MUTE)
+            .filter(action -> action.actionType() == ModerationAction.MUTE)
             .findFirst();
         if (lastMute.isEmpty()) {
             // User was never muted
@@ -68,7 +68,7 @@ public final class RejoinMuteListener extends ListenerAdapter {
         }
 
         Optional<ActionRecord> lastUnmute = actions.stream()
-            .filter(action -> action.actionType() == ModerationUtils.Action.UNMUTE)
+            .filter(action -> action.actionType() == ModerationAction.UNMUTE)
             .findFirst();
         if (lastUnmute.isEmpty()) {
             // User was never unmuted

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/TemporaryModerationRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/TemporaryModerationRoutine.java
@@ -20,8 +20,8 @@ import java.util.stream.Collectors;
 // FIXME javadoc
 public final class TemporaryModerationRoutine {
     private static final Logger logger = LoggerFactory.getLogger(TemporaryModerationRoutine.class);
-    private static final Set<ModerationUtils.Action> REVOCABLE_ACTIONS =
-            EnumSet.of(ModerationUtils.Action.BAN, ModerationUtils.Action.MUTE);
+    private static final Set<ModerationAction> REVOCABLE_ACTIONS =
+            EnumSet.of(ModerationAction.BAN, ModerationAction.MUTE);
 
     private final ModerationActionsStore actionsStore;
     private final JDA jda;
@@ -96,9 +96,9 @@ public final class TemporaryModerationRoutine {
         // Do not revoke an action which was already revoked by another action issued afterwards
         // For example if a user was unbanned manually after being temp-banned,
         // but also if the system automatically revoked a temp-ban already itself
-        ModerationUtils.Action revokeActionType = switch (groupIdentifier.type) {
-            case BAN -> ModerationUtils.Action.UNBAN;
-            case MUTE -> ModerationUtils.Action.UNMUTE;
+        ModerationAction revokeActionType = switch (groupIdentifier.type) {
+            case BAN -> ModerationAction.UNBAN;
+            case MUTE -> ModerationAction.UNMUTE;
             default -> throw new AssertionError("Unsupported action type: " + groupIdentifier.type);
         };
         ActionRecord lastRevokeAction = actionsStore
@@ -134,7 +134,7 @@ public final class TemporaryModerationRoutine {
     }
 
     private @NotNull AuditableRestAction<Void> executeRevocation(@NotNull Guild guild,
-            @NotNull User target, @NotNull ModerationUtils.Action actionType) {
+            @NotNull User target, @NotNull ModerationAction actionType) {
         logger.info("Revoked temporary action {} against user '{}' ({}).", actionType,
                 target.getAsTag(), target.getId());
 
@@ -162,7 +162,7 @@ public final class TemporaryModerationRoutine {
     }
 
     private record RevocationGroupIdentifier(long guildId, long targetId,
-            @NotNull ModerationUtils.Action type) {
+            @NotNull ModerationAction type) {
         public static RevocationGroupIdentifier of(@NotNull ActionRecord actionRecord) {
             return new RevocationGroupIdentifier(actionRecord.guildId(), actionRecord.targetId(),
                     actionRecord.actionType());

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/TemporaryModerationRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/TemporaryModerationRoutine.java
@@ -1,0 +1,171 @@
+package org.togetherjava.tjbot.commands.moderation;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
+import net.dv8tion.jda.api.requests.ErrorResponse;
+import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+// FIXME javadoc
+public final class TemporaryModerationRoutine {
+    private static final Logger logger = LoggerFactory.getLogger(TemporaryModerationRoutine.class);
+    private static final Set<ModerationUtils.Action> REVOCABLE_ACTIONS =
+            EnumSet.of(ModerationUtils.Action.BAN, ModerationUtils.Action.MUTE);
+
+    private final ModerationActionsStore actionsStore;
+    private final JDA jda;
+    private final ScheduledExecutorService checkExpiredActionsService =
+            Executors.newSingleThreadScheduledExecutor();
+
+    /**
+     * Creates a new instance.
+     *
+     * @param jda the JDA instance to use to send messages and retrieve information
+     * @param actionsStore the store used to retrieve temporary moderation actions
+     */
+    public TemporaryModerationRoutine(@NotNull JDA jda,
+            @NotNull ModerationActionsStore actionsStore) {
+        this.actionsStore = actionsStore;
+        this.jda = jda;
+    }
+
+    private static void handleFailure(@NotNull Throwable failure,
+            @NotNull RevocationGroupIdentifier groupIdentifier) {
+        if (failure instanceof ErrorResponseException errorResponseException) {
+            if (errorResponseException.getErrorResponse() == ErrorResponse.UNKNOWN_USER) {
+                logger.info(
+                        "Attempted to revoke a temporary moderation action but user '{}' does not exist anymore.",
+                        groupIdentifier.targetId);
+                return;
+            }
+
+            if (errorResponseException.getErrorResponse() == ErrorResponse.UNKNOWN_BAN) {
+                logger.info(
+                        "Attempted to revoke a temporary moderation action but the action is not relevant for user '{}' anymore.",
+                        groupIdentifier.targetId);
+                return;
+            }
+        }
+
+        logger.warn(
+                "Attempted to revoke a temporary moderation action for user '{}' but something unexpected went wrong.",
+                groupIdentifier.targetId, failure);
+    }
+
+    private void checkExpiredActions() {
+        logger.debug("Checking expired temporary moderation actions to revoke...");
+
+        actionsStore.getExpiredActionsAscending()
+            .stream()
+            .filter(action -> REVOCABLE_ACTIONS.contains(action.actionType()))
+            .collect(Collectors.groupingBy(RevocationGroupIdentifier::of))
+            .forEach(this::processGroupedActions);
+
+        logger.debug("Finished checking expired temporary moderation actions to revoke.");
+    }
+
+    private void processGroupedActions(@NotNull RevocationGroupIdentifier groupIdentifier,
+            @NotNull Collection<ActionRecord> expiredActions) {
+        // Last issued temporary action takes priority
+        ActionRecord actionToRevoke = expiredActions.stream()
+            .max(Comparator.comparing(ActionRecord::issuedAt))
+            .orElseThrow();
+
+        // Do not revoke an action which was overwritten by a permanent action that was issued
+        // afterwards
+        // For example if a user was perm-banned after being temp-banned
+        ActionRecord lastAction = actionsStore
+            .findLastActionAgainstTargetByType(groupIdentifier.guildId, groupIdentifier.targetId,
+                    groupIdentifier.type)
+            .orElseThrow();
+        if (lastAction.actionExpiresAt() == null) {
+            return;
+        }
+
+        // Do not revoke an action which was already revoked by another action issued afterwards
+        // For example if a user was unbanned manually after being temp-banned,
+        // but also if the system automatically revoked a temp-ban already itself
+        ModerationUtils.Action revokeActionType = switch (groupIdentifier.type) {
+            case BAN -> ModerationUtils.Action.UNBAN;
+            case MUTE -> ModerationUtils.Action.UNMUTE;
+            default -> throw new AssertionError("Unsupported action type: " + groupIdentifier.type);
+        };
+        ActionRecord lastRevokeAction = actionsStore
+            .findLastActionAgainstTargetByType(groupIdentifier.guildId, groupIdentifier.targetId,
+                    revokeActionType)
+            .orElseThrow();
+        if (lastRevokeAction.issuedAt().isAfter(actionToRevoke.issuedAt())
+                && (lastRevokeAction.actionExpiresAt() == null
+                        || lastRevokeAction.actionExpiresAt().isAfter(Instant.now()))) {
+            return;
+        }
+
+        revokeAction(groupIdentifier);
+    }
+
+    private void revokeAction(@NotNull RevocationGroupIdentifier groupIdentifier) {
+        if (!REVOCABLE_ACTIONS.contains(groupIdentifier.type)) {
+            throw new AssertionError("Unsupported action type: " + groupIdentifier.type);
+        }
+
+        Guild guild = jda.getGuildById(groupIdentifier.guildId);
+        if (guild == null) {
+            logger.info(
+                    "Attempted to revoke a temporary moderation action but the bot is not connected to the guild '{}' anymore, skipping revoking.",
+                    groupIdentifier.guildId);
+            return;
+        }
+
+        jda.retrieveUserById(groupIdentifier.targetId)
+            .flatMap(target -> executeRevocation(guild, target, groupIdentifier.type))
+            .queue(result -> {
+            }, failure -> handleFailure(failure, groupIdentifier));
+    }
+
+    private @NotNull AuditableRestAction<Void> executeRevocation(@NotNull Guild guild,
+            @NotNull User target, @NotNull ModerationUtils.Action actionType) {
+        logger.info("Revoked temporary action {} against user '{}' ({}).", actionType,
+                target.getAsTag(), target.getId());
+
+        String reason = "Automatic revocation of temporary action.";
+        actionsStore.addAction(guild.getIdLong(), jda.getSelfUser().getIdLong(), target.getIdLong(),
+                actionType, null, reason);
+
+        return (switch (actionType) {
+            case BAN -> guild.unban(target);
+            case MUTE -> guild.removeRoleFromMember(target.getIdLong(),
+                    ModerationUtils.getMutedRole(guild).orElseThrow());
+            default -> throw new AssertionError("Unsupported action type: " + actionType);
+        }).reason(reason);
+    }
+
+    /**
+     * Starts the routine, automatically checking expired temporary moderation actions on a
+     * schedule.
+     */
+    public void start() {
+        // TODO This should be registered at some sort of routine system instead (see GH issue #235
+        // which adds support for routines)
+        checkExpiredActionsService.scheduleWithFixedDelay(this::checkExpiredActions, 0, 5,
+                TimeUnit.MINUTES);
+    }
+
+    private record RevocationGroupIdentifier(long guildId, long targetId,
+            @NotNull ModerationUtils.Action type) {
+        public static RevocationGroupIdentifier of(@NotNull ActionRecord actionRecord) {
+            return new RevocationGroupIdentifier(actionRecord.guildId(), actionRecord.targetId(),
+                    actionRecord.actionType());
+        }
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnbanCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnbanCommand.java
@@ -53,7 +53,7 @@ public final class UnbanCommand extends SlashCommandAdapter {
             @NotNull Guild guild, @NotNull Interaction event) {
         guild.unban(target).reason(reason).queue(result -> {
             MessageEmbed message = ModerationUtils.createActionResponse(author.getUser(),
-                    ModerationUtils.Action.UNBAN, target, null, reason);
+                    ModerationAction.UNBAN, target, null, reason);
             event.replyEmbeds(message).queue();
 
             logger.info("'{}' ({}) unbanned the user '{}' ({}) from guild '{}' for reason '{}'.",
@@ -61,7 +61,7 @@ public final class UnbanCommand extends SlashCommandAdapter {
                     guild.getName(), reason);
 
             actionsStore.addAction(guild.getIdLong(), author.getIdLong(), target.getIdLong(),
-                    ModerationUtils.Action.UNBAN, null, reason);
+                    ModerationAction.UNBAN, null, reason);
         }, unbanFailure -> handleFailure(unbanFailure, target, event));
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnmuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnmuteCommand.java
@@ -78,7 +78,7 @@ public final class UnmuteCommand extends SlashCommandAdapter {
         if (!hasSentDm) {
             dmNoticeText = "(Unable to send them a DM.)";
         }
-        return ModerationUtils.createActionResponse(author.getUser(), ModerationUtils.Action.UNMUTE,
+        return ModerationUtils.createActionResponse(author.getUser(), ModerationAction.UNMUTE,
                 target.getUser(), dmNoticeText, reason);
     }
 
@@ -89,7 +89,7 @@ public final class UnmuteCommand extends SlashCommandAdapter {
                 target.getId(), guild.getName(), reason);
 
         actionsStore.addAction(guild.getIdLong(), author.getIdLong(), target.getIdLong(),
-                ModerationUtils.Action.UNMUTE, null, reason);
+                ModerationAction.UNMUTE, null, reason);
 
         return guild.removeRoleFromMember(target, ModerationUtils.getMutedRole(guild).orElseThrow())
             .reason(reason);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/WarnCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/WarnCommand.java
@@ -84,7 +84,7 @@ public final class WarnCommand extends SlashCommandAdapter {
                 reason);
 
         actionsStore.addAction(guild.getIdLong(), author.getIdLong(), target.getIdLong(),
-                ModerationUtils.Action.WARN, null, reason);
+                ModerationAction.WARN, null, reason);
     }
 
     private static @NotNull MessageEmbed sendFeedback(boolean hasSentDm, @NotNull User target,
@@ -93,8 +93,8 @@ public final class WarnCommand extends SlashCommandAdapter {
         if (!hasSentDm) {
             dmNoticeText = "(Unable to send them a DM.)";
         }
-        return ModerationUtils.createActionResponse(author.getUser(), ModerationUtils.Action.WARN,
-                target, dmNoticeText, reason);
+        return ModerationUtils.createActionResponse(author.getUser(), ModerationAction.WARN, target,
+                dmNoticeText, reason);
     }
 
     @Override

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/RevocableModerationAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/RevocableModerationAction.java
@@ -6,23 +6,67 @@ import net.dv8tion.jda.api.requests.RestAction;
 import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.moderation.ModerationAction;
 
-// FIXME Javadoc
+/**
+ * Represents revocable moderation actions, such as temporary bans. Primarily used by
+ * {@link TemporaryModerationRoutine} to identify and revoke such actions.
+ */
 interface RevocableModerationAction {
+    /**
+     * Classification of a revocation failure.
+     */
+    @SuppressWarnings("PublicInnerClass")
     enum FailureIdentification {
+        /**
+         * Acknowledges that the failure is known and has been handled. Hence, further error
+         * handling should not be continued.
+         */
         KNOWN,
+        /**
+         * The failure is unknown and has not been handled. Hence, further error handling should be
+         * continued.
+         */
         UNKNOWN
     }
 
+    /**
+     * The type to apply the temporary action, such as
+     * {@link net.dv8tion.jda.api.audit.ActionType#BAN}.
+     * 
+     * @return the type to apply the temporary action
+     */
     @NotNull
     ModerationAction getApplyType();
 
+    /**
+     * The type to revoke the temporary action, such as
+     * {@link net.dv8tion.jda.api.audit.ActionType#UNBAN}.
+     * 
+     * @return the type to revoke the temporary action
+     */
     @NotNull
     ModerationAction getRevokeType();
 
+    /**
+     * Revokes the temporary action against the given target.
+     * 
+     * @param guild the guild the user belongs to
+     * @param target the target to revoke the action against
+     * @param reason why the action is revoked
+     * @return the unsubmitted revocation action
+     */
     @NotNull
     RestAction<Void> revokeAction(@NotNull Guild guild, @NotNull User target,
             @NotNull String reason);
 
+    /**
+     * Handle a failure that might occur during revocation, i.e. execution of the action returned by
+     * {@link #revokeAction(Guild, User, String)}.
+     * 
+     * @param failure the failure to handle
+     * @param targetId the id of the user who is targeted by the revocation
+     * @return a classification of the failure, decides whether the surrounding flow will continue
+     *         to handle the error further or not
+     */
     @NotNull
     FailureIdentification handleRevokeFailure(@NotNull Throwable failure, long targetId);
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/RevocableModerationAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/RevocableModerationAction.java
@@ -1,0 +1,28 @@
+package org.togetherjava.tjbot.commands.moderation.temp;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.requests.RestAction;
+import org.jetbrains.annotations.NotNull;
+import org.togetherjava.tjbot.commands.moderation.ModerationAction;
+
+// FIXME Javadoc
+interface RevocableModerationAction {
+    enum FailureIdentification {
+        KNOWN,
+        UNKNOWN
+    }
+
+    @NotNull
+    ModerationAction getApplyType();
+
+    @NotNull
+    ModerationAction getRevokeType();
+
+    @NotNull
+    RestAction<Void> revokeAction(@NotNull Guild guild, @NotNull User target,
+            @NotNull String reason);
+
+    @NotNull
+    FailureIdentification handleRevokeFailure(@NotNull Throwable failure, long targetId);
+}

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryBanAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryBanAction.java
@@ -10,7 +10,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.moderation.ModerationAction;
 
-// FIXME Javadoc
+/**
+ * Action to revoke temporary bans, as applied by
+ * {@link org.togetherjava.tjbot.commands.moderation.BanCommand} and executed by
+ * {@link TemporaryModerationRoutine}.
+ */
 final class TemporaryBanAction implements RevocableModerationAction {
     private static final Logger logger = LoggerFactory.getLogger(TemporaryBanAction.class);
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryBanAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryBanAction.java
@@ -1,0 +1,53 @@
+package org.togetherjava.tjbot.commands.moderation.temp;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
+import net.dv8tion.jda.api.requests.ErrorResponse;
+import net.dv8tion.jda.api.requests.RestAction;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.togetherjava.tjbot.commands.moderation.ModerationAction;
+
+// FIXME Javadoc
+final class TemporaryBanAction implements RevocableModerationAction {
+    private static final Logger logger = LoggerFactory.getLogger(TemporaryBanAction.class);
+
+    @Override
+    public @NotNull ModerationAction getApplyType() {
+        return ModerationAction.BAN;
+    }
+
+    @Override
+    public @NotNull ModerationAction getRevokeType() {
+        return ModerationAction.UNBAN;
+    }
+
+    @Override
+    public @NotNull RestAction<Void> revokeAction(@NotNull Guild guild, @NotNull User target,
+            @NotNull String reason) {
+        return guild.unban(target).reason(reason);
+    }
+
+    @Override
+    public @NotNull FailureIdentification handleRevokeFailure(@NotNull Throwable failure,
+            long targetId) {
+        if (failure instanceof ErrorResponseException errorResponseException) {
+            if (errorResponseException.getErrorResponse() == ErrorResponse.UNKNOWN_USER) {
+                logger.info(
+                        "Attempted to revoke a temporary ban but user '{}' does not exist anymore.",
+                        targetId);
+                return FailureIdentification.KNOWN;
+            }
+
+            if (errorResponseException.getErrorResponse() == ErrorResponse.UNKNOWN_BAN) {
+                logger.info(
+                        "Attempted to revoke a temporary ban but the user '{}' is not banned anymore.",
+                        targetId);
+                return FailureIdentification.KNOWN;
+            }
+        }
+        return FailureIdentification.UNKNOWN;
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryBanAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryBanAction.java
@@ -39,16 +39,21 @@ final class TemporaryBanAction implements RevocableModerationAction {
             long targetId) {
         if (failure instanceof ErrorResponseException errorResponseException) {
             if (errorResponseException.getErrorResponse() == ErrorResponse.UNKNOWN_USER) {
-                logger.info(
+                logger.debug(
                         "Attempted to revoke a temporary ban but user '{}' does not exist anymore.",
                         targetId);
                 return FailureIdentification.KNOWN;
             }
 
             if (errorResponseException.getErrorResponse() == ErrorResponse.UNKNOWN_BAN) {
-                logger.info(
+                logger.debug(
                         "Attempted to revoke a temporary ban but the user '{}' is not banned anymore.",
                         targetId);
+                return FailureIdentification.KNOWN;
+            }
+
+            if (errorResponseException.getErrorResponse() == ErrorResponse.MISSING_PERMISSIONS) {
+                logger.warn("Attempted to revoke a temporary ban but the bot lacks permission.");
                 return FailureIdentification.KNOWN;
             }
         }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryModerationRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryModerationRoutine.java
@@ -21,7 +21,16 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-// FIXME javadoc
+/**
+ * Routine that revokes temporary moderation actions, such as temporary bans, as listed by
+ * {@link ModerationActionsStore}.
+ * <p>
+ * The routine is started by using {@link #start()} and then automatically executes on a schedule.
+ * <p>
+ * Revoked actions are compatible with {@link ModerationActionsStore} and commands such as
+ * {@link org.togetherjava.tjbot.commands.moderation.UnbanCommand} and
+ * {@link org.togetherjava.tjbot.commands.moderation.AuditCommand}.
+ */
 public final class TemporaryModerationRoutine {
     private static final Logger logger = LoggerFactory.getLogger(TemporaryModerationRoutine.class);
 
@@ -142,7 +151,7 @@ public final class TemporaryModerationRoutine {
     public void start() {
         // TODO This should be registered at some sort of routine system instead (see GH issue #235
         // which adds support for routines)
-        // NOTE The initial run has to be delayed until after the guild cache has been updated
+        // TODO The initial run has to be delayed until after the guild cache has been updated
         // (during CommandSystem startup)
         checkExpiredActionsService.scheduleWithFixedDelay(this::checkExpiredActions, 5, 5,
                 TimeUnit.MINUTES);
@@ -150,7 +159,7 @@ public final class TemporaryModerationRoutine {
 
     private record RevocationGroupIdentifier(long guildId, long targetId,
             @NotNull ModerationAction type) {
-        public static RevocationGroupIdentifier of(@NotNull ActionRecord actionRecord) {
+        static RevocationGroupIdentifier of(@NotNull ActionRecord actionRecord) {
             return new RevocationGroupIdentifier(actionRecord.guildId(), actionRecord.targetId(),
                     actionRecord.actionType());
         }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryModerationRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryModerationRoutine.java
@@ -1,4 +1,4 @@
-package org.togetherjava.tjbot.commands.moderation;
+package org.togetherjava.tjbot.commands.moderation.temp;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
@@ -9,6 +9,10 @@ import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.togetherjava.tjbot.commands.moderation.ActionRecord;
+import org.togetherjava.tjbot.commands.moderation.ModerationAction;
+import org.togetherjava.tjbot.commands.moderation.ModerationActionsStore;
+import org.togetherjava.tjbot.commands.moderation.ModerationUtils;
 
 import java.time.Instant;
 import java.util.*;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryModerationRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryModerationRoutine.java
@@ -12,8 +12,6 @@ import org.togetherjava.tjbot.commands.moderation.ModerationAction;
 import org.togetherjava.tjbot.commands.moderation.ModerationActionsStore;
 
 import java.time.Instant;
-import java.util.Collection;
-import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executors;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryMuteAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryMuteAction.java
@@ -1,0 +1,50 @@
+package org.togetherjava.tjbot.commands.moderation.temp;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
+import net.dv8tion.jda.api.requests.ErrorResponse;
+import net.dv8tion.jda.api.requests.RestAction;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.togetherjava.tjbot.commands.moderation.ModerationAction;
+import org.togetherjava.tjbot.commands.moderation.ModerationUtils;
+
+// FIXME Javadoc
+final class TemporaryMuteAction implements RevocableModerationAction {
+    private static final Logger logger = LoggerFactory.getLogger(TemporaryMuteAction.class);
+
+    @Override
+    public @NotNull ModerationAction getApplyType() {
+        return ModerationAction.MUTE;
+    }
+
+    @Override
+    public @NotNull ModerationAction getRevokeType() {
+        return ModerationAction.UNMUTE;
+    }
+
+    @Override
+    public @NotNull RestAction<Void> revokeAction(@NotNull Guild guild, @NotNull User target,
+            @NotNull String reason) {
+        return guild
+            .removeRoleFromMember(target.getIdLong(),
+                    ModerationUtils.getMutedRole(guild).orElseThrow())
+            .reason(reason);
+    }
+
+    @Override
+    public @NotNull FailureIdentification handleRevokeFailure(@NotNull Throwable failure,
+            long targetId) {
+        if (failure instanceof ErrorResponseException errorResponseException) {
+            if (errorResponseException.getErrorResponse() == ErrorResponse.UNKNOWN_USER) {
+                logger.info(
+                        "Attempted to revoke a temporary mute but user '{}' does not exist anymore.",
+                        targetId);
+                return FailureIdentification.KNOWN;
+            }
+        }
+        return FailureIdentification.UNKNOWN;
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryMuteAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryMuteAction.java
@@ -11,7 +11,11 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.moderation.ModerationAction;
 import org.togetherjava.tjbot.commands.moderation.ModerationUtils;
 
-// FIXME Javadoc
+/**
+ * Action to revoke temporary mutes, as applied by
+ * {@link org.togetherjava.tjbot.commands.moderation.MuteCommand} and executed by
+ * {@link TemporaryModerationRoutine}.
+ */
 final class TemporaryMuteAction implements RevocableModerationAction {
     private static final Logger logger = LoggerFactory.getLogger(TemporaryMuteAction.class);
 
@@ -37,13 +41,12 @@ final class TemporaryMuteAction implements RevocableModerationAction {
     @Override
     public @NotNull FailureIdentification handleRevokeFailure(@NotNull Throwable failure,
             long targetId) {
-        if (failure instanceof ErrorResponseException errorResponseException) {
-            if (errorResponseException.getErrorResponse() == ErrorResponse.UNKNOWN_USER) {
-                logger.info(
-                        "Attempted to revoke a temporary mute but user '{}' does not exist anymore.",
-                        targetId);
-                return FailureIdentification.KNOWN;
-            }
+        if (failure instanceof ErrorResponseException errorResponseException
+                && errorResponseException.getErrorResponse() == ErrorResponse.UNKNOWN_USER) {
+            logger.info(
+                    "Attempted to revoke a temporary mute but user '{}' does not exist anymore.",
+                    targetId);
+            return FailureIdentification.KNOWN;
         }
         return FailureIdentification.UNKNOWN;
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This package offers classes dealing with temporary moderation actions, such as temporary bans.
+ */
+package org.togetherjava.tjbot.commands.moderation.temp;


### PR DESCRIPTION
### Overview

Dyno supports temporary bans and mutes, so should we. This adds support for such a feature. Part of #63 and #64 .

Therefore, a `duration` option is added to the existing `ban` and `mute` commands, which allows selection from a menu, such as:

![choice menu](https://i.imgur.com/meKiAhn.png)

![response](https://i.imgur.com/Rf66iFl.png)

![user DM](https://i.imgur.com/EwjBc4N.png)

### Details

The feature is implemented by using the existing `ModerationActionsStore`, which already supports a field `expires_at`.

A new class `TemporaryModerationRoutine` is scheduled every 5 minutes. The routine basically selects all actions from the store where `expires_at` is behind `now` (minus edge cases, like already revoked, overwriten by another action, ...) and then revokes those actions by unbanning/unmuting the user.

The system is **designed modular** enough to easily be expanded with new temporary moderation actions (i.e. other than temp ban and temp mute). Therefore, the slim interface `RevocableModerationAction` is implemented and an implementation is added to a list in `TemporaryModerationRoutine`, the rest is automatic.

The system also gracefully supports long downtimes. Hence, it is not a problem if the actual revocation date of an action is missed, the system will revoke it on the next execution when the bot is online again. This also holds true if the bot is temporarily removed from a guild or, more importantly if an user is temporarily not a member of the guild anymore (think about a temporary mute, then user leaves and wants to rejoin after the expiration date, mute should not be applied anymore).

### Notes

Error handling, such as users who got deleted in the meantime, left the guild or the even the bot leaving the guild and similar, are handled solely by `logger` messages. There is no direct feedback in any guild channel (on purpose).

![logger success](https://i.imgur.com/0OqAA45.png)

Revocation is picked up by the existing mod-audit-log feature:

![audit log](https://i.imgur.com/CTZ7o1m.png)

As well as by the `/audit` command (ignore the timestamps, I didnt have the bot running for some time):

![audit command](https://i.imgur.com/HtwraQP.png)

### Checklist

#### TODO

* [x] Wait for #252 
* [x] Add support for temp mutes
* [x] Fix remaining issues in the code
* [x] Javadoc, Linter

#### Testing

Base cases:
* [x] Perm ban
* [x] Perm mute
* [x] Temp ban
* [x] Temp unmute

Bot leaves guild
* [x] Temp ban/mute, then remove bot from guild and wait until revoke kicks in (can be mocked easily by editing the DB guildId value)

User does not exist
* [x] Temp ban/mute, then delete user account from Discord and wait until revoke kicks in (can be mocked easily by editing the DB userId value)

User is not a member
* [x] Temp mute user, kick user, wait until revoke kicks in

Multiple overlapping actions
* [x] Temp ban user, then unban, then temp ban again with different time (all within less than 5 minutes (the routine schedule))

Stale event
* [x] Temp ban user, then unban, temp unban should not be executed anymore
* [x] Temp mute user, then unmute, temp unmute should not be executed anymore
