### PR TITLE
Update Logviewer Dependencies

### DIFF
--- a/logviewer/build.gradle
+++ b/logviewer/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "com.google.cloud.tools.jib" version "3.1.4"
     id "org.springframework.boot" version "2.5.5"
     id "io.spring.dependency-management" version "1.0.11.RELEASE"
-    id "com.vaadin" version "21.0.2"
+    id "com.vaadin" version "22.0.0"
     id 'java'
     id 'database-settings'
 }
@@ -44,10 +44,10 @@ dependencies {
     implementation(project(":database"))
     implementation 'org.jooq:jooq:3.15.3'
 
-    implementation 'com.vaadin:vaadin-core:21.0.2'
-    implementation ('com.vaadin:vaadin-spring:18.0.0')
+    implementation 'com.vaadin:vaadin-core:22.0.0'
+    implementation ('com.vaadin:vaadin-spring:19.0.0')
     implementation 'org.vaadin.artur:a-vaadin-helper:1.7.2'
-    implementation 'org.vaadin.crudui:crudui:4.6.0'
+    implementation 'org.vaadin.crudui:crudui:5.0.0'
     implementation 'com.vaadin.componentfactory:enhanced-dialog:21.0.0'
 
 


### PR DESCRIPTION
Merged from several Dependabot PRs

* vaadin-core: 21.0.2 -> 22.0.0 (#294)
* com.vaadin: 21.0.2 -> 22.0.0 (#293)
* crudui: 4.6.0 -> 5.0.0 ( #291)
* vaadin-spring: 18.0.0 -> 19.0.0 (#289)

### Checklist

- [ ] Wait until `EnhancedDialog` is compatible with 22. See [this](https://github.com/vaadin-component-factory/vcf-enhanced-dialog/issues/4).