### PR TITLE
Bump log4j version to fix RCE vulnerability

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -47,9 +47,9 @@ dependencies {
 
     implementation 'net.dv8tion:JDA:4.3.0_339'
 
-    implementation 'org.apache.logging.log4j:log4j-api:2.14.1'
-    implementation 'org.apache.logging.log4j:log4j-core:2.14.1'
-    implementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.14.1'
+    implementation 'org.apache.logging.log4j:log4j-api:2.15.0'
+    implementation 'org.apache.logging.log4j:log4j-core:2.15.0'
+    implementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.15.0'
 
     implementation 'org.jooq:jooq:3.15.3'
 

--- a/logviewer/build.gradle
+++ b/logviewer/build.gradle
@@ -36,9 +36,9 @@ jooq {
 }
 
 dependencies {
-    compileOnly 'org.apache.logging.log4j:log4j-api:2.14.1'
-    runtimeOnly 'org.apache.logging.log4j:log4j-jul:2.14.1'
-    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.14.1'
+    compileOnly 'org.apache.logging.log4j:log4j-api:2.15.0'
+    runtimeOnly 'org.apache.logging.log4j:log4j-jul:2.15.0'
+    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.15.0'
 
 
     implementation(project(":database"))


### PR DESCRIPTION
This will fix the newest RCE vulnerability in log4j by upgrading its version from 2.14.1 to 2.15.0.

The exploit: https://www.lunasec.io/docs/blog/log4j-zero-day/
Log4j security announcement: https://logging.apache.org/log4j/2.x/security.html