### PR TITLE
Spring + Log4j2 Update on Logviewer

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -47,9 +47,9 @@ dependencies {
 
     implementation 'net.dv8tion:JDA:4.4.0_351'
 
-    implementation 'org.apache.logging.log4j:log4j-api:2.15.0'
-    implementation 'org.apache.logging.log4j:log4j-core:2.15.0'
-    implementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.15.0'
+    compileOnly 'org.apache.logging.log4j:log4j-api:2.16.0'
+    runtimeOnly 'org.apache.logging.log4j:log4j-core:2.16.0'
+    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j18-impl:2.16.0'
 
     implementation 'org.jooq:jooq:3.15.3'
 

--- a/logviewer/build.gradle
+++ b/logviewer/build.gradle
@@ -40,13 +40,13 @@ dependencies {
         version {
             require '2.16.0'
         }
-        because 'Log4Shell happend'
+        because 'Log4Shell happened'
     }
     runtimeOnly('org.apache.logging.log4j:log4j-core') {
         version {
             require '2.16.0'
         }
-        because 'Log4Shell happend'
+        because 'Log4Shell happened'
     }
 
     runtimeOnly 'org.apache.logging.log4j:log4j-jul:2.16.0'

--- a/logviewer/build.gradle
+++ b/logviewer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "com.google.cloud.tools.jib" version "3.1.4"
-    id "org.springframework.boot" version "2.5.5"
+    id "org.springframework.boot" version "2.6.1"
     id "io.spring.dependency-management" version "1.0.11.RELEASE"
     id "com.vaadin" version "21.0.2"
     id 'java'
@@ -36,35 +36,47 @@ jooq {
 }
 
 dependencies {
-    compileOnly 'org.apache.logging.log4j:log4j-api:2.15.0'
-    runtimeOnly 'org.apache.logging.log4j:log4j-jul:2.15.0'
-    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.15.0'
+    implementation('org.apache.logging.log4j:log4j-api') {
+        version {
+            require '2.16.0'
+        }
+        because 'Log4Shell happend'
+    }
+    runtimeOnly('org.apache.logging.log4j:log4j-core') {
+        version {
+            require '2.16.0'
+        }
+        because 'Log4Shell happend'
+    }
+
+    runtimeOnly 'org.apache.logging.log4j:log4j-jul:2.16.0'
+    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.16.0'
 
 
     implementation(project(":database"))
     implementation 'org.jooq:jooq:3.15.3'
 
     implementation 'com.vaadin:vaadin-core:21.0.2'
-    implementation ('com.vaadin:vaadin-spring:18.0.0')
+    implementation('com.vaadin:vaadin-spring:18.0.0')
     implementation 'org.vaadin.artur:a-vaadin-helper:1.7.2'
     implementation 'org.vaadin.crudui:crudui:4.6.0'
     implementation 'com.vaadin.componentfactory:enhanced-dialog:21.0.0'
 
 
-    implementation ('org.springframework.boot:spring-boot-starter-web:2.5.5'){
+    implementation('org.springframework.boot:spring-boot-starter-web:2.6.1') {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
     }
-    implementation ('org.springframework.boot:spring-boot-starter-security:2.5.5'){
+    implementation('org.springframework.boot:spring-boot-starter-security:2.6.1') {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
     }
-    implementation ('org.springframework.boot:spring-boot-starter-oauth2-client:2.5.5'){
+    implementation('org.springframework.boot:spring-boot-starter-oauth2-client:2.6.1') {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
     }
 
-    developmentOnly ('org.springframework.boot:spring-boot-starter-actuator:2.5.5'){
+    developmentOnly('org.springframework.boot:spring-boot-starter-actuator:2.6.1') {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
     }
-    developmentOnly ('org.springframework.boot:spring-boot-devtools:2.5.5'){
+    developmentOnly('org.springframework.boot:spring-boot-devtools:2.6.1') {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
     }
 }
@@ -79,7 +91,7 @@ jib {
             password = System.getenv('REGISTRY_PASSWORD') ?: ''
         }
     }
-    container{
+    container {
         setPorts(["5050"].asList())
         setCreationTime(Instant.now().toString())
     }


### PR DESCRIPTION
This time really set log4j on 2.16+ (2.16 since 2.15 seems still to be vulnerable https://logging.apache.org/log4j/2.x/changes-report.html#a2.16.0)
Updated Spring to 2.6.1
