### PR TITLE
Delete outdated comment

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagSystem.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagSystem.java
@@ -107,7 +107,6 @@ public final class TagSystem {
      * @param id the id of the tag to put
      * @param content the content of the tag to put
      */
-    // Execute closes resources; without curly braces on the lambda, the call would be ambiguous
     void putTag(String id, String content) {
         database.writeTransaction(
                 context -> context.insertInto(Tags.TAGS, Tags.TAGS.ID, Tags.TAGS.CONTENT)


### PR DESCRIPTION
After 2087bfd (Removed now obsolete curlies and java:S1602, 2021-11-17),
there is one leftover comment to delete.

Also checked if there is any other mention of: `@SuppressWarnings({"resource", "java:S1602"})`, `resource`, `java:S1602`, `ambiguous`, `curly`, `brace`. 