### PR TITLE
Add config template

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -1,0 +1,19 @@
+{
+    "token": "<put_your_token_here>",
+    "databasePath": "local-database.db",
+    "projectWebsite": "https://github.com/Together-Java/TJ-Bot",
+    "discordGuildInvite": "https://discord.com/invite/XXFUXzK",
+    "modAuditLogChannelPattern": "mod_audit_log",
+    "mutedRolePattern": "Muted",
+    "heavyModerationRolePattern": "Moderator",
+    "softModerationRolePattern": "Moderator|Staff Assistant",
+    "tagManageRolePattern": "Moderator|Staff Assistant|Top Helpers .+",
+    "freeCommand": [
+        {
+            "statusChannel": <put_a_channel_id_here>,
+            "monitoredChannels": [
+                    <put_a_channel_id_here>
+                  ]
+        }
+   ]
+}


### PR DESCRIPTION
### Overview

Closes #234. This adds a `config.json.template` file, containing reasonable default values and some placeholders for the configuration file of the bot.

This is a solution to the problem of maintaining the `config.json` that we all have to use in a transparent way without git-tracking the real `config.json` and accidentally commiting our real bot tokens when doing changes.

That approach seems to be the most idiomatic way currently used (see for example [https://stackoverflow.com/questions/9794931/keep-file-in-a-git-repo-but-dont-track-changes](https://stackoverflow.com/questions/9794931/keep-file-in-a-git-repo-but-dont-track-changes)).

This also gets rid of the problems we had with forgetting to maintain the default config in our Wiki (we can now simply refer to this template instead) and it eases the flow for people when rebasing `develop` when it introduces changes to the config.