### PR TITLE
Add routine support

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
@@ -51,10 +51,8 @@ public enum Features {
         Collection<Feature> features = new ArrayList<>();
 
         // Routines
-        // TODO This should be moved into some proper command system instead (see GH issue #235
-        // which adds support for routines)
-        new ModAuditLogRoutine(jda, database).start();
-        new TemporaryModerationRoutine(jda, actionsStore).start();
+        features.add(new ModAuditLogRoutine(database));
+        features.add(new TemporaryModerationRoutine(jda, actionsStore));
 
         // Message receivers
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Routine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Routine.java
@@ -1,0 +1,69 @@
+package org.togetherjava.tjbot.commands;
+
+import net.dv8tion.jda.api.JDA;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Routines are executed on a reoccurring schedule by the core system.
+ * <p>
+ * All routines have to implement this interface. A new routine can then be registered by adding it
+ * to {@link Features}.
+ * <p>
+ * <p>
+ * After registration, the system will automatically start and execute {@link #run(JDA)} on the
+ * schedule defined by {@link #createSchedule()}.
+ */
+public interface Routine extends Feature {
+    /**
+     * Triggered by the core system on the schedule defined by
+     *
+     * @param jda the JDA instance the bot is operating with
+     */
+    void run(@NotNull JDA jda);
+
+    /**
+     * Retrieves the schedule of this routine. Called by the core system once during the startup in
+     * order to execute the routine accordingly.
+     * <p>
+     * Changes on the schedule returned by this method afterwards will not be picked up.
+     *
+     * @return the schedule of this routine
+     */
+    @NotNull
+    Schedule createSchedule();
+
+    /**
+     * The schedule of routines.
+     *
+     * @param mode whether subsequent executions are executed at a fixed rate or are delayed,
+     *        influences how {@link #duration} is interpreted
+     * @param initialDuration the time which the first execution of the routine is delayed
+     * @param duration the time all subsequent executions of the routine are delayed. Either
+     *        measured before execution ({@link ScheduleMode#FIXED_RATE}) or after execution has
+     *        finished ({@link ScheduleMode#FIXED_DELAY}).
+     * @param unit the time unit for both, {@link #initialDuration} and {@link #duration}, e.g.
+     *        seconds
+     */
+    record Schedule(@NotNull ScheduleMode mode, long initialDuration, long duration,
+            @NotNull TimeUnit unit) {
+    }
+
+
+    /**
+     * Whether subsequent executions of a routine are executed at a fixed rate or are delayed.
+     */
+    enum ScheduleMode {
+        /**
+         * Executions are scheduled for a fixed rate, the time duration between executions is
+         * measured between their starting time.
+         */
+        FIXED_RATE,
+        /**
+         * Executions are scheduled for a fixed delay, the time duration between executions is
+         * measured between after they have finished.
+         */
+        FIXED_DELAY
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Routine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Routine.java
@@ -12,16 +12,16 @@ import java.util.concurrent.TimeUnit;
  * to {@link Features}.
  * <p>
  * <p>
- * After registration, the system will automatically start and execute {@link #run(JDA)} on the
- * schedule defined by {@link #createSchedule()}.
+ * After registration, the system will automatically start and execute {@link #runRoutine(JDA)} on
+ * the schedule defined by {@link #createSchedule()}.
  */
 public interface Routine extends Feature {
     /**
-     * Triggered by the core system on the schedule defined by
+     * Triggered by the core system on the schedule defined by {@link #createSchedule()}.
      *
      * @param jda the JDA instance the bot is operating with
      */
-    void run(@NotNull JDA jda);
+    void runRoutine(@NotNull JDA jda);
 
     /**
      * Retrieves the schedule of this routine. Called by the core system once during the startup in

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryModerationRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryModerationRoutine.java
@@ -53,7 +53,7 @@ public final class TemporaryModerationRoutine implements Routine {
     }
 
     @Override
-    public void run(@NotNull JDA jda) {
+    public void runRoutine(@NotNull JDA jda) {
         checkExpiredActions();
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
@@ -91,11 +91,12 @@ public final class BotCore extends ListenerAdapter implements SlashCommandProvid
             .forEach(routine -> {
                 Routine.Schedule schedule = routine.createSchedule();
                 switch (schedule.mode()) {
-                    case FIXED_RATE -> ROUTINE_SERVICE.scheduleAtFixedRate(() -> routine.run(jda),
-                            schedule.initialDuration(), schedule.duration(), schedule.unit());
+                    case FIXED_RATE -> ROUTINE_SERVICE.scheduleAtFixedRate(
+                            () -> routine.runRoutine(jda), schedule.initialDuration(),
+                            schedule.duration(), schedule.unit());
                     case FIXED_DELAY -> ROUTINE_SERVICE.scheduleWithFixedDelay(
-                            () -> routine.run(jda), schedule.initialDuration(), schedule.duration(),
-                            schedule.unit());
+                            () -> routine.runRoutine(jda), schedule.initialDuration(),
+                            schedule.duration(), schedule.unit());
                     default -> throw new AssertionError("Unsupported schedule mode");
                 }
             });

--- a/application/src/main/java/org/togetherjava/tjbot/routines/ModAuditLogRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/routines/ModAuditLogRoutine.java
@@ -204,7 +204,7 @@ public final class ModAuditLogRoutine implements Routine {
     }
 
     @Override
-    public void run(@NotNull JDA jda) {
+    public void runRoutine(@NotNull JDA jda) {
         checkAuditLogsRoutine(jda);
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/routines/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/routines/package-info.java
@@ -2,8 +2,7 @@
  * This package contains most routines of the bot. Routines can also be created in different
  * modules, if desired.
  * <p>
- * Routines are actions that are executed periodically on a schedule. They are added and started
- * manually in {@link org.togetherjava.tjbot.Application}.
+ * Routines are actions that are executed periodically on a schedule. They are added to the system
+ * in {@link org.togetherjava.tjbot.commands.Features}.
  */
-// TODO GH issue #235 will introduce a proper routine system
 package org.togetherjava.tjbot.routines;


### PR DESCRIPTION
### Overview

Implements and closes #235. Adds an interface `Routine implements Feature`, which allows classes to be executed on a pre-defined fixed schedule by the bots core system (i.e. every 5 minutes).

Also migrated the two existing routines:
* `TemporaryModerationRoutine` (for temp bans, mutes, ...)
* `ModAuditLogRoutine`

### Example

A quick example routine would be
```java
class Foo implements Routine {
  @Override
  public void run(JDA jda) {
    System.out.println("hello");
  }

  @Override
  public Schedule createSchedule() {
    return new Routine.Schedule(Routine.ScheduleMode.FIXED_RATE, 0, 5, TimeUnit.SECONDS);
  }
}
```
with an addition in `Features.java`:
```java
features.add(new Foo());
```
The system will now basically hand over the routine to a `ScheduledExecutorService` and execute its `run(JDA)` method on the schedule defined by its `createSchedule()`.

### Remarks

This is based on (and hence also blocked by) #345 .