### PR TITLE
Add hints how to free a channel to busy message

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/free/UserStrings.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/free/UserStrings.java
@@ -12,6 +12,8 @@ enum UserStrings {
             Thank you for asking in an available channel. A helper will be with you shortly!
 
             __Do not post your question in other channels.__
+                 
+            After you are satisfied with the given answer don't forget to free the channel for others with the '/free' command!
             """),
     MARK_AS_FREE("""
             This channel is now available for a question to be asked.

--- a/application/src/main/java/org/togetherjava/tjbot/commands/free/UserStrings.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/free/UserStrings.java
@@ -12,7 +12,7 @@ enum UserStrings {
             Thank you for asking in an available channel. A helper will be with you shortly!
 
             __Do not post your question in other channels.__
-                 
+
             Once your issue is resolved, feel free to /free the channel, thanks.
             """),
     MARK_AS_FREE("""

--- a/application/src/main/java/org/togetherjava/tjbot/commands/free/UserStrings.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/free/UserStrings.java
@@ -13,7 +13,7 @@ enum UserStrings {
 
             __Do not post your question in other channels.__
                  
-            After you are satisfied with the given answer don't forget to free the channel for others with the '/free' command!
+            Once your issue is resolved, feel free to /free the channel, thanks.
             """),
     MARK_AS_FREE("""
             This channel is now available for a question to be asked.


### PR DESCRIPTION
### Overview

Slight adjustment of the busy-message to tell people how to free a channel again.

Originally from #344 but had to be closed since OP wasnt able to run Spotless, so I had to do it (but cant do that on their fork).