### PR TITLE
Preserving whitespace on tag-raw

### DIFF
--- a/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagManageCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagManageCommandTest.java
@@ -1,0 +1,31 @@
+package org.togetherjava.tjbot.commands.tags;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+final class TagManageCommandTest {
+
+    @Test
+    void preserveLeadingSpaces() {
+        String before = """
+                hello  world
+                 hello world\s
+                  hello world \s
+                   hello   world \s
+                    hello     world  \s
+                      hello world    \s
+                          hello world   \s""";
+        String after = """
+                hello  world
+                 hello world\s
+                \u2800hello world \s
+                \u2800 hello   world \s
+                \u2800\u2800hello     world  \s
+                \u2800\u2800\u2800hello world    \s
+                \u2800\u2800\u2800\u2800\u2800hello world   \s""";
+
+        assertEquals(after, TagManageCommand.preserveLeadingSpaces(before));
+        assertEquals(before, TagManageCommand.undoPreserveLeadingSpaces(after));
+    }
+}


### PR DESCRIPTION
Fixes and closes #273 .

Note that this is a rather dirty solution. Join in the discussion at the GH issue if you have better ideas.

---

See the GH issue for a detailed description of the problem.

---

The solution proposed by this is to replace all groups of 2 leading-whitespaces by braille-blanks. They look similar to whitespace but Discord does not recognize them and hence does not left-trim them.

To not mess up the actual messages when creating or editing, the fix is undone on tag-create and tag-edit.