### PR TITLE
Fix database methods are ambiguous without curlies

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/DatabaseCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/DatabaseCommand.java
@@ -85,12 +85,12 @@ public final class DatabaseCommand extends SlashCommandAdapter {
         // /db get hello
         String key = Objects.requireNonNull(event.getOption(KEY_OPTION)).getAsString();
         try {
-            Optional<String> value = database.read(context -> {
-                try (var select = context.selectFrom(Storage.STORAGE)) {
-                    return Optional.ofNullable(select.where(Storage.STORAGE.KEY.eq(key)).fetchOne())
-                        .map(StorageRecord::getValue);
-                }
-            });
+            Optional<String> value = database.read(
+                    context -> Optional
+                        .ofNullable(context.selectFrom(Storage.STORAGE)
+                            .where(Storage.STORAGE.KEY.eq(key))
+                            .fetchOne())
+                        .map(StorageRecord::getValue));
             if (value.isEmpty()) {
                 event.reply("Nothing found for the key '" + key + "'").setEphemeral(true).queue();
                 return;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdStore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdStore.java
@@ -234,7 +234,7 @@ public final class ComponentIdStore implements AutoCloseable {
     private void heatRecord(@NotNull UUID uuid) {
         int updatedRecords;
         synchronized (storeLock) {
-            updatedRecords = database.write(context -> {
+            updatedRecords = database.writeAndProvide(context -> {
                 return context.update(ComponentIds.COMPONENT_IDS)
                     .set(ComponentIds.COMPONENT_IDS.LAST_USED, Instant.now())
                     .where(ComponentIds.COMPONENT_IDS.UUID.eq(uuid.toString()))

--- a/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdStore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdStore.java
@@ -210,16 +210,13 @@ public final class ComponentIdStore implements AutoCloseable {
         }
     }
 
-    @SuppressWarnings({"resource", "java:S1602"})
     private @NotNull Optional<ComponentId> getFromDatabase(@NotNull UUID uuid) {
-        return database.read(context -> {
-            return Optional
-                .ofNullable(context.selectFrom(ComponentIds.COMPONENT_IDS)
-                    .where(ComponentIds.COMPONENT_IDS.UUID.eq(uuid.toString()))
-                    .fetchOne())
-                .map(ComponentIdsRecord::getComponentId)
-                .map(ComponentIdStore::deserializeComponentId);
-        });
+        return database.read(context -> Optional
+            .ofNullable(context.selectFrom(ComponentIds.COMPONENT_IDS)
+                .where(ComponentIds.COMPONENT_IDS.UUID.eq(uuid.toString()))
+                .fetchOne())
+            .map(ComponentIdsRecord::getComponentId)
+            .map(ComponentIdStore::deserializeComponentId));
     }
 
     /**
@@ -230,16 +227,14 @@ public final class ComponentIdStore implements AutoCloseable {
      * @param uuid the uuid to heat
      * @throws IllegalArgumentException if there is no, or multiple, records associated to that UUID
      */
-    @SuppressWarnings({"resource", "java:S1602"})
     private void heatRecord(@NotNull UUID uuid) {
         int updatedRecords;
         synchronized (storeLock) {
-            updatedRecords = database.writeAndProvide(context -> {
-                return context.update(ComponentIds.COMPONENT_IDS)
-                    .set(ComponentIds.COMPONENT_IDS.LAST_USED, Instant.now())
-                    .where(ComponentIds.COMPONENT_IDS.UUID.eq(uuid.toString()))
-                    .execute();
-            });
+            updatedRecords =
+                    database.writeAndProvide(context -> context.update(ComponentIds.COMPONENT_IDS)
+                        .set(ComponentIds.COMPONENT_IDS.LAST_USED, Instant.now())
+                        .where(ComponentIds.COMPONENT_IDS.UUID.eq(uuid.toString()))
+                        .execute());
         }
 
         // NOTE Case 0, where no records are updated, is ignored on purpose.
@@ -255,7 +250,6 @@ public final class ComponentIdStore implements AutoCloseable {
         AtomicInteger evictedCounter = new AtomicInteger(0);
         synchronized (storeLock) {
             database.write(context -> {
-                @SuppressWarnings("resource")
                 Result<ComponentIdsRecord> oldRecords = context
                     .selectFrom(ComponentIds.COMPONENT_IDS)
                     .where(ComponentIds.COMPONENT_IDS.LIFESPAN.notEqual(Lifespan.PERMANENT.name())
@@ -317,13 +311,11 @@ public final class ComponentIdStore implements AutoCloseable {
             return;
         }
 
-        // Without curly braces on the lambda, the call would be ambiguous
-        @SuppressWarnings("java:S1602")
         Map<Lifespan, Integer> lifespanToCount = Arrays.stream(Lifespan.values())
-            .collect(Collectors.toMap(Function.identity(), lifespan -> database.read(context -> {
-                return context.fetchCount(ComponentIds.COMPONENT_IDS,
-                        ComponentIds.COMPONENT_IDS.LIFESPAN.eq(lifespan.name()));
-            })));
+            .collect(Collectors.toMap(Function.identity(),
+                    lifespan -> database
+                        .read(context -> context.fetchCount(ComponentIds.COMPONENT_IDS,
+                                ComponentIds.COMPONENT_IDS.LIFESPAN.eq(lifespan.name())))));
         int recordsCount = lifespanToCount.values().stream().mapToInt(Integer::intValue).sum();
 
         logger.debug("The component id store consists of {} records ({})", recordsCount,

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagSystem.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagSystem.java
@@ -97,7 +97,7 @@ public final class TagSystem {
     // Execute closes resources; without curly braces on the lambda, the call would be ambiguous
     @SuppressWarnings({"resource", "java:S1602"})
     void deleteTag(String id) {
-        int deletedRecords = database.write(context -> {
+        int deletedRecords = database.writeAndProvide(context -> {
             return context.deleteFrom(Tags.TAGS).where(Tags.TAGS.ID.eq(id)).execute();
         });
         if (deletedRecords == 0) {

--- a/application/src/main/java/org/togetherjava/tjbot/routines/ModAuditLogRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/routines/ModAuditLogRoutine.java
@@ -259,15 +259,15 @@ public final class ModAuditLogRoutine {
     private void handleAuditLogs(@NotNull MessageChannel auditLogChannel,
             @NotNull PaginationAction<? extends AuditLogEntry, AuditLogPaginationAction> auditLogAction,
             long guildId) {
-        @SuppressWarnings("squid:S1602")
-        Instant lastAuditLogEntryTimestamp = database.read(context -> {
-            return Optional
-                .ofNullable(context.fetchOne(ModAuditLogGuildProcess.MOD_AUDIT_LOG_GUILD_PROCESS,
-                        ModAuditLogGuildProcess.MOD_AUDIT_LOG_GUILD_PROCESS.GUILD_ID.eq(guildId)))
-                .map(entry -> entry.get(
-                        ModAuditLogGuildProcess.MOD_AUDIT_LOG_GUILD_PROCESS.LAST_PROCESSED_AUDIT_LOG_ENTRY))
-                .orElse(Instant.now());
-        });
+        Instant lastAuditLogEntryTimestamp =
+                database.read(context -> Optional
+                    .ofNullable(context.fetchOne(
+                            ModAuditLogGuildProcess.MOD_AUDIT_LOG_GUILD_PROCESS,
+                            ModAuditLogGuildProcess.MOD_AUDIT_LOG_GUILD_PROCESS.GUILD_ID
+                                .eq(guildId)))
+                    .map(entry -> entry.get(
+                            ModAuditLogGuildProcess.MOD_AUDIT_LOG_GUILD_PROCESS.LAST_PROCESSED_AUDIT_LOG_ENTRY))
+                    .orElse(Instant.now()));
         // NOTE This is a minor race condition. By taking the time before the actual lookup we
         // ensure that we do not miss anything but instead it is possible to receive an
         // action twice in such a rare case, which is okay.

--- a/application/src/test/java/org/togetherjava/tjbot/commands/basic/DatabaseCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/basic/DatabaseCommandTest.java
@@ -43,9 +43,7 @@ final class DatabaseCommandTest {
     void setupDatabase() throws SQLException {
         // TODO This has to be done dynamically by the Flyway script, adjust gradle test settings
         database = new Database("jdbc:sqlite:");
-        database.write(context -> {
-            context.ddl(Storage.STORAGE).executeBatch();
-        });
+        database.write(context -> context.ddl(Storage.STORAGE).executeBatch());
     }
 
     @Test
@@ -131,11 +129,11 @@ final class DatabaseCommandTest {
     }
 
     private void assertValueInDatabase(@NotNull String key, @NotNull String value) {
-        Result<Record1<String>> results = database.read(context -> {
-            try (var select = context.select(Storage.STORAGE.VALUE)) {
-                return select.from(Storage.STORAGE).where(Storage.STORAGE.KEY.eq(key)).fetch();
-            }
-        });
+        Result<Record1<String>> results =
+                database.read(context -> context.select(Storage.STORAGE.VALUE)
+                    .from(Storage.STORAGE)
+                    .where(Storage.STORAGE.KEY.eq(key))
+                    .fetch());
         assertEquals(1, results.size());
         assertEquals(value, results.get(0).get(Storage.STORAGE.VALUE));
     }

--- a/logviewer/src/main/java/org/togetherjava/tjbot/logwatcher/logs/LogRepositoryImpl.java
+++ b/logviewer/src/main/java/org/togetherjava/tjbot/logwatcher/logs/LogRepositoryImpl.java
@@ -44,22 +44,16 @@ public class LogRepositoryImpl implements LogRepository {
     }
 
     @Override
-    @SuppressWarnings("java:S1602") // Curly Braces are necessary here
     public List<Logevents> findAll() {
-        return this.db.read(ctx -> {
-            return ctx.selectFrom(LOGEVENTS).fetch(this::recordToPojo);
-        });
+        return this.db.read(ctx -> ctx.selectFrom(LOGEVENTS).fetch(this::recordToPojo));
     }
 
 
     @Override
-    @SuppressWarnings("java:S1602") // Curly Braces are necessary here
     public List<Logevents> findWithLevelMatching(Collection<String> logLevels) {
-        return this.db.read(ctx -> {
-            return ctx.selectFrom(LOGEVENTS)
-                .where(LOGEVENTS.LEVEL.in(logLevels))
-                .fetch(this::recordToPojo);
-        });
+        return this.db.read(ctx -> ctx.selectFrom(LOGEVENTS)
+            .where(LOGEVENTS.LEVEL.in(logLevels))
+            .fetch(this::recordToPojo));
     }
 
     private Logevents recordToPojo(final LogeventsRecord logRecord) {

--- a/logviewer/src/main/java/org/togetherjava/tjbot/logwatcher/users/UserRepositoryImpl.java
+++ b/logviewer/src/main/java/org/togetherjava/tjbot/logwatcher/users/UserRepositoryImpl.java
@@ -15,7 +15,6 @@ import java.util.Set;
 import static org.togetherjava.tjbot.db.generated.tables.Users.USERS;
 
 @Component
-@SuppressWarnings("java:S1602") // Curly Braces are necessary here
 public class UserRepositoryImpl implements UserRepository {
 
     private final Database db;
@@ -26,60 +25,48 @@ public class UserRepositoryImpl implements UserRepository {
 
     @Override
     public Users findByDiscordID(long discordID) {
-        return this.db.readTransaction(ctx -> {
-            return ctx.selectFrom(USERS)
-                .where(USERS.DISCORDID.eq(discordID))
-                .fetchOne(this::recordToRole);
-        });
+        return this.db.readTransaction(ctx -> ctx.selectFrom(USERS)
+            .where(USERS.DISCORDID.eq(discordID))
+            .fetchOne(this::recordToRole));
     }
 
     @Override
     public Users findByUsername(String username) {
-        return this.db.readTransaction(ctx -> {
-            return ctx.selectFrom(USERS)
-                .where(USERS.USERNAME.eq(username))
-                .fetchOne(this::recordToRole);
-        });
+        return this.db.readTransaction(ctx -> ctx.selectFrom(USERS)
+            .where(USERS.USERNAME.eq(username))
+            .fetchOne(this::recordToRole));
     }
 
     @Override
     public List<Users> findAll() {
-        return this.db.readTransaction(ctx -> {
-            return ctx.selectFrom(USERS).fetch(this::recordToRole);
-        });
+        return this.db.readTransaction(ctx -> ctx.selectFrom(USERS).fetch(this::recordToRole));
     }
 
     @Override
     public int count() {
-        return this.db.readTransaction(ctx -> {
-            return ctx.fetchCount(USERS);
-        });
+        return this.db.readTransaction(ctx -> ctx.fetchCount(USERS));
     }
 
     @Override
     public void save(Users user) {
-        this.db.writeTransaction(ctx -> {
-            ctx.newRecord(USERS)
-                .setDiscordid(user.getDiscordid())
-                .setUsername(user.getUsername())
-                .merge();
-        });
+        this.db.writeTransaction(ctx -> ctx.newRecord(USERS)
+            .setDiscordid(user.getDiscordid())
+            .setUsername(user.getUsername())
+            .merge());
     }
 
     @Override
     public void delete(Users user) {
-        this.db.writeTransaction(ctx -> {
-            ctx.deleteFrom(USERS).where(USERS.DISCORDID.eq(user.getDiscordid())).execute();
-        });
+        this.db.writeTransaction(ctx -> ctx.deleteFrom(USERS)
+            .where(USERS.DISCORDID.eq(user.getDiscordid()))
+            .execute());
     }
 
     @Override
     public Set<Role> fetchRolesForUser(Users user) {
-        return new HashSet<>(this.db.readTransaction(ctx -> {
-            return ctx.selectFrom(Userroles.USERROLES)
-                .where(Userroles.USERROLES.USERID.eq(user.getDiscordid()))
-                .fetch(this::recordToRole);
-        }));
+        return new HashSet<>(this.db.readTransaction(ctx -> ctx.selectFrom(Userroles.USERROLES)
+            .where(Userroles.USERROLES.USERID.eq(user.getDiscordid()))
+            .fetch(this::recordToRole)));
     }
 
     @Override


### PR DESCRIPTION
### Overview

Fixes #201 .

**tl;dr,** the database interface lead to annoying situations, such as:

![](https://user-images.githubusercontent.com/13614011/137620888-c365d7c6-6f4c-414a-9e1c-15971c386c34.png)
![](https://user-images.githubusercontent.com/13614011/137620953-2c467aca-0c9d-4aa3-8e66-4c236cccfbd0.png)

Its now fixed by renaming the methods slightly:
* the `void read` method got renamed to `readAndConsume`
* the non-void `T write` method got renamed to `writeAndProvide`

(analogously for the transaction methods)

This also fixes all currently existing instances of `java:S1602`, which have been **suppressed** so far.

### Details

I did not rename either both void or both non-void methods on purpose. Mostly to reduce the otherwise heavy merge conflicts. The `void read` method is the one that is generally not used, same for the `T write` method. Hence I only renamed the "rarely used" methods. Context-wise it also makes sense that `read(...)` actually returns a result while `write(...)` usually does not return a result.

### Merge conflicts

I made the changes in a way that the merge conflicts are **as minimal as possible**. In general, you should be able to just accept any change without any interferences (unless you changed the logic itself that this refactoring touches - unlikely though).