### PR TITLE
Fixed bug with tag-raw not working with code snippets

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
@@ -74,7 +74,11 @@ public enum MessageUtils {
     public static @NotNull String escapeMarkdown(@NotNull String text) {
         // NOTE Unfortunately the utility does not escape backslashes '\', so we have to do it
         // ourselves
-        return MarkdownSanitizer.escape(text.replace("\\", "\\\\"));
+        // NOTE It also does not properly escape three backticks '```', it makes it '\```' but we
+        // need '\`\`\`'
+        String beforeEscape = text.replace("\\", "\\\\");
+        String afterEscape = MarkdownSanitizer.escape(beforeEscape);
+        return afterEscape.replace("\\```", "\\`\\`\\`");
     }
 
 }

--- a/application/src/test/java/org/togetherjava/tjbot/commands/utils/MessageUtilsTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/utils/MessageUtilsTest.java
@@ -12,28 +12,29 @@ final class MessageUtilsTest {
     void escapeMarkdown() {
         List<TestCase> tests = List.of(new TestCase("empty", "", ""),
                 new TestCase("no markdown", "hello world", "hello world"),
-                new TestCase("basic markdown", "\\*\\*hello\\*\\* \\_world\\_",
-                        "**hello** _world_"),
+                new TestCase(
+                        "basic markdown", "\\*\\*hello\\*\\* \\_world\\_", "**hello** _world_"),
                 new TestCase("code block", """
-                        \\```java
+                        \\`\\`\\`java
                         int x = 5;
-                        \\```
+                        \\`\\`\\`
                         """, """
                         ```java
                         int x = 5;
                         ```
-                        """), new TestCase("escape simple", "hello\\\\\\\\world\\\\\\\\test",
+                        """),
+                new TestCase("escape simple", "hello\\\\\\\\world\\\\\\\\test",
                         "hello\\\\world\\\\test"),
                 new TestCase("escape complex", """
                         Hello\\\\\\\\world
-                        \\```java
+                        \\`\\`\\`java
                         Hello\\\\\\\\
                         world
-                        \\```
+                        \\`\\`\\`
                         test out this
-                        \\```java
+                        \\`\\`\\`java
                         "Hello \\\\" World\\\\\\\\\\\\"" haha
-                        \\```
+                        \\`\\`\\`
                         """, """
                         Hello\\\\world
                         ```java
@@ -44,7 +45,118 @@ final class MessageUtilsTest {
                         ```java
                         "Hello \\" World\\\\\\"" haha
                         ```
-                        """));
+                        """),
+                new TestCase("escape real example",
+                        """
+                                Graph traversal can be accomplished easily using \\*\\*BFS\\*\\* or \\*\\*DFS\\*\\*. The algorithms only differ in the order in which nodes are visited: https://i.imgur.com/n9WrkQG.png
+
+                                The code to accomplish them is identical and only differs in the behavior of the \\`Queue\\` they are based on. \\*\\*BFS\\*\\* uses a \\*\\*FIFO\\*\\*-queue and \\*\\*DFS\\*\\* a \\*\\*LIFO\\*\\*-queue.
+                                \\`\\`\\`java
+                                Queue<Node> nodesToProcess = ... // depending on BFS or DFS
+                                nodesToProcess.add(rootNode); // add all starting nodes
+
+                                Set<Queue> visitedNodes = new HashSet<>();
+                                while (!nodesToProcess.isEmpty()) {
+                                  // Settle node
+                                  Node currentNode = visitedNodes.poll();
+                                  if (!visitedNodes.add(currentNode)) {
+                                    continue; // Already visited before
+                                  }
+
+                                  // Do something with the node
+                                  System.out.println(currentNode); // Replace by whatever you need
+
+                                  // Relax all outgoing edges
+                                  for (Node neighbor : currentNode.getNeighbors()) {
+                                    nodesToProcess.add(neighbor);
+                                  }
+                                }
+                                \\`\\`\\`
+                                To get \\*\\*BFS\\*\\*, use a \\*\\*FIFO\\*\\*-queue:
+                                \\`\\`\\`java
+                                Queue<Node> nodesToProcess = new ArrayDeque<>();
+                                \\`\\`\\`
+                                And for \\*\\*DFS\\*\\* a \\*\\*LIFO\\*\\*-queue:
+                                \\`\\`\\`java
+                                Queue<Node> nodesToProcess = Collections.asLifoQueue(new ArrayDeque<>());
+                                \\`\\`\\`
+                                That's all, very simple to setup and use.
+
+                                For directed graphs relax all \\*\\*outgoing edges\\*\\*.
+                                For \\*\\*tree\\*\\*s the \\`visitedNodes\\` logic can be dropped, since each node can only have maximally one parent, simplifying the algorithm to just:
+                                \\`\\`\\`java
+                                Queue<Node> nodesToProcess = ... // depending on BFS or DFS
+                                nodesToProcess.add(rootNode); // add all starting nodes
+
+                                while (!nodesToProcess.isEmpty()) {
+                                  // Settle node
+                                  Node currentNode = visitedNodes.poll();
+
+                                  // Do something with the node
+                                  System.out.println(currentNode); // Replace by whatever you need
+
+                                  // Relax all outgoing edges
+                                  for (Node child : currentNode.getChildren()) {
+                                    nodesToProcess.add(child);
+                                  }
+                                }
+                                \\`\\`\\`
+                                """,
+                        """
+                                Graph traversal can be accomplished easily using **BFS** or **DFS**. The algorithms only differ in the order in which nodes are visited: https://i.imgur.com/n9WrkQG.png
+
+                                The code to accomplish them is identical and only differs in the behavior of the `Queue` they are based on. **BFS** uses a **FIFO**-queue and **DFS** a **LIFO**-queue.
+                                ```java
+                                Queue<Node> nodesToProcess = ... // depending on BFS or DFS
+                                nodesToProcess.add(rootNode); // add all starting nodes
+
+                                Set<Queue> visitedNodes = new HashSet<>();
+                                while (!nodesToProcess.isEmpty()) {
+                                  // Settle node
+                                  Node currentNode = visitedNodes.poll();
+                                  if (!visitedNodes.add(currentNode)) {
+                                    continue; // Already visited before
+                                  }
+
+                                  // Do something with the node
+                                  System.out.println(currentNode); // Replace by whatever you need
+
+                                  // Relax all outgoing edges
+                                  for (Node neighbor : currentNode.getNeighbors()) {
+                                    nodesToProcess.add(neighbor);
+                                  }
+                                }
+                                ```
+                                To get **BFS**, use a **FIFO**-queue:
+                                ```java
+                                Queue<Node> nodesToProcess = new ArrayDeque<>();
+                                ```
+                                And for **DFS** a **LIFO**-queue:
+                                ```java
+                                Queue<Node> nodesToProcess = Collections.asLifoQueue(new ArrayDeque<>());
+                                ```
+                                That's all, very simple to setup and use.
+
+                                For directed graphs relax all **outgoing edges**.
+                                For **tree**s the `visitedNodes` logic can be dropped, since each node can only have maximally one parent, simplifying the algorithm to just:
+                                ```java
+                                Queue<Node> nodesToProcess = ... // depending on BFS or DFS
+                                nodesToProcess.add(rootNode); // add all starting nodes
+
+                                while (!nodesToProcess.isEmpty()) {
+                                  // Settle node
+                                  Node currentNode = visitedNodes.poll();
+
+                                  // Do something with the node
+                                  System.out.println(currentNode); // Replace by whatever you need
+
+                                  // Relax all outgoing edges
+                                  for (Node child : currentNode.getChildren()) {
+                                    nodesToProcess.add(child);
+                                  }
+                                }
+                                ```
+                                """));
 
         for (TestCase test : tests) {
             assertEquals(test.escapedMessage(), MessageUtils.escapeMarkdown(test.originalMessage()),


### PR DESCRIPTION
### Bug

Fixes #269 .

Basically, `/tag-manage raw` did not escape triple backticks correctly.

![issue](https://camo.githubusercontent.com/1babb2d20d8c059266fb9bf6a49106a705ee9cbb436ed7742208e2747fbd2048/68747470733a2f2f692e696d6775722e636f6d2f5530344637637a2e706e67)

Resulting in crap like this:

![tag](https://camo.githubusercontent.com/302ad0cb85f9bd88d99db3a03a7f2bbf97ddc3ae1a969f7a91912055e14d49a9/68747470733a2f2f692e696d6775722e636f6d2f6c5034686f72422e706e67)

### Fix

The fix applied here is relatively simple, we still use the existing escaping utility but apply a patch on top where we replace its result with the proper result.

I slightly rewrote the code section to make it clearer that we now have a replace before and one after the escape utility. Otherwise its too easy to confuse with two replacements happening before, i.e.
```java
escape(text.replace(...)).replace(...)
// vs
escape(text.replace(...).replace(...))
```
I also adjusted the existing test cases and added a new unit test to cover this particular complex case as well.