### PR TITLE
Set file encoding explicitly to UTF-8

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -71,7 +71,3 @@ dependencies {
 application {
     mainClass = 'org.togetherjava.tjbot.BootstrapLauncher'
 }
-
-test {
-    useJUnitPlatform()
-}

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ subprojects {
 
 
     compileJava {
+        options.encoding = 'UTF-8'
+
         // Makes spotlessApply task run on every compile/build.
         dependsOn 'spotlessApply'
 
@@ -70,6 +72,7 @@ subprojects {
     }
 
     test {
+        systemProperty 'file.encoding', 'UTF-8'
         useJUnitPlatform()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -68,4 +68,8 @@ subprojects {
             eclipse('4.19.0').configFile("${rootProject.rootDir}/meta/formatting/google-style-eclipse.xml")
         }
     }
+
+    test {
+        useJUnitPlatform()
+    }
 }

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -10,6 +10,3 @@ dependencies {
     implementation 'org.jooq:jooq:3.15.3'
 }
 
-test {
-    useJUnitPlatform()
-}

--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -7,6 +7,3 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 }
 
-test {
-    useJUnitPlatform()
-}

--- a/logviewer/build.gradle
+++ b/logviewer/build.gradle
@@ -85,10 +85,6 @@ jib {
     }
 }
 
-tasks.test {
-    useJUnitPlatform()
-}
-
 vaadin {
     pnpmEnable = true
     productionMode = true


### PR DESCRIPTION
> Most Java tools use the system file encoding when no specific encoding is specified. This means that running the same build on machines with different file encoding can yield different outputs. Currently Gradle only tracks on a per-task basis that no file encoding has been specified, but it does not track the system encoding of the JVM in use. This can cause incorrect builds. You should always set the file system encoding to avoid these kind of problems.

We already encountered an issue with encoding, which resulted in this PR. For more info, #286. 

An alternative way of doing this is:
```groovy
org.gradle.jvmargs=-Dfile.encoding=UTF-8
```