### PR TITLE
Display /tags in alphabetical order

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
@@ -9,8 +9,11 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.commands.utils.MessageUtils;
 import org.slf4j.Logger;
+
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -30,6 +33,7 @@ import java.util.stream.Collectors;
 public final class TagsCommand extends SlashCommandAdapter {
     private final TagSystem tagSystem;
     private static final Logger logger = LoggerFactory.getLogger(TagsCommand.class);
+    private static final int MAX_TAGS_THRESHOLD_WARNING = 200;
 
     /**
      * Creates a new instance, using the given tag system as base.
@@ -44,17 +48,16 @@ public final class TagsCommand extends SlashCommandAdapter {
 
     @Override
     public void onSlashCommand(@NotNull SlashCommandEvent event) {
-        int MAX_TAGS_THRESHOLD_WARNING = 200;
-        if (tagSystem.getAllIds().size() > MAX_TAGS_THRESHOLD_WARNING) {
+        Collection<String> tagIds = tagSystem.getAllIds();
+        if (tagIds.size() > MAX_TAGS_THRESHOLD_WARNING) {
             // TODO Implement the edge case
 
             logger.warn(
                     "The amount of tags is very high and it might soon exceed the maximum character limit. The code should be adjusted to support this edge case soon.");
         }
-        String tagListText = tagSystem.getAllIds()
-            .stream()
+        String tagListText = tagIds.stream()
             .sorted()
-            .map(tag -> "* " + tag)
+            .map(tag -> "\u2022 " + tag)
             .collect(Collectors.joining("\n"));
 
         event

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
@@ -13,7 +13,6 @@ import org.slf4j.Logger;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -31,9 +30,9 @@ import java.util.stream.Collectors;
  * </pre>
  */
 public final class TagsCommand extends SlashCommandAdapter {
-    private final TagSystem tagSystem;
     private static final Logger logger = LoggerFactory.getLogger(TagsCommand.class);
     private static final int MAX_TAGS_THRESHOLD_WARNING = 200;
+    private final TagSystem tagSystem;
 
     /**
      * Creates a new instance, using the given tag system as base.

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
@@ -30,8 +30,10 @@ import java.util.stream.Collectors;
  * </pre>
  */
 public final class TagsCommand extends SlashCommandAdapter {
+
     private static final Logger logger = LoggerFactory.getLogger(TagsCommand.class);
     private static final int MAX_TAGS_THRESHOLD_WARNING = 200;
+
     private final TagSystem tagSystem;
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
@@ -45,17 +45,18 @@ public final class TagsCommand extends SlashCommandAdapter {
 
     @Override
     public void onSlashCommand(@NotNull SlashCommandEvent event) {
-        // TODO A list might be better than comma separated, which is hard to read
 
         ArrayList<String> list = new ArrayList<>(tagSystem.getAllIds());
+
         if (list.size() > 200) {
+
             Logger logger = Logger.getLogger(TagsCommand.class.getName());
+
             logger.setLevel(Level.WARNING);
             logger.warning("- WARNING - TAGS ARE BEYOND 200 LINES ");
         }
 
-        event
-                .replyEmbeds(MessageUtils.generateEmbed("All available tags",
+        event.replyEmbeds(MessageUtils.generateEmbed("All available tags",
                         "* " + String.join("\n ",
                                 list.stream().sorted().collect(Collectors.joining("\n * "))),
                         event.getUser(), TagSystem.AMBIENT_COLOR))

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
@@ -56,10 +56,8 @@ public final class TagsCommand extends SlashCommandAdapter {
             logger.warn(
                     "The amount of tags is very high and it might soon exceed the maximum character limit. The code should be adjusted to support this edge case soon.");
         }
-        String tagListText = tagIds.stream()
-            .sorted()
-            .map(tag -> "\u2022 " + tag)
-            .collect(Collectors.joining("\n"));
+        String tagListText =
+                tagIds.stream().sorted().map(tag -> "• " + tag).collect(Collectors.joining("\n"));
 
         event
             .replyEmbeds(MessageUtils.generateEmbed("All available tags", tagListText,

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
@@ -49,7 +49,7 @@ public final class TagsCommand extends SlashCommandAdapter {
             // TODO Implement the edge case
 
             logger.warn(
-                    "The amount of tags is very high and it might soon exceed the maximum character limit. The code should be adjusted to support this edge case soon.\n");
+                    "The amount of tags is very high and it might soon exceed the maximum character limit. The code should be adjusted to support this edge case soon.");
         }
         String tagListText = tagSystem.getAllIds()
             .stream()

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
@@ -8,8 +8,12 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.commands.utils.MessageUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /**
  * Implements the {@code /tags} command which lets the bot respond with all available tags.
@@ -42,11 +46,22 @@ public final class TagsCommand extends SlashCommandAdapter {
     @Override
     public void onSlashCommand(@NotNull SlashCommandEvent event) {
         // TODO A list might be better than comma separated, which is hard to read
-        event.replyEmbeds(MessageUtils.generateEmbed("All available tags",
-                String.join(", ", tagSystem.getAllIds()), event.getUser(), TagSystem.AMBIENT_COLOR))
-            .addActionRow(
-                    TagSystem.createDeleteButton(generateComponentId(event.getUser().getId())))
-            .queue();
+
+        ArrayList<String> list = new ArrayList<>(tagSystem.getAllIds());
+        if (list.size() > 200) {
+            Logger logger = Logger.getLogger(TagsCommand.class.getName());
+            logger.setLevel(Level.WARNING);
+            logger.warning("- WARNING - TAGS ARE BEYOND 200 LINES ");
+        }
+
+        event
+                .replyEmbeds(MessageUtils.generateEmbed("All available tags",
+                        "* " + String.join("\n ",
+                                list.stream().sorted().collect(Collectors.joining("\n * "))),
+                        event.getUser(), TagSystem.AMBIENT_COLOR))
+                .addActionRow(
+                        TagSystem.createDeleteButton(generateComponentId(event.getUser().getId())))
+                .queue();
     }
 
     @Override


### PR DESCRIPTION
Fixes and closes #240 by displaying each tag in a separate line as bullet points and sorting them alphabetically.

Also, added a warn-log message if there are more than 200 tags in order to make us aware early enough of approaching the "line limit" (actually a character limit) of about 300 tags (~4k characters).

![example](https://user-images.githubusercontent.com/58050604/145042519-f16dc114-87f2-4792-8e54-d8df865c8e82.png)

---
## Checklist

* [x] Wait for #295 to be merged