### PR TITLE
Removed trailing space from ' YouTube Together' to 'YouTube Together'

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
@@ -45,7 +45,7 @@ public final class VcActivityCommand extends SlashCommandAdapter {
     private static final String MAX_USES_OPTION = "max-uses";
     private static final String MAX_AGE_OPTION = "max-age";
 
-    private static final String YOUTUBE_TOGETHER_NAME = " YouTube Together";
+    public static final String YOUTUBE_TOGETHER_NAME = "YouTube Together";
     public static final String POKER_NAME = "Poker";
     public static final String BETRAYAL_IO_NAME = "Betrayal.io";
     public static final String FISHINGTON_IO_NAME = "Fishington.io";


### PR DESCRIPTION
> Solution for issue #283.

Removed trailing space from ' YouTube Together' to `YouTube Together`.
please review my pull request.