### PR TITLE
Add unit tests for tag-system

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
@@ -17,6 +17,7 @@ import org.togetherjava.tjbot.commands.tags.TagsCommand;
 import org.togetherjava.tjbot.commands.tophelper.TopHelpersCommand;
 import org.togetherjava.tjbot.commands.tophelper.TopHelpersMessageListener;
 import org.togetherjava.tjbot.commands.tophelper.TopHelpersPurgeMessagesRoutine;
+import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.routines.ModAuditLogRoutine;
 
@@ -29,7 +30,7 @@ import java.util.Collection;
  * it with the system.
  * <p>
  * To add a new slash command, extend the commands returned by
- * {@link #createFeatures(JDA, Database)}.
+ * {@link #createFeatures(JDA, Database, Config)}.
  */
 public enum Features {
     ;
@@ -42,10 +43,11 @@ public enum Features {
      *
      * @param jda the JDA instance commands will be registered at
      * @param database the database of the application, which features can use to persist data
+     * @param config the configuration features should use
      * @return a collection of all features
      */
     public static @NotNull Collection<Feature> createFeatures(@NotNull JDA jda,
-            @NotNull Database database) {
+            @NotNull Database database, @NotNull Config config) {
         TagSystem tagSystem = new TagSystem(database);
         ModerationActionsStore actionsStore = new ModerationActionsStore(database);
 
@@ -55,35 +57,35 @@ public enum Features {
         Collection<Feature> features = new ArrayList<>();
 
         // Routines
-        features.add(new ModAuditLogRoutine(database));
-        features.add(new TemporaryModerationRoutine(jda, actionsStore));
+        features.add(new ModAuditLogRoutine(database, config));
+        features.add(new TemporaryModerationRoutine(jda, actionsStore, config));
         features.add(new TopHelpersPurgeMessagesRoutine(database));
 
         // Message receivers
-        features.add(new TopHelpersMessageListener(database));
+        features.add(new TopHelpersMessageListener(database, config));
 
         // Event receivers
-        features.add(new RejoinMuteListener(actionsStore));
+        features.add(new RejoinMuteListener(actionsStore, config));
 
         // Slash commands
         features.add(new PingCommand());
         features.add(new TeXCommand());
         features.add(new TagCommand(tagSystem));
-        features.add(new TagManageCommand(tagSystem));
+        features.add(new TagManageCommand(tagSystem, config));
         features.add(new TagsCommand(tagSystem));
         features.add(new VcActivityCommand());
-        features.add(new WarnCommand(actionsStore));
-        features.add(new KickCommand(actionsStore));
-        features.add(new BanCommand(actionsStore));
-        features.add(new UnbanCommand(actionsStore));
-        features.add(new AuditCommand(actionsStore));
-        features.add(new MuteCommand(actionsStore));
-        features.add(new UnmuteCommand(actionsStore));
+        features.add(new WarnCommand(actionsStore, config));
+        features.add(new KickCommand(actionsStore, config));
+        features.add(new BanCommand(actionsStore, config));
+        features.add(new UnbanCommand(actionsStore, config));
+        features.add(new AuditCommand(actionsStore, config));
+        features.add(new MuteCommand(actionsStore, config));
+        features.add(new UnmuteCommand(actionsStore, config));
+        features.add(new TopHelpersCommand(database, config));
         features.add(new RoleSelectCommand());
-        features.add(new TopHelpersCommand(database));
 
         // Mixtures
-        features.add(new FreeCommand());
+        features.add(new FreeCommand(config));
 
         return features;
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/free/FreeCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/free/FreeCommand.java
@@ -61,6 +61,8 @@ public final class FreeCommand extends SlashCommandAdapter implements EventRecei
     private static final String COMMAND_NAME = "free";
     private static final Color MESSAGE_HIGHLIGHT_COLOR = Color.decode("#CCCC00");
 
+    private final Config config;
+
     // Map to store channel ID's, use Guild.getChannels() to guarantee order for display
     private final ChannelMonitor channelMonitor;
     private final Map<Long, Long> channelIdToMessageIdForStatus;
@@ -73,11 +75,14 @@ public final class FreeCommand extends SlashCommandAdapter implements EventRecei
      * <p>
      * This fetches configuration information from a json configuration file (see
      * {@link FreeCommandConfig}) for further details.
+     * 
+     * @param config the config to use for this
      */
-    public FreeCommand() {
+    public FreeCommand(@NotNull Config config) {
         super(COMMAND_NAME, "Marks this channel as free for another user to ask a question",
                 SlashCommandVisibility.GUILD);
 
+        this.config = config;
         channelIdToMessageIdForStatus = new HashMap<>();
         channelMonitor = new ChannelMonitor();
 
@@ -339,8 +344,7 @@ public final class FreeCommand extends SlashCommandAdapter implements EventRecei
     }
 
     private void initChannelsToMonitor() {
-        Config.getInstance()
-            .getFreeCommandConfig()
+        config.getFreeCommandConfig()
             .stream()
             .map(FreeCommandConfig::getMonitoredChannels)
             .flatMap(Collection::stream)
@@ -348,8 +352,7 @@ public final class FreeCommand extends SlashCommandAdapter implements EventRecei
     }
 
     private void initStatusMessageChannels(@NotNull final JDA jda) {
-        Config.getInstance()
-            .getFreeCommandConfig()
+        config.getFreeCommandConfig()
             .stream()
             .map(FreeCommandConfig::getStatusChannel)
             // throws IllegalStateException if the id's don't match TextChannels

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/AuditCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/AuditCommand.java
@@ -39,16 +39,17 @@ public final class AuditCommand extends SlashCommandAdapter {
      * Constructs an instance.
      *
      * @param actionsStore used to store actions issued by this command
+     * @param config the config to use for this
      */
-    public AuditCommand(@NotNull ModerationActionsStore actionsStore) {
+    public AuditCommand(@NotNull ModerationActionsStore actionsStore, @NotNull Config config) {
         super(COMMAND_NAME, "Lists all moderation actions that have been taken against a user",
                 SlashCommandVisibility.GUILD);
 
         getData().addOption(OptionType.USER, TARGET_OPTION, "The user who to retrieve actions for",
                 true);
 
-        hasRequiredRole = Pattern.compile(Config.getInstance().getHeavyModerationRolePattern())
-            .asMatchPredicate();
+        hasRequiredRole =
+                Pattern.compile(config.getHeavyModerationRolePattern()).asMatchPredicate();
         this.actionsStore = Objects.requireNonNull(actionsStore);
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/BanCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/BanCommand.java
@@ -55,8 +55,9 @@ public final class BanCommand extends SlashCommandAdapter {
      * Constructs an instance.
      *
      * @param actionsStore used to store actions issued by this command
+     * @param config the config to use for this
      */
-    public BanCommand(@NotNull ModerationActionsStore actionsStore) {
+    public BanCommand(@NotNull ModerationActionsStore actionsStore, @NotNull Config config) {
         super(COMMAND_NAME, "Bans the given user from the server", SlashCommandVisibility.GUILD);
 
         OptionData durationData = new OptionData(OptionType.STRING, DURATION_OPTION,
@@ -70,8 +71,8 @@ public final class BanCommand extends SlashCommandAdapter {
                     "the amount of days of the message history to delete, none means no messages are deleted.",
                     true).addChoice("none", 0).addChoice("recent", 1).addChoice("all", 7));
 
-        hasRequiredRole = Pattern.compile(Config.getInstance().getHeavyModerationRolePattern())
-            .asMatchPredicate();
+        hasRequiredRole =
+                Pattern.compile(config.getHeavyModerationRolePattern()).asMatchPredicate();
         this.actionsStore = Objects.requireNonNull(actionsStore);
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/KickCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/KickCommand.java
@@ -42,15 +42,15 @@ public final class KickCommand extends SlashCommandAdapter {
      * Constructs an instance.
      *
      * @param actionsStore used to store actions issued by this command
+     * @param config the config to use for this
      */
-    public KickCommand(@NotNull ModerationActionsStore actionsStore) {
+    public KickCommand(@NotNull ModerationActionsStore actionsStore, @NotNull Config config) {
         super(COMMAND_NAME, "Kicks the given user from the server", SlashCommandVisibility.GUILD);
 
         getData().addOption(OptionType.USER, TARGET_OPTION, "The user who you want to kick", true)
             .addOption(OptionType.STRING, REASON_OPTION, "Why the user should be kicked", true);
 
-        hasRequiredRole = Pattern.compile(Config.getInstance().getSoftModerationRolePattern())
-            .asMatchPredicate();
+        hasRequiredRole = Pattern.compile(config.getSoftModerationRolePattern()).asMatchPredicate();
         this.actionsStore = Objects.requireNonNull(actionsStore);
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
@@ -40,12 +40,6 @@ public enum ModerationUtils {
      * embeds.
      */
     static final Color AMBIENT_COLOR = Color.decode("#895FE8");
-    /**
-     * Matches the name of the role that is used to mute users, as used by {@link MuteCommand} and
-     * similar.
-     */
-    public static final Predicate<String> isMuteRole =
-            Pattern.compile(Config.getInstance().getMutedRolePattern()).asMatchPredicate();
 
     /**
      * Checks whether the given reason is valid. If not, it will handle the situation and respond to
@@ -332,13 +326,26 @@ public enum ModerationUtils {
     }
 
     /**
+     * Gets a predicate that identifies the role used to mute a member in a guild.
+     *
+     * @param config the config used to identify the muted role
+     * @return predicate that matches the name of the muted role
+     */
+    public static Predicate<String> getIsMutedRolePredicate(@NotNull Config config) {
+        return Pattern.compile(config.getMutedRolePattern()).asMatchPredicate();
+    }
+
+    /**
      * Gets the role used to mute a member in a guild.
      *
      * @param guild the guild to get the muted role from
+     * @param config the config used to identify the muted role
      * @return the muted role, if found
      */
-    public static @NotNull Optional<Role> getMutedRole(@NotNull Guild guild) {
-        return guild.getRoles().stream().filter(role -> isMuteRole.test(role.getName())).findAny();
+    public static @NotNull Optional<Role> getMutedRole(@NotNull Guild guild,
+            @NotNull Config config) {
+        Predicate<String> isMutedRole = getIsMutedRolePredicate(config);
+        return guild.getRoles().stream().filter(role -> isMutedRole.test(role.getName())).findAny();
     }
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/RejoinMuteListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/RejoinMuteListener.java
@@ -9,9 +9,9 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.EventReceiver;
+import org.togetherjava.tjbot.config.Config;
 
 import java.time.Instant;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -26,23 +26,27 @@ public final class RejoinMuteListener implements EventReceiver {
     private static final Logger logger = LoggerFactory.getLogger(RejoinMuteListener.class);
 
     private final ModerationActionsStore actionsStore;
+    private final Config config;
 
     /**
      * Constructs an instance.
      *
      * @param actionsStore used to store actions issued by this command and to retrieve whether a
      *        user should be muted
+     * @param config the config to use for this
      */
-    public RejoinMuteListener(@NotNull ModerationActionsStore actionsStore) {
-        this.actionsStore = Objects.requireNonNull(actionsStore);
+    public RejoinMuteListener(@NotNull ModerationActionsStore actionsStore,
+            @NotNull Config config) {
+        this.actionsStore = actionsStore;
+        this.config = config;
     }
 
-    private static void muteMember(@NotNull Member member) {
+    private void muteMember(@NotNull Member member) {
         Guild guild = member.getGuild();
         logger.info("Reapplied existing mute to user '{}' ({}) in guild '{}' after rejoining.",
                 member.getUser().getAsTag(), member.getId(), guild.getName());
 
-        guild.addRoleToMember(member, ModerationUtils.getMutedRole(guild).orElseThrow())
+        guild.addRoleToMember(member, ModerationUtils.getMutedRole(guild, config).orElseThrow())
             .reason("Reapplied existing mute after rejoining the server")
             .queue();
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnbanCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnbanCommand.java
@@ -35,8 +35,9 @@ public final class UnbanCommand extends SlashCommandAdapter {
      * Constructs an instance.
      *
      * @param actionsStore used to store actions issued by this command
+     * @param config the config to use for this
      */
-    public UnbanCommand(@NotNull ModerationActionsStore actionsStore) {
+    public UnbanCommand(@NotNull ModerationActionsStore actionsStore, @NotNull Config config) {
         super(COMMAND_NAME, "Unbans the given user from the server", SlashCommandVisibility.GUILD);
 
         getData()
@@ -44,8 +45,8 @@ public final class UnbanCommand extends SlashCommandAdapter {
                     true)
             .addOption(OptionType.STRING, REASON_OPTION, "Why the user should be unbanned", true);
 
-        hasRequiredRole = Pattern.compile(Config.getInstance().getHeavyModerationRolePattern())
-            .asMatchPredicate();
+        hasRequiredRole =
+                Pattern.compile(config.getHeavyModerationRolePattern()).asMatchPredicate();
         this.actionsStore = Objects.requireNonNull(actionsStore);
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/WarnCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/WarnCommand.java
@@ -39,15 +39,16 @@ public final class WarnCommand extends SlashCommandAdapter {
      * Creates a new instance.
      *
      * @param actionsStore used to store actions issued by this command
+     * @param config the config to use for this
      */
-    public WarnCommand(@NotNull ModerationActionsStore actionsStore) {
+    public WarnCommand(@NotNull ModerationActionsStore actionsStore, @NotNull Config config) {
         super("warn", "Warns the given user", SlashCommandVisibility.GUILD);
 
         getData().addOption(OptionType.USER, USER_OPTION, "The user who you want to warn", true)
             .addOption(OptionType.STRING, REASON_OPTION, "Why you want to warn the user", true);
 
-        hasRequiredRole = Pattern.compile(Config.getInstance().getHeavyModerationRolePattern())
-            .asMatchPredicate();
+        hasRequiredRole =
+                Pattern.compile(config.getHeavyModerationRolePattern()).asMatchPredicate();
         this.actionsStore = Objects.requireNonNull(actionsStore);
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryModerationRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryModerationRoutine.java
@@ -11,6 +11,7 @@ import org.togetherjava.tjbot.commands.Routine;
 import org.togetherjava.tjbot.commands.moderation.ActionRecord;
 import org.togetherjava.tjbot.commands.moderation.ModerationAction;
 import org.togetherjava.tjbot.commands.moderation.ModerationActionsStore;
+import org.togetherjava.tjbot.config.Config;
 
 import java.time.Instant;
 import java.util.Map;
@@ -41,13 +42,14 @@ public final class TemporaryModerationRoutine implements Routine {
      *
      * @param jda the JDA instance to use to send messages and retrieve information
      * @param actionsStore the store used to retrieve temporary moderation actions
+     * @param config the config to use for this
      */
     public TemporaryModerationRoutine(@NotNull JDA jda,
-            @NotNull ModerationActionsStore actionsStore) {
+            @NotNull ModerationActionsStore actionsStore, @NotNull Config config) {
         this.actionsStore = actionsStore;
         this.jda = jda;
 
-        typeToRevocableAction = Stream.of(new TemporaryBanAction(), new TemporaryMuteAction())
+        typeToRevocableAction = Stream.of(new TemporaryBanAction(), new TemporaryMuteAction(config))
             .collect(
                     Collectors.toMap(RevocableModerationAction::getApplyType, Function.identity()));
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryMuteAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryMuteAction.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.moderation.ModerationAction;
 import org.togetherjava.tjbot.commands.moderation.ModerationUtils;
+import org.togetherjava.tjbot.config.Config;
 
 /**
  * Action to revoke temporary mutes, as applied by
@@ -18,6 +19,16 @@ import org.togetherjava.tjbot.commands.moderation.ModerationUtils;
  */
 final class TemporaryMuteAction implements RevocableModerationAction {
     private static final Logger logger = LoggerFactory.getLogger(TemporaryMuteAction.class);
+    private final Config config;
+
+    /**
+     * Creates a new instance of a temporary mute action.
+     * 
+     * @param config the config to use to identify the muted role
+     */
+    TemporaryMuteAction(@NotNull Config config) {
+        this.config = config;
+    }
 
     @Override
     public @NotNull ModerationAction getApplyType() {
@@ -34,7 +45,7 @@ final class TemporaryMuteAction implements RevocableModerationAction {
             @NotNull String reason) {
         return guild
             .removeRoleFromMember(target.getIdLong(),
-                    ModerationUtils.getMutedRole(guild).orElseThrow())
+                    ModerationUtils.getMutedRole(guild, config).orElseThrow())
             .reason(reason);
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagCommand.java
@@ -22,8 +22,8 @@ import java.util.Objects;
 public final class TagCommand extends SlashCommandAdapter {
     private final TagSystem tagSystem;
 
-    private static final String ID_OPTION = "id";
-    private static final String REPLY_TO_USER_OPTION = "reply-to";
+    static final String ID_OPTION = "id";
+    static final String REPLY_TO_USER_OPTION = "reply-to";
 
     /**
      * Creates a new instance, using the given tag system as base.

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagManageCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagManageCommand.java
@@ -56,13 +56,13 @@ public final class TagManageCommand extends SlashCommandAdapter {
      * Creates a new instance, using the given tag system as base.
      *
      * @param tagSystem the system providing the actual tag data
+     * @param config the config to use for this
      */
-    public TagManageCommand(TagSystem tagSystem) {
+    public TagManageCommand(TagSystem tagSystem, @NotNull Config config) {
         super("tag-manage", "Provides commands to manage all tags", SlashCommandVisibility.GUILD);
 
         this.tagSystem = tagSystem;
-        hasRequiredRole =
-                Pattern.compile(Config.getInstance().getTagManageRolePattern()).asMatchPredicate();
+        hasRequiredRole = Pattern.compile(config.getTagManageRolePattern()).asMatchPredicate();
 
         // TODO Think about adding a "Are you sure"-dialog to 'edit', 'edit-with-message' and
         // 'delete'

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagManageCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagManageCommand.java
@@ -43,11 +43,11 @@ import java.util.regex.Pattern;
  */
 public final class TagManageCommand extends SlashCommandAdapter {
     private static final Logger logger = LoggerFactory.getLogger(TagManageCommand.class);
-    private static final String ID_OPTION = "id";
+    static final String ID_OPTION = "id";
     private static final String ID_DESCRIPTION = "the id of the tag";
-    private static final String CONTENT_OPTION = "content";
+    static final String CONTENT_OPTION = "content";
     private static final String CONTENT_DESCRIPTION = "the content of the tag";
-    private static final String MESSAGE_ID_OPTION = "message-id";
+    static final String MESSAGE_ID_OPTION = "message-id";
     private static final String MESSAGE_ID_DESCRIPTION = "the id of the message to refer to";
     private final TagSystem tagSystem;
     private final Predicate<String> hasRequiredRole;
@@ -295,7 +295,7 @@ public final class TagManageCommand extends SlashCommandAdapter {
     }
 
 
-    private enum Subcommand {
+    enum Subcommand {
         RAW("raw"),
         CREATE("create"),
         CREATE_WITH_MESSAGE("create-with-message"),
@@ -305,11 +305,16 @@ public final class TagManageCommand extends SlashCommandAdapter {
 
         private final String name;
 
-        Subcommand(String name) {
+        Subcommand(@NotNull String name) {
             this.name = name;
         }
 
-        static Subcommand fromName(String name) {
+        @NotNull
+        String getName() {
+            return name;
+        }
+
+        static Subcommand fromName(@NotNull String name) {
             for (Subcommand subcommand : Subcommand.values()) {
                 if (subcommand.name.equals(name)) {
                     return subcommand;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
@@ -5,11 +5,12 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.events.interaction.ButtonClickEvent;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
+
 import java.time.Instant;
-import org.slf4j.Logger;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersCommand.java
@@ -55,12 +55,12 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
      * Creates a new instance.
      *
      * @param database the database containing the message counts of top helpers
+     * @param config the config to use for this
      */
-    public TopHelpersCommand(@NotNull Database database) {
+    public TopHelpersCommand(@NotNull Database database, @NotNull Config config) {
         super(COMMAND_NAME, "Lists top helpers for the last month", SlashCommandVisibility.GUILD);
         // TODO Add options to optionally pick a time range once JDA/Discord offers a date-picker
-        hasRequiredRole = Pattern.compile(Config.getInstance().getSoftModerationRolePattern())
-            .asMatchPredicate();
+        hasRequiredRole = Pattern.compile(config.getSoftModerationRolePattern()).asMatchPredicate();
         this.database = database;
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersMessageListener.java
@@ -21,9 +21,10 @@ public final class TopHelpersMessageListener extends MessageReceiverAdapter {
      * Creates a new listener to receive all message sent in help channels.
      *
      * @param database to store message meta-data in
+     * @param config the config to use for this
      */
-    public TopHelpersMessageListener(@NotNull Database database) {
-        super(Pattern.compile(Config.getInstance().getHelpChannelPattern()));
+    public TopHelpersMessageListener(@NotNull Database database, @NotNull Config config) {
+        super(Pattern.compile(config.getHelpChannelPattern()));
         this.database = database;
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -14,7 +14,6 @@ import java.util.List;
 /**
  * Configuration of the application. Create instances using {@link #load(Path)}.
  */
-@SuppressWarnings("ClassCanBeRecord")
 public final class Config {
 
     private final String token;

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -10,18 +10,12 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
- * Configuration of the application, as singleton.
- * <p>
- * Create instances using {@link #load(Path)} and then access them with {@link #getInstance()}.
+ * Configuration of the application. Create instances using {@link #load(Path)}.
  */
-@SuppressWarnings({"Singleton", "ClassCanBeRecord"})
+@SuppressWarnings("ClassCanBeRecord")
 public final class Config {
-
-    @SuppressWarnings("RedundantFieldInitialization")
-    private static Config config = null;
 
     private final String token;
     private final String databasePath;
@@ -62,27 +56,14 @@ public final class Config {
     }
 
     /**
-     * Loads the configuration from the given file. Will override any previously loaded data.
-     * <p>
-     * Access the instance using {@link #getInstance()}.
+     * Loads the configuration from the given file.
      *
      * @param path the configuration file, as JSON object
+     * @return the loaded configuration
      * @throws IOException if the file could not be loaded
      */
-    public static void load(Path path) throws IOException {
-        config = new ObjectMapper().readValue(path.toFile(), Config.class);
-    }
-
-    /**
-     * Gets the singleton instance of the configuration.
-     * <p>
-     * Must be loaded beforehand using {@link #load(Path)}.
-     *
-     * @return the previously loaded configuration
-     */
-    public static Config getInstance() {
-        return Objects.requireNonNull(config,
-                "can not get the configuration before it has been loaded");
+    public static Config load(Path path) throws IOException {
+        return new ObjectMapper().readValue(path.toFile(), Config.class);
     }
 
     /**

--- a/application/src/test/java/org/togetherjava/tjbot/commands/basic/PingCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/basic/PingCommandTest.java
@@ -1,22 +1,39 @@
 package org.togetherjava.tjbot.commands.basic;
 
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.togetherjava.tjbot.commands.SlashCommand;
 import org.togetherjava.tjbot.jda.JdaTester;
 
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 final class PingCommandTest {
-    @Test
-    void pingCommand() {
-        SlashCommand command = new PingCommand();
-        JdaTester jdaTester = new JdaTester();
+    private JdaTester jdaTester;
+    private SlashCommand command;
 
+    private @NotNull SlashCommandEvent triggerSlashCommand() {
         SlashCommandEvent event = jdaTester.createSlashCommandEvent(command).build();
         command.onSlashCommand(event);
+        return event;
+    }
 
-        verify(event, times(1)).reply("Pong!");
+    @BeforeEach
+    void setUp() {
+        jdaTester = new JdaTester();
+        command = jdaTester.spySlashCommand(new PingCommand());
+    }
+
+    @Test
+    @DisplayName("'/ping' responds with pong")
+    void pingRespondsWithPong() {
+        // GIVEN
+        // WHEN using '/ping'
+        SlashCommandEvent event = triggerSlashCommand();
+
+        // THEN the bot replies with pong
+        verify(event).reply("Pong!");
     }
 }

--- a/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagCommandTest.java
@@ -1,0 +1,97 @@
+package org.togetherjava.tjbot.commands.tags;
+
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.togetherjava.tjbot.commands.SlashCommand;
+import org.togetherjava.tjbot.db.Database;
+import org.togetherjava.tjbot.db.generated.tables.Tags;
+import org.togetherjava.tjbot.jda.JdaTester;
+import org.togetherjava.tjbot.jda.SlashCommandEventBuilder;
+
+import static org.mockito.Mockito.*;
+
+final class TagCommandTest {
+    private TagSystem system;
+    private JdaTester jdaTester;
+    private SlashCommand command;
+
+    @BeforeEach
+    void setUp() {
+        Database database = Database.createMemoryDatabase(Tags.TAGS);
+        system = spy(new TagSystem(database));
+        jdaTester = new JdaTester();
+        command = new TagCommand(system);
+    }
+
+    private @NotNull SlashCommandEvent triggerSlashCommand(@NotNull String id,
+            @Nullable Member userToReplyTo) {
+        SlashCommandEventBuilder builder =
+                jdaTester.createSlashCommandEvent(command).setOption(TagCommand.ID_OPTION, id);
+        if (userToReplyTo != null) {
+            builder.setOption(TagCommand.REPLY_TO_USER_OPTION, userToReplyTo);
+        }
+
+        SlashCommandEvent event = builder.build();
+        command.onSlashCommand(event);
+        return event;
+    }
+
+    @Test
+    @DisplayName("Respond that the tag could not be found if the system has no tags registered yet")
+    void canNotFindTagInEmptySystem() {
+        // GIVEN a system without any tags registered
+        // WHEN triggering the slash command '/tag id:first'
+        SlashCommandEvent event = triggerSlashCommand("first", null);
+
+        // THEN responds that the tag could not be found
+        verify(event).reply("Could not find any tag with id 'first'.");
+    }
+
+    @Test
+    @DisplayName("Respond that the tag could not be found but suggest a different tag instead, if the system has a different tag registered")
+    void canNotFindTagSuggestDifferentTag() {
+        // GIVEN a system with the tag "first" registered
+        system.putTag("first", "foo");
+
+        // WHEN triggering the slash command '/tag id:second'
+        SlashCommandEvent event = triggerSlashCommand("second", null);
+
+        // THEN responds that the tag could not be found and instead suggests using the other tag
+        verify(event)
+            .reply("Could not find any tag with id 'second', did you perhaps mean 'first'?");
+    }
+
+    @Test
+    @DisplayName("Respond with the tags content if the tag could be found")
+    void canFindTheTagAndRespondWithContent() {
+        // GIVEN a system with the tag "first" registered
+        system.putTag("first", "foo");
+
+        // WHEN triggering the slash command '/tag id:first'
+        SlashCommandEvent event = triggerSlashCommand("first", null);
+
+        // THEN finds the tag and responds with its content
+        verify(event).replyEmbeds(any(MessageEmbed.class));
+    }
+
+    @Test
+    @DisplayName("Replies to given users and responds with the tags content if the tag could be found and a user is given")
+    void canFindTagsAndRepliesToUser() {
+        // GIVEN a system with the tag "first" registered and a user to reply to
+        system.putTag("first", "foo");
+        Member userToReplyTo = jdaTester.createMemberSpy(1);
+
+        // WHEN triggering the slash command '/tag id:first reply-to:...' with that user
+        SlashCommandEvent event = triggerSlashCommand("first", userToReplyTo);
+
+        // THEN responds with the tags content and replies to the user
+        verify(event).replyEmbeds(any(MessageEmbed.class));
+        verify(jdaTester.getReplyActionMock()).setContent(userToReplyTo.getAsMention());
+    }
+}

--- a/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagManageCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagManageCommandTest.java
@@ -1,0 +1,413 @@
+package org.togetherjava.tjbot.commands.tags;
+
+import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.requests.ErrorResponse;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.togetherjava.tjbot.commands.SlashCommand;
+import org.togetherjava.tjbot.config.Config;
+import org.togetherjava.tjbot.db.Database;
+import org.togetherjava.tjbot.db.generated.tables.Tags;
+import org.togetherjava.tjbot.jda.JdaTester;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.AdditionalMatchers.aryEq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+final class TagManageCommandTest {
+    private TagSystem system;
+    private JdaTester jdaTester;
+    private SlashCommand command;
+    private Member moderator;
+
+    private static @NotNull MessageEmbed getResponse(@NotNull SlashCommandEvent event) {
+        ArgumentCaptor<MessageEmbed> responseCaptor = ArgumentCaptor.forClass(MessageEmbed.class);
+        verify(event).replyEmbeds(responseCaptor.capture());
+        return responseCaptor.getValue();
+    }
+
+    @BeforeEach
+    void setUp() {
+        Config config = mock(Config.class);
+        String moderatorRoleName = "Moderator";
+        when(config.getTagManageRolePattern()).thenReturn(moderatorRoleName);
+
+        Database database = Database.createMemoryDatabase(Tags.TAGS);
+        system = spy(new TagSystem(database));
+        jdaTester = new JdaTester();
+        command = new TagManageCommand(system, config);
+
+        moderator = jdaTester.createMemberSpy(1);
+        Role moderatorRole = mock(Role.class);
+        doReturn(true).when(moderator).hasPermission(any(Permission.class));
+        doReturn(List.of(moderatorRole)).when(moderator).getRoles();
+        when(moderatorRole.getName()).thenReturn(moderatorRoleName);
+    }
+
+    private @NotNull SlashCommandEvent triggerRawCommand(@NotNull String tagId) {
+        return triggerRawCommandWithUser(tagId, moderator);
+    }
+
+    private @NotNull SlashCommandEvent triggerRawCommandWithUser(@NotNull String tagId,
+            @NotNull Member user) {
+        SlashCommandEvent event = jdaTester.createSlashCommandEvent(command)
+            .setSubcommand(TagManageCommand.Subcommand.RAW.getName())
+            .setOption(TagManageCommand.ID_OPTION, tagId)
+            .setUserWhoTriggered(user)
+            .build();
+
+        command.onSlashCommand(event);
+        return event;
+    }
+
+    private @NotNull SlashCommandEvent triggerCreateCommand(@NotNull String tagId,
+            @NotNull String content) {
+        return triggerTagContentCommand(TagManageCommand.Subcommand.CREATE, tagId, content);
+    }
+
+    private @NotNull SlashCommandEvent triggerEditCommand(@NotNull String tagId,
+            @NotNull String content) {
+        return triggerTagContentCommand(TagManageCommand.Subcommand.EDIT, tagId, content);
+    }
+
+    private @NotNull SlashCommandEvent triggerTagContentCommand(
+            @NotNull TagManageCommand.Subcommand subcommand, @NotNull String tagId,
+            @NotNull String content) {
+        SlashCommandEvent event = jdaTester.createSlashCommandEvent(command)
+            .setSubcommand(subcommand.getName())
+            .setOption(TagManageCommand.ID_OPTION, tagId)
+            .setOption(TagManageCommand.CONTENT_OPTION, content)
+            .setUserWhoTriggered(moderator)
+            .build();
+
+        command.onSlashCommand(event);
+        return event;
+    }
+
+    private @NotNull SlashCommandEvent triggerCreateWithMessageCommand(@NotNull String tagId,
+            @NotNull String messageId) {
+        return triggerTagMessageCommand(TagManageCommand.Subcommand.CREATE_WITH_MESSAGE, tagId,
+                messageId);
+    }
+
+    private @NotNull SlashCommandEvent triggerEditWithMessageCommand(@NotNull String tagId,
+            @NotNull String messageId) {
+        return triggerTagMessageCommand(TagManageCommand.Subcommand.EDIT_WITH_MESSAGE, tagId,
+                messageId);
+    }
+
+    private @NotNull SlashCommandEvent triggerTagMessageCommand(
+            @NotNull TagManageCommand.Subcommand subcommand, @NotNull String tagId,
+            @NotNull String messageId) {
+        SlashCommandEvent event = jdaTester.createSlashCommandEvent(command)
+            .setSubcommand(subcommand.getName())
+            .setOption(TagManageCommand.ID_OPTION, tagId)
+            .setOption(TagManageCommand.MESSAGE_ID_OPTION, messageId)
+            .setUserWhoTriggered(moderator)
+            .build();
+
+        command.onSlashCommand(event);
+        return event;
+    }
+
+    private @NotNull SlashCommandEvent triggerDeleteCommand(@NotNull String tagId) {
+        SlashCommandEvent event = jdaTester.createSlashCommandEvent(command)
+            .setSubcommand(TagManageCommand.Subcommand.DELETE.getName())
+            .setOption(TagManageCommand.ID_OPTION, tagId)
+            .setUserWhoTriggered(moderator)
+            .build();
+
+        command.onSlashCommand(event);
+        return event;
+    }
+
+    private void postMessage(@NotNull String content, @NotNull String id) {
+        Message message = new MessageBuilder(content).build();
+        doReturn(jdaTester.createSucceededActionMock(message)).when(jdaTester.getTextChannelSpy())
+            .retrieveMessageById(id);
+    }
+
+    private void failOnRetrieveMessage(@NotNull String messageId, @NotNull Throwable failure) {
+        doReturn(jdaTester.createFailedActionMock(failure)).when(jdaTester.getTextChannelSpy())
+            .retrieveMessageById(messageId);
+    }
+
+    @Test
+    @DisplayName("Users without the required role can not use '/tag-manage'")
+    void commandCanNotBeUsedWithoutRoles() {
+        // GIVEN a regular user without roles
+        Member regularUser = jdaTester.createMemberSpy(1);
+
+        // WHEN the regular user triggers any '/tag-manage' command
+        SlashCommandEvent event = triggerRawCommandWithUser("foo", regularUser);
+
+        // THEN the command can not be used since the user lacks roles
+        verify(event).reply("Tags can only be managed by users with a corresponding role.");
+    }
+
+    @Test
+    @DisplayName("'/tag-manage raw' can not be used on unknown tags")
+    void rawTagCanNotFindUnknownTag() {
+        // GIVEN a tag system without any tags
+        // WHEN using '/tag-manage raw id:unknown'
+        SlashCommandEvent event = triggerRawCommand("unknown");
+
+        // THEN the command can not find the tag and responds accordingly
+        verify(event).reply(startsWith("Could not find any tag"));
+    }
+
+    @Test
+    @DisplayName("'/tag-manage raw' shows the raw content of a known tag")
+    void rawTagShowsContentIfFound() {
+        // GIVEN a tag system with the "foo" tag
+        system.putTag("foo", "bar");
+
+        // WHEN using '/tag-manage raw id:foo'
+        triggerRawCommand("foo");
+
+        // THEN the command responds with its content as an attachment
+        verify(jdaTester.getReplyActionMock())
+            .addFile(aryEq("bar".getBytes(StandardCharsets.UTF_8)), anyString());
+    }
+
+    @Test
+    @DisplayName("'/tag-manage create' fails if the tag already exists")
+    void createTagThatAlreadyExistsFails() {
+        // GIVEN a tag system with the "foo" tag
+        system.putTag("foo", "old");
+
+        // WHEN using '/tag-manage create id:foo content:new'
+        SlashCommandEvent event = triggerCreateCommand("foo", "new");
+
+        // THEN the command fails and responds accordingly, the tag is still there and unchanged
+        verify(event).reply("The tag with id 'foo' already exists.");
+        assertTrue(system.hasTag("foo"));
+        assertEquals("old", system.getTag("foo").orElseThrow());
+    }
+
+    @Test
+    @DisplayName("'/tag-manage create' works if the tag is new")
+    void createNewTagWorks() {
+        // GIVEN a tag system without any tags
+        // WHEN using '/tag-manage create id:foo content:bar'
+        SlashCommandEvent event = triggerCreateCommand("foo", "bar");
+
+        // THEN the command succeeds and the system contains the tag
+        assertEquals("Success", getResponse(event).getTitle());
+        assertTrue(system.hasTag("foo"));
+        assertEquals("bar", system.getTag("foo").orElseThrow());
+    }
+
+    @Test
+    @DisplayName("'/tag-manage edit' fails if the tag is unknown")
+    void editUnknownTagFails() {
+        // GIVEN a tag system without any tags
+        // WHEN using '/tag-manage edit id:foo content:new'
+        SlashCommandEvent event = triggerEditCommand("foo", "new");
+
+        // THEN the command fails and responds accordingly, the tag was not created
+        verify(event).reply(startsWith("Could not find any tag with id"));
+        assertFalse(system.hasTag("foo"));
+    }
+
+    @Test
+    @DisplayName("'/tag-manage edit' works if the tag is known")
+    void editExistingTagWorks() {
+        // GIVEN a tag system with the "foo" tag
+        system.putTag("foo", "old");
+
+        // WHEN using '/tag-manage edit id:foo content:new'
+        SlashCommandEvent event = triggerEditCommand("foo", "new");
+
+        // THEN the command succeeds and the content of the tag was changed
+        assertEquals("Success", getResponse(event).getTitle());
+        assertEquals("new", system.getTag("foo").orElseThrow());
+    }
+
+    @Test
+    @DisplayName("'/tag-manage delete' fails if the tag is unknown")
+    void deleteUnknownTagFails() {
+        // GIVEN a tag system without any tags
+        // WHEN using '/tag-manage delete id:foo'
+        SlashCommandEvent event = triggerDeleteCommand("foo");
+
+        // THEN the command fails and responds accordingly
+        verify(event).reply(startsWith("Could not find any tag with id"));
+    }
+
+    @Test
+    @DisplayName("'/tag-manage delete' works if the tag is known")
+    void deleteExistingTagWorks() {
+        // GIVEN a tag system with the "foo" tag
+        system.putTag("foo", "bar");
+
+        // WHEN using '/tag-manage delete id:foo'
+        SlashCommandEvent event = triggerDeleteCommand("foo");
+
+        // THEN the command succeeds and the tag was deleted
+        assertEquals("Success", getResponse(event).getTitle());
+        assertFalse(system.hasTag("foo"));
+    }
+
+    @Test
+    @DisplayName("'/tag-manage create-with-message' fails if the given message id is in an invalid format")
+    void createWithMessageFailsForInvalidMessageId() {
+        // GIVEN a tag system without any tags
+        // WHEN using '/tag-manage create-with-message id:foo message-id:bar'
+        SlashCommandEvent event = triggerCreateWithMessageCommand("foo", "bar");
+
+        // THEN the command fails and responds accordingly, the tag was not created
+        verify(event).reply("The given message id 'bar' is invalid, expected a number.");
+        assertFalse(system.hasTag("foo"));
+    }
+
+    @Test
+    @DisplayName("'/tag-manage create-with-message' fails if the tag is known")
+    void createWithMessageTagThatAlreadyExistsFails() {
+        // GIVEN a tag system with the "foo" tag and a message with id and content
+        system.putTag("foo", "old");
+        postMessage("new", "1");
+
+        // WHEN using '/tag-manage create-with-message id:foo message-id:1'
+        SlashCommandEvent event = triggerCreateWithMessageCommand("foo", "1");
+
+        // THEN the command fails and responds accordingly, the tag is still there and unchanged
+        verify(event).reply("The tag with id 'foo' already exists.");
+        assertTrue(system.hasTag("foo"));
+        assertEquals("old", system.getTag("foo").orElseThrow());
+    }
+
+    @Test
+    @DisplayName("'/tag-manage create-with-message' works if the tag is new")
+    void createWithMessageNewTagWorks() {
+        // GIVEN a tag system without any tags and a message with id and content
+        postMessage("bar", "1");
+
+        // WHEN using '/tag-manage create-with-message id:foo message-id:1'
+        SlashCommandEvent event = triggerCreateWithMessageCommand("foo", "1");
+
+        // THEN the command succeeds and the system contains the tag
+        assertEquals("Success", getResponse(event).getTitle());
+        assertTrue(system.hasTag("foo"));
+        assertEquals("bar", system.getTag("foo").orElseThrow());
+    }
+
+    @Test
+    @DisplayName("'/tag-manage create-with-message' fails if the linked message is unknown")
+    void createWithMessageUnknownMessageFails() {
+        // GIVEN a tag system without any tags and an unknown message id
+        failOnRetrieveMessage("1",
+                jdaTester.createErrorResponseException(ErrorResponse.UNKNOWN_MESSAGE));
+
+        // WHEN using '/tag-manage create-with-message id:foo message-id:1'
+        SlashCommandEvent event = triggerCreateWithMessageCommand("foo", "1");
+
+        // THEN the command fails and responds accordingly, the tag was not created
+        verify(event).reply("The message with id '1' does not exist.");
+        assertFalse(system.hasTag("foo"));
+    }
+
+    @Test
+    @DisplayName("'/tag-manage create-with-message' fails if there is a generic error (such as a network failure)")
+    void createWithMessageGenericErrorFails() {
+        // GIVEN a tag system without any tags and a generic network failure
+        failOnRetrieveMessage("1", new IOException("Generic network failure"));
+
+        // WHEN using '/tag-manage create-with-message id:foo message-id:1'
+        SlashCommandEvent event = triggerCreateWithMessageCommand("foo", "1");
+
+        // THEN the command fails and responds accordingly, the tag was not created
+        verify(event).reply(startsWith("Something unexpected went wrong"));
+        assertFalse(system.hasTag("foo"));
+    }
+
+    @Test
+    @DisplayName("'/tag-manage edit-with-message' fails if the given message id is in an invalid format")
+    void editWithMessageFailsForInvalidMessageId() {
+        // GIVEN a tag system with the "foo" tag
+        system.putTag("foo", "old");
+
+        // WHEN using '/tag-manage edit-with-message id:foo message-id:new'
+        SlashCommandEvent event = triggerEditWithMessageCommand("foo", "bar");
+
+        // THEN the command fails and responds accordingly, the tags content was not changed
+        verify(event).reply("The given message id 'bar' is invalid, expected a number.");
+        assertEquals("old", system.getTag("foo").orElseThrow());
+    }
+
+    @Test
+    @DisplayName("'/tag-manage edit-with-message' fails if the tag is unknown")
+    void editWithMessageUnknownTagFails() {
+        // GIVEN a tag system without any tags
+        postMessage("bar", "1");
+
+        // WHEN using '/tag-manage edit-with-message id:foo message-id:new'
+        SlashCommandEvent event = triggerEditWithMessageCommand("foo", "1");
+
+        // THEN the command fails and responds accordingly, the tag was not created
+        verify(event).reply(startsWith("Could not find any tag with id"));
+        assertFalse(system.hasTag("foo"));
+    }
+
+    @Test
+    @DisplayName("'/tag-manage edit-with-message' works if the tag is known")
+    void editWithMessageExistingTagWorks() {
+        // GIVEN a tag system with the "foo" tag
+        system.putTag("foo", "old");
+        postMessage("new", "1");
+
+        // WHEN using '/tag-manage edit-with-message id:foo message-id:1'
+        SlashCommandEvent event = triggerEditWithMessageCommand("foo", "1");
+
+        // THEN the command succeeds and the content of the tag was changed
+        assertEquals("Success", getResponse(event).getTitle());
+        assertEquals("new", system.getTag("foo").orElseThrow());
+    }
+
+    @Test
+    @DisplayName("'/tag-manage edit-with-message' fails if the linked message is unknown")
+    void editWithMessageUnknownMessageFails() {
+        // GIVEN a tag system with the "foo" tag and an unknown message id
+        system.putTag("foo", "old");
+        failOnRetrieveMessage("1",
+                jdaTester.createErrorResponseException(ErrorResponse.UNKNOWN_MESSAGE));
+
+        // WHEN using '/tag-manage edit-with-message id:foo message-id:1'
+        SlashCommandEvent event = triggerEditWithMessageCommand("foo", "1");
+
+        // THEN the command fails and responds accordingly, the tag has not changed
+        verify(event).reply("The message with id '1' does not exist.");
+        assertTrue(system.hasTag("foo"));
+        assertEquals("old", system.getTag("foo").orElseThrow());
+    }
+
+    @Test
+    @DisplayName("'/tag-manage edit-with-message' fails if there is a generic error (such as a network failure)")
+    void editWithMessageGenericErrorFails() {
+        // GIVEN a tag system with the "foo" tag and a generic network failure
+        system.putTag("foo", "old");
+        failOnRetrieveMessage("1", new IOException("Generic network failure"));
+
+        // WHEN using '/tag-manage edit-with-message id:foo message-id:1'
+        SlashCommandEvent event = triggerEditWithMessageCommand("foo", "1");
+
+        // THEN the command fails and responds accordingly, the tag has not changed
+        verify(event).reply(startsWith("Something unexpected went wrong"));
+        assertTrue(system.hasTag("foo"));
+        assertEquals("old", system.getTag("foo").orElseThrow());
+    }
+}

--- a/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagSystemTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagSystemTest.java
@@ -1,0 +1,121 @@
+package org.togetherjava.tjbot.commands.tags;
+
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.togetherjava.tjbot.db.Database;
+import org.togetherjava.tjbot.db.generated.tables.Tags;
+import org.togetherjava.tjbot.jda.JdaTester;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+final class TagSystemTest {
+    private TagSystem system;
+    private Database database;
+    private JdaTester jdaTester;
+
+    private void insertTagRaw(String id, String content) {
+        database
+            .write(context -> context.newRecord(Tags.TAGS).setId(id).setContent(content).insert());
+    }
+
+    private Optional<String> readTagRaw(String id) {
+        return database.read(context -> context.selectFrom(Tags.TAGS)
+            .where(Tags.TAGS.ID.eq(id))
+            .fetchOptional(Tags.TAGS.CONTENT));
+    }
+
+    private int getAmountOfRecords() {
+        return database.read(context -> context.fetchCount(Tags.TAGS));
+    }
+
+    @BeforeEach
+    void setUp() {
+        database = Database.createMemoryDatabase(Tags.TAGS);
+        system = spy(new TagSystem(database));
+        jdaTester = new JdaTester();
+    }
+
+    @Test
+    void createDeleteButton() {
+        assertEquals("foo", TagSystem.createDeleteButton("foo").getId());
+        assertEquals("fooBarFooBar", TagSystem.createDeleteButton("fooBarFooBar").getId());
+    }
+
+    @Test
+    void handleIsUnknownTag() {
+        insertTagRaw("known", "foo");
+        SlashCommandEvent event = jdaTester.createSlashCommandEvent(new TagCommand(system)).build();
+
+        assertFalse(system.handleIsUnknownTag("known", event));
+        verify(event, never()).reply(anyString());
+
+        assertTrue(system.handleIsUnknownTag("unknown", event));
+        verify(event).reply(anyString());
+    }
+
+    @Test
+    void hasTag() {
+        insertTagRaw("known", "foo");
+
+        assertTrue(system.hasTag("known"));
+        assertFalse(system.hasTag("unknown"));
+    }
+
+    @Test
+    void deleteTag() {
+        insertTagRaw("known", "foo");
+
+        assertThrowsExactly(IllegalArgumentException.class, () -> system.deleteTag("unknown"));
+        assertEquals(1, getAmountOfRecords());
+
+        system.deleteTag("known");
+        assertEquals(0, getAmountOfRecords());
+    }
+
+    @Test
+    void putTag() {
+        insertTagRaw("before", "foo");
+
+        system.putTag("now", "bar");
+
+        Optional<String> maybeContent = readTagRaw("now");
+        assertTrue(maybeContent.isPresent());
+        assertEquals("bar", maybeContent.orElseThrow());
+
+        // Overwrite existing content
+        system.putTag("before", "baz");
+        maybeContent = readTagRaw("before");
+        assertTrue(maybeContent.isPresent());
+        assertEquals("baz", maybeContent.orElseThrow());
+    }
+
+    @Test
+    void getTag() {
+        insertTagRaw("known", "foo");
+
+        assertTrue(system.getTag("unknown").isEmpty());
+
+        Optional<String> maybeContent = system.getTag("known");
+        assertTrue(maybeContent.isPresent());
+        assertEquals("foo", maybeContent.orElseThrow());
+    }
+
+    @Test
+    void getAllIds() {
+        assertTrue(system.getAllIds().isEmpty());
+
+        insertTagRaw("first", "foo");
+        assertEquals(Set.of("first"), system.getAllIds());
+
+        insertTagRaw("second", "bar");
+        assertEquals(Set.of("first", "second"), system.getAllIds());
+
+        insertTagRaw("third", "baz");
+        assertEquals(Set.of("first", "second", "third"), system.getAllIds());
+    }
+}

--- a/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagsCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagsCommandTest.java
@@ -1,0 +1,147 @@
+package org.togetherjava.tjbot.commands.tags;
+
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.ButtonClickEvent;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.components.ActionRow;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.togetherjava.tjbot.commands.SlashCommand;
+import org.togetherjava.tjbot.db.Database;
+import org.togetherjava.tjbot.db.generated.tables.Tags;
+import org.togetherjava.tjbot.jda.JdaTester;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.*;
+
+final class TagsCommandTest {
+    private TagSystem system;
+    private JdaTester jdaTester;
+    private SlashCommand command;
+
+    private static @Nullable String getResponseDescription(@NotNull SlashCommandEvent event) {
+        ArgumentCaptor<MessageEmbed> responseCaptor = ArgumentCaptor.forClass(MessageEmbed.class);
+        verify(event).replyEmbeds(responseCaptor.capture());
+        return responseCaptor.getValue().getDescription();
+    }
+
+    private @NotNull SlashCommandEvent triggerSlashCommand() {
+        SlashCommandEvent event = jdaTester.createSlashCommandEvent(command).build();
+        command.onSlashCommand(event);
+        return event;
+    }
+
+    private @NotNull ButtonClickEvent triggerButtonClick(@NotNull Member userWhoClicked,
+            long idOfAuthor) {
+        ButtonClickEvent event = jdaTester.createButtonClickEvent()
+            .setUserWhoClicked(userWhoClicked)
+            .setActionRows(ActionRow.of(TagSystem.createDeleteButton("foo")))
+            .buildWithSingleButton();
+        command.onButtonClick(event, List.of(Long.toString(idOfAuthor)));
+        return event;
+    }
+
+    @BeforeEach
+    void setUp() {
+        system = spy(new TagSystem(Database.createMemoryDatabase(Tags.TAGS)));
+        jdaTester = new JdaTester();
+        command = jdaTester.spySlashCommand(new TagsCommand(system));
+    }
+
+    @Test
+    @DisplayName("The list of tags is empty if there are no tags registered")
+    void noResponseForEmptySystem() {
+        // GIVEN a tag system without any tags
+        // WHEN using '/tags'
+        SlashCommandEvent event = triggerSlashCommand();
+
+        // THEN the response has no description
+        assertNull(getResponseDescription(event));
+    }
+
+    @Test
+    @DisplayName("The list of tags shows a single element if there is one tag registered")
+    void singleElementListForOneTag() {
+        // GIVEN a tag system with the 'first' tag
+        system.putTag("first", "foo");
+
+        // WHEN using '/tags'
+        SlashCommandEvent event = triggerSlashCommand();
+
+        // THEN the response consists of the single element
+        assertEquals("• first", getResponseDescription(event));
+    }
+
+    @Test
+    @DisplayName("The list of tags shows multiply elements if there are multiple tags registered")
+    void multipleElementListForMultipleTag() {
+        // GIVEN a tag system with some tags
+        system.putTag("first", "foo");
+        system.putTag("second", "bar");
+        system.putTag("third", "baz");
+
+        // WHEN using '/tags'
+        SlashCommandEvent event = triggerSlashCommand();
+
+        // THEN the response contains all tags
+        String expectedDescription = """
+                • first
+                • second
+                • third""";
+        assertEquals(expectedDescription, getResponseDescription(event));
+    }
+
+    @Test
+    @DisplayName("The list of tags can be deleted by the original author")
+    void authorCanDeleteList() {
+        // GIVEN a '/tags' message send by an author
+        long idOfAuthor = 1;
+        Member messageAuthor = jdaTester.createMemberSpy(idOfAuthor);
+
+        // WHEN the original author clicks the delete button
+        ButtonClickEvent event = triggerButtonClick(messageAuthor, idOfAuthor);
+
+        // THEN the '/tags' message is deleted
+        verify(event.getMessage()).delete();
+    }
+
+    @Test
+    @DisplayName("The list of tags can be deleted by a moderator")
+    void moderatorCanDeleteList() {
+        // GIVEN a '/tags' message send by an author and a moderator
+        long idOfAuthor = 1;
+        Member moderator = jdaTester.createMemberSpy(2);
+        doReturn(true).when(moderator).hasPermission(any(Permission.class));
+
+        // WHEN the moderator clicks the delete button
+        ButtonClickEvent event = triggerButtonClick(moderator, idOfAuthor);
+
+        // THEN the '/tags' message is deleted
+        verify(event.getMessage()).delete();
+    }
+
+    @Test
+    @DisplayName("The list of tags can not deleted by other users")
+    void othersCanNotDeleteList() {
+        // GIVEN a '/tags' message send by an author and another user
+        long idOfAuthor = 1;
+        Member otherUser = jdaTester.createMemberSpy(3);
+        doReturn(false).when(otherUser).hasPermission(any(Permission.class));
+
+        // WHEN the other clicks the delete button
+        ButtonClickEvent event = triggerButtonClick(otherUser, idOfAuthor);
+
+        // THEN the '/tags' message is not deleted
+        verify(event.getMessage(), never()).delete();
+        verify(event).reply(anyString());
+    }
+}

--- a/application/src/test/java/org/togetherjava/tjbot/jda/ButtonClickEventBuilder.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/ButtonClickEventBuilder.java
@@ -1,0 +1,245 @@
+package org.togetherjava.tjbot.jda;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.ButtonClickEvent;
+import net.dv8tion.jda.api.interactions.components.ActionRow;
+import net.dv8tion.jda.api.interactions.components.Button;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.togetherjava.tjbot.commands.SlashCommand;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * Builder to create button click events that can be used for example with
+ * {@link SlashCommand#onButtonClick(ButtonClickEvent, List)}.
+ * <p>
+ * Create instances of this class by using {@link JdaTester#createButtonClickEvent()}.
+ * <p>
+ * Among other Discord related things, the builder optionally accepts a message
+ * ({@link #setMessage(Message)}) and the user who clicked on the button
+ * ({@link #setUserWhoClicked(Member)} ). As well as several ways to modify the message directly for
+ * convenience, such as {@link #setContent(String)} or {@link #setActionRows(ActionRow...)}. The
+ * builder is by default already setup with a valid dummy message and the user who clicked the
+ * button is set to the author of the message.
+ * <p>
+ * In order to build the event, at least one button has to be added to the message and marked as
+ * <i>clicked</i>. Therefore, use {@link #setActionRows(ActionRow...)} or modify the message
+ * manually using {@link #setMessage(Message)}. Then mark the desired button as clicked using
+ * {@link #build(Button)} or, if the message only contains a single button,
+ * {@link #buildWithSingleButton()} will automatically select the button.
+ * <p>
+ * Refer to the following examples:
+ *
+ * <pre>
+ * {@code
+ * // Default message with a delete button
+ * jdaTester.createButtonClickEvent()
+ *   .setActionRows(ActionRow.of(Button.of(ButtonStyle.DANGER, "1", "Delete"))
+ *   .buildWithSingleButton();
+ *
+ * // More complex message with a user who clicked the button that is not the message author and multiple buttons
+ * Button clickedButton = Button.of(ButtonStyle.PRIMARY, "1", "Next");
+ * jdaTester.createButtonClickEvent()
+ *   .setMessage(new MessageBuilder()
+ *     .setContent("See the following entry")
+ *     .setEmbeds(
+ *       new EmbedBuilder()
+ *         .setDescription("John")
+ *         .build())
+ *     .build())
+ *   .setUserWhoClicked(jdaTester.createMemberSpy(5))
+ *   .setActionRows(
+ *     ActionRow.of(Button.of(ButtonStyle.PRIMARY, "1", "Previous"),
+ *     clickedButton)
+ *   .build(clickedButton);
+ * }
+ * </pre>
+ */
+public final class ButtonClickEventBuilder {
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private final @NotNull Supplier<? extends ButtonClickEvent> mockEventSupplier;
+    private final UnaryOperator<Message> mockMessageOperator;
+    private MessageBuilder messageBuilder;
+    private Member userWhoClicked;
+
+    ButtonClickEventBuilder(@NotNull Supplier<? extends ButtonClickEvent> mockEventSupplier,
+            @NotNull UnaryOperator<Message> mockMessageOperator) {
+        this.mockEventSupplier = mockEventSupplier;
+        this.mockMessageOperator = mockMessageOperator;
+
+        messageBuilder = new MessageBuilder();
+        messageBuilder.setContent("test message");
+    }
+
+    /**
+     * Sets the given message that this event is associated to. Will override any data previously
+     * set with the more direct methods such as {@link #setContent(String)} or
+     * {@link #setActionRows(ActionRow...)}.
+     * <p>
+     * The message must contain at least one button, or the button has to be added later with
+     * {@link #setActionRows(ActionRow...)}.
+     *
+     * @param message the message to set
+     * @return this builder instance for chaining
+     */
+    public @NotNull ButtonClickEventBuilder setMessage(@NotNull Message message) {
+        messageBuilder = new MessageBuilder(message);
+        return this;
+    }
+
+    /**
+     * Sets the content of the message that this event is associated to. Usage of
+     * {@link #setMessage(Message)} will overwrite any content set by this.
+     * 
+     * @param content the content of the message
+     * @return this builder instance for chaining
+     */
+    public @NotNull ButtonClickEventBuilder setContent(@NotNull String content) {
+        messageBuilder.setContent(content);
+        return this;
+    }
+
+    /**
+     * Sets the embeds of the message that this event is associated to. Usage of
+     * {@link #setMessage(Message)} will overwrite any content set by this.
+     * 
+     * @param embeds the embeds of the message
+     * @return this builder instance for chaining
+     */
+    public @NotNull ButtonClickEventBuilder setEmbeds(@NotNull MessageEmbed... embeds) {
+        messageBuilder.setEmbeds(embeds);
+        return this;
+    }
+
+    /**
+     * Sets the action rows of the message that this event is associated to. Usage of
+     * {@link #setMessage(Message)} will overwrite any content set by this.
+     * <p>
+     * At least one of the rows must contain a button before {@link #build(Button)} is called.
+     * 
+     * @param rows the action rows of the message
+     * @return this builder instance for chaining
+     */
+    public @NotNull ButtonClickEventBuilder setActionRows(@NotNull ActionRow... rows) {
+        messageBuilder.setActionRows(rows);
+        return this;
+    }
+
+    /**
+     * Sets the user who clicked the button, i.e. who triggered the event.
+     * 
+     * @param userWhoClicked the user who clicked the button
+     * @return this builder instance for chaining
+     */
+    @NotNull
+    public ButtonClickEventBuilder setUserWhoClicked(@NotNull Member userWhoClicked) {
+        this.userWhoClicked = userWhoClicked;
+        return this;
+    }
+
+    /**
+     * Builds an instance of a button click event, corresponding to the current configuration of the
+     * builder.
+     * <p>
+     * The message must contain exactly one button, which is automatically assumed to be the button
+     * that has been clicked. Use {@link #build(Button)} for messages with multiple buttons instead.
+     *
+     * @return the created slash command instance
+     */
+    public @NotNull ButtonClickEvent buildWithSingleButton() {
+        return createEvent(null);
+    }
+
+    /**
+     * Builds an instance of a button click event, corresponding to the current configuration of the
+     * builder.
+     * <p>
+     * The message must the given button. {@link #buildWithSingleButton()} can be used for
+     * convenience for messages that only have a single button.
+     *
+     * @param clickedButton the button that was clicked, i.e. that triggered the event. Must be
+     *        contained in the message.
+     * @return the created slash command instance
+     */
+    public @NotNull ButtonClickEvent build(@NotNull Button clickedButton) {
+        return createEvent(clickedButton);
+    }
+
+    private @NotNull ButtonClickEvent createEvent(@Nullable Button maybeClickedButton) {
+        Message message = mockMessageOperator.apply(messageBuilder.build());
+        Button clickedButton = determineClickedButton(maybeClickedButton, message);
+
+        return mockButtonClickEvent(message, clickedButton);
+    }
+
+    private static @NotNull Button determineClickedButton(@Nullable Button maybeClickedButton,
+            @NotNull Message message) {
+        if (maybeClickedButton != null) {
+            return requireButtonInMessage(maybeClickedButton, message);
+        }
+
+        // Otherwise, attempt to extract the button from the message. Only allow a single button in
+        // this case to prevent ambiguity.
+        return requireSingleButton(getMessageButtons(message));
+    }
+
+    private static @NotNull Button requireButtonInMessage(@NotNull Button clickedButton,
+            @NotNull Message message) {
+        boolean isClickedButtonUnknown =
+                getMessageButtons(message).noneMatch(clickedButton::equals);
+
+        if (isClickedButtonUnknown) {
+            throw new IllegalArgumentException(
+                    "The given clicked button is not part of the messages components,"
+                            + " make sure to add the button to one of the messages action rows first.");
+        }
+        return clickedButton;
+    }
+
+    private static @NotNull Button requireSingleButton(@NotNull Stream<? extends Button> stream) {
+        Function<String, ? extends RuntimeException> descriptionToException =
+                IllegalArgumentException::new;
+
+        return stream.reduce((x, y) -> {
+            throw descriptionToException
+                .apply("The message contains more than a single button, unable to automatically determine the clicked button."
+                        + " Either only use a single button or explicitly state the clicked button");
+        })
+            .orElseThrow(() -> descriptionToException.apply(
+                    "The message contains no buttons, unable to automatically determine the clicked button."
+                            + " Add the button to the message first."));
+    }
+
+    private static @NotNull Stream<Button> getMessageButtons(@NotNull Message message) {
+        return message.getActionRows().stream().map(ActionRow::getButtons).flatMap(List::stream);
+    }
+
+    private @NotNull ButtonClickEvent mockButtonClickEvent(@NotNull Message message,
+            @NotNull Button clickedButton) {
+        ButtonClickEvent event = mockEventSupplier.get();
+
+        when(event.getMessage()).thenReturn(message);
+        when(event.getButton()).thenReturn(clickedButton);
+        when(event.getComponent()).thenReturn(clickedButton);
+        when(event.getComponentId()).thenReturn(clickedButton.getId());
+        when(event.getComponentType()).thenReturn(clickedButton.getType());
+
+        when(event.getMember()).thenReturn(userWhoClicked);
+        User asUser = userWhoClicked.getUser();
+        when(event.getUser()).thenReturn(asUser);
+
+        return event;
+    }
+}

--- a/application/src/test/java/org/togetherjava/tjbot/jda/JdaTester.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/JdaTester.java
@@ -1,26 +1,45 @@
 package org.togetherjava.tjbot.jda;
 
+import net.dv8tion.jda.api.AccountType;
 import net.dv8tion.jda.api.Permission;
-import net.dv8tion.jda.api.entities.SelfUser;
+import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.events.interaction.ButtonClickEvent;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
-import net.dv8tion.jda.api.requests.restaction.MessageAction;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
+import net.dv8tion.jda.api.interactions.Interaction;
+import net.dv8tion.jda.api.interactions.components.Component;
+import net.dv8tion.jda.api.requests.ErrorResponse;
+import net.dv8tion.jda.api.requests.Response;
+import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
+import net.dv8tion.jda.api.utils.AttachmentOption;
 import net.dv8tion.jda.api.utils.ConcurrentSessionController;
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.*;
 import net.dv8tion.jda.internal.requests.Requester;
+import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.MessageActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.interactions.ReplyActionImpl;
 import net.dv8tion.jda.internal.utils.config.AuthorizationConfig;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.mockito.ArgumentMatchers;
+import org.mockito.stubbing.Answer;
 import org.togetherjava.tjbot.commands.SlashCommand;
+import org.togetherjava.tjbot.commands.componentids.ComponentIdGenerator;
 
 import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
+import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.Mockito.*;
 
 /**
@@ -31,7 +50,7 @@ import static org.mockito.Mockito.*;
  * be exploited for testing.
  * <p>
  * An example test using this class might look like:
- * 
+ *
  * <pre>
  * {
  *     &#64;code
@@ -41,7 +60,7 @@ import static org.mockito.Mockito.*;
  *     SlashCommandEvent event = jdaTester.createSlashCommandEvent(command).build();
  *     command.onSlashCommand(event);
  *
- *     verify(event, times(1)).reply("Pong!");
+ *     verify(event).reply("Pong!");
  * }
  * </pre>
  */
@@ -51,6 +70,7 @@ public final class JdaTester {
             new ScheduledThreadPoolExecutor(4);
     private static final String TEST_TOKEN = "TEST_TOKEN";
     private static final long USER_ID = 1;
+    private static final long SELF_USER_ID = 2;
     private static final long APPLICATION_ID = 1;
     private static final long PRIVATE_CHANNEL_ID = 1;
     private static final long GUILD_ID = 1;
@@ -58,6 +78,12 @@ public final class JdaTester {
 
     private final JDAImpl jda;
     private final MemberImpl member;
+    private final GuildImpl guild;
+    private final ReplyActionImpl replyAction;
+    private final AuditableRestActionImpl<Void> auditableRestAction;
+    private final MessageActionImpl messageAction;
+    private final TextChannelImpl textChannel;
+    private final PrivateChannelImpl privateChannel;
 
     /**
      * Creates a new instance. The instance uses a fresh and isolated mocked JDA setup.
@@ -66,29 +92,34 @@ public final class JdaTester {
      * which can have an impact on tests. For example a previous text that already send messages to
      * a channel, the messages will then still be present in the instance.
      */
+    @SuppressWarnings("unchecked")
     public JdaTester() {
         // TODO Extend this functionality, make it nicer.
         // Maybe offer a builder for multiple users and channels and what not
         jda = mock(JDAImpl.class);
         when(jda.getCacheFlags()).thenReturn(EnumSet.noneOf(CacheFlag.class));
 
-        SelfUser selfUser = mock(SelfUserImpl.class);
+        SelfUserImpl selfUser = spy(new SelfUserImpl(SELF_USER_ID, jda));
         UserImpl user = spy(new UserImpl(USER_ID, jda));
-        GuildImpl guild = spy(new GuildImpl(jda, GUILD_ID));
+        guild = spy(new GuildImpl(jda, GUILD_ID));
+        Member selfMember = spy(new MemberImpl(guild, selfUser));
         member = spy(new MemberImpl(guild, user));
-        TextChannelImpl textChannel = spy(new TextChannelImpl(TEXT_CHANNEL_ID, guild));
-        PrivateChannelImpl privateChannel = spy(new PrivateChannelImpl(PRIVATE_CHANNEL_ID, user));
-        MessageAction messageAction = mock(MessageActionImpl.class);
+        textChannel = spy(new TextChannelImpl(TEXT_CHANNEL_ID, guild));
+        privateChannel = spy(new PrivateChannelImpl(PRIVATE_CHANNEL_ID, user));
+        messageAction = mock(MessageActionImpl.class);
         EntityBuilder entityBuilder = mock(EntityBuilder.class);
+        Role everyoneRole = new RoleImpl(GUILD_ID, guild);
 
-        // TODO Depending on the commands we might need a lot more mocking here
         when(entityBuilder.createUser(any())).thenReturn(user);
         when(entityBuilder.createMember(any(), any())).thenReturn(member);
-        // TODO Giving out all permissions makes it impossible to test permission requirements on
-        // commands
-        doReturn(true).when(member).hasPermission(ArgumentMatchers.<Permission>any());
-        when(selfUser.getApplicationId()).thenReturn(String.valueOf(APPLICATION_ID));
-        when(selfUser.getApplicationIdLong()).thenReturn(APPLICATION_ID);
+        doReturn(true).when(member).hasPermission(any(Permission.class));
+        doReturn(true).when(member).hasPermission(any(GuildChannel.class), any(Permission.class));
+        doReturn(true).when(selfMember).hasPermission(any(Permission.class));
+        doReturn(true).when(selfMember)
+            .hasPermission(any(GuildChannel.class), any(Permission.class));
+
+        doReturn(String.valueOf(APPLICATION_ID)).when(selfUser).getApplicationId();
+        doReturn(APPLICATION_ID).when(selfUser).getApplicationIdLong();
         doReturn(selfUser).when(jda).getSelfUser();
         when(jda.getGuildChannelById(anyLong())).thenReturn(textChannel);
         when(jda.getPrivateChannelById(anyLong())).thenReturn(privateChannel);
@@ -99,8 +130,29 @@ public final class JdaTester {
         when(jda.getRateLimitPool()).thenReturn(RATE_LIMIT_POOL);
         when(jda.getSessionController()).thenReturn(new ConcurrentSessionController());
         doReturn(new Requester(jda, new AuthorizationConfig(TEST_TOKEN))).when(jda).getRequester();
+        when(jda.getAccountType()).thenReturn(AccountType.BOT);
 
         doReturn(messageAction).when(privateChannel).sendMessage(anyString());
+
+        replyAction = mock(ReplyActionImpl.class);
+        when(replyAction.setEphemeral(anyBoolean())).thenReturn(replyAction);
+        when(replyAction.addActionRow(anyCollection())).thenReturn(replyAction);
+        when(replyAction.addActionRow(ArgumentMatchers.<Component>any())).thenReturn(replyAction);
+        when(replyAction.setContent(anyString())).thenReturn(replyAction);
+        when(replyAction.addFile(any(byte[].class), any(String.class), any(AttachmentOption.class)))
+            .thenReturn(replyAction);
+        doNothing().when(replyAction).queue();
+
+        auditableRestAction = (AuditableRestActionImpl<Void>) mock(AuditableRestActionImpl.class);
+        doNothing().when(auditableRestAction).queue();
+
+        doNothing().when(messageAction).queue();
+
+        doReturn(everyoneRole).when(guild).getPublicRole();
+        doReturn(selfMember).when(guild).getMember(selfUser);
+        doReturn(member).when(guild).getMember(not(eq(selfUser)));
+
+        doReturn(null).when(textChannel).retrieveMessageById(any());
     }
 
     /**
@@ -117,22 +169,225 @@ public final class JdaTester {
             @NotNull SlashCommand command) {
         UnaryOperator<SlashCommandEvent> mockOperator = event -> {
             SlashCommandEvent slashCommandEvent = spy(event);
-            ReplyActionImpl replyAction = mock(ReplyActionImpl.class);
-
-            doReturn(replyAction).when(slashCommandEvent).reply(anyString());
-            when(replyAction.setEphemeral(anyBoolean())).thenReturn(replyAction);
-            doReturn(member).when(slashCommandEvent).getMember();
-
+            mockInteraction(slashCommandEvent);
             return slashCommandEvent;
         };
 
-        return new SlashCommandEventBuilder(jda, mockOperator).command(command)
-            .token(TEST_TOKEN)
-            .channelId(String.valueOf(TEXT_CHANNEL_ID))
-            .applicationId(String.valueOf(APPLICATION_ID))
-            .guildId(String.valueOf(GUILD_ID))
-            .userId(String.valueOf(USER_ID));
+        return new SlashCommandEventBuilder(jda, mockOperator).setCommand(command)
+            .setToken(TEST_TOKEN)
+            .setChannelId(String.valueOf(TEXT_CHANNEL_ID))
+            .setApplicationId(String.valueOf(APPLICATION_ID))
+            .setGuildId(String.valueOf(GUILD_ID))
+            .setUserId(String.valueOf(USER_ID))
+            .setUserWhoTriggered(member);
     }
 
-    // TODO Add methods to create button and menu events as well
+    /**
+     * Creates a Mockito mocked button click event, which can be used for
+     * {@link SlashCommand#onButtonClick(ButtonClickEvent, List)}.
+     * <p>
+     * The method creates a builder that can be used to further adjust the event before creation,
+     * e.g. provide options.
+     *
+     * @return a builder used to create a Mockito mocked slash command event
+     */
+    public @NotNull ButtonClickEventBuilder createButtonClickEvent() {
+        Supplier<ButtonClickEvent> mockEventSupplier = () -> {
+            ButtonClickEvent event = mock(ButtonClickEvent.class);
+            mockButtonClickEvent(event);
+            return event;
+        };
+
+        UnaryOperator<Message> mockMessageOperator = event -> {
+            Message message = spy(event);
+            mockMessage(message);
+            return message;
+        };
+
+        return new ButtonClickEventBuilder(mockEventSupplier, mockMessageOperator)
+            .setUserWhoClicked(member);
+    }
+
+    /**
+     * Creates a Mockito spy on the given slash command.
+     * <p>
+     * The spy is also prepared for mocked execution, e.g. attributes such as
+     * {@link SlashCommand#acceptComponentIdGenerator(ComponentIdGenerator)} are filled with mocks.
+     *
+     * @param command the command to spy on
+     * @param <T> the type of the command to spy on
+     * @return the created spy
+     */
+    public <T extends SlashCommand> @NotNull T spySlashCommand(@NotNull T command) {
+        T spiedCommand = spy(command);
+        spiedCommand
+            .acceptComponentIdGenerator((componentId, lifespan) -> UUID.randomUUID().toString());
+        return spiedCommand;
+    }
+
+    /**
+     * Creates a Mockito spy for a member with the given user id.
+     *
+     * @param userId the id of the member to create
+     * @return the created spy
+     */
+    public @NotNull Member createMemberSpy(long userId) {
+        UserImpl user = spy(new UserImpl(userId, jda));
+        return spy(new MemberImpl(guild, user));
+    }
+
+    /**
+     * Gets the Mockito mock used as universal reply action by all mocks created by this tester
+     * instance.
+     * <p>
+     * For example the events created by {@link #createSlashCommandEvent(SlashCommand)} will return
+     * this mock on several of their methods.
+     *
+     * @return the reply action mock used by this tester
+     */
+    public @NotNull ReplyAction getReplyActionMock() {
+        return replyAction;
+    }
+
+    /**
+     * Gets the text channel spy used as universal text channel by all mocks created by this tester
+     * instance.
+     * <p>
+     * For example the events created by {@link #createSlashCommandEvent(SlashCommand)} will return
+     * this spy on several of their methods.
+     *
+     * @return the text channel spy used by this tester
+     */
+    public @NotNull TextChannel getTextChannelSpy() {
+        return textChannel;
+    }
+
+    /**
+     * Creates a mocked action that always succeeds and consumes the given object.
+     * <p>
+     * Such an action is useful for testing things involving calls like
+     * {@link TextChannel#retrieveMessageById(long)} or similar, example:
+     * 
+     * <pre>
+     * {
+     *     &#64;code
+     *     var jdaTester = new JdaTester();
+     *
+     *     var message = new MessageBuilder("Hello World!").build();
+     *     var action = jdaTester.createSucceededActionMock(message);
+     *
+     *     doReturn(action).when(jdaTester.getTextChannelSpy()).retrieveMessageById("1");
+     * }
+     * </pre>
+     * 
+     * @param t the object to consume on success
+     * @param <T> the type of the object to consume
+     * @return the mocked action
+     */
+    @SuppressWarnings("unchecked")
+    public <T> @NotNull RestAction<T> createSucceededActionMock(@Nullable T t) {
+        RestAction<T> action = (RestAction<T>) mock(RestAction.class);
+
+        Answer<Void> successExecution = invocation -> {
+            Consumer<? super T> successConsumer = invocation.getArgument(0);
+            successConsumer.accept(t);
+            return null;
+        };
+
+        doNothing().when(action).queue();
+
+        doAnswer(successExecution).when(action).queue(any());
+        doAnswer(successExecution).when(action).queue(any(), any());
+
+        return action;
+    }
+
+    /**
+     * Creates a mocked action that always fails and consumes the given failure reason.
+     * <p>
+     * Such an action is useful for testing things involving calls like
+     * {@link TextChannel#retrieveMessageById(long)} or similar, example:
+     * 
+     * <pre>
+     * {
+     *     &#64;code
+     *     var jdaTester = new JdaTester();
+     *
+     *     var reason = new FooException();
+     *     var action = jdaTester.createFailedActionMock(reason);
+     *
+     *     doReturn(action).when(jdaTester.getTextChannelSpy()).retrieveMessageById("1");
+     * }
+     * </pre>
+     * 
+     * @param failureReason the reason to consume on failure
+     * @param <T> the type of the object the action would contain if it would succeed
+     * @return the mocked action
+     */
+    @SuppressWarnings("unchecked")
+    public <T> @NotNull RestAction<T> createFailedActionMock(@NotNull Throwable failureReason) {
+        RestAction<T> action = (RestAction<T>) mock(RestAction.class);
+
+        Answer<Void> failureExecution = invocation -> {
+            Consumer<? super Throwable> failureConsumer = invocation.getArgument(1);
+            failureConsumer.accept(failureReason);
+            return null;
+        };
+
+        doNothing().when(action).queue();
+        doNothing().when(action).queue(any());
+
+        doAnswer(failureExecution).when(action).queue(any(), any());
+
+        return action;
+    }
+
+    /**
+     * Creates an exception used by JDA on failure in most calls to the Discord API.
+     * <p>
+     * The exception merely wraps around the given reason and has no valid error code or message
+     * set.
+     * 
+     * @param reason the reason of the error
+     * @return the created exception
+     */
+    public @NotNull ErrorResponseException createErrorResponseException(
+            @NotNull ErrorResponse reason) {
+        return ErrorResponseException.create(reason, new Response(null, -1, "", -1, Set.of()));
+    }
+
+    private void mockInteraction(@NotNull Interaction interaction) {
+        doReturn(replyAction).when(interaction).reply(anyString());
+        doReturn(replyAction).when(interaction).replyEmbeds(ArgumentMatchers.<MessageEmbed>any());
+        doReturn(replyAction).when(interaction).replyEmbeds(anyCollection());
+
+        doReturn(member).when(interaction).getMember();
+        doReturn(member.getUser()).when(interaction).getUser();
+
+        doReturn(textChannel).when(interaction).getChannel();
+        doReturn(textChannel).when(interaction).getMessageChannel();
+        doReturn(textChannel).when(interaction).getTextChannel();
+        doReturn(textChannel).when(interaction).getGuildChannel();
+        doReturn(privateChannel).when(interaction).getPrivateChannel();
+    }
+
+    private void mockButtonClickEvent(@NotNull ButtonClickEvent event) {
+        mockInteraction(event);
+
+        doReturn(replyAction).when(event).editButton(any());
+    }
+
+    private void mockMessage(@NotNull Message message) {
+        doReturn(messageAction).when(message).reply(anyString());
+        doReturn(messageAction).when(message).replyEmbeds(ArgumentMatchers.<MessageEmbed>any());
+        doReturn(messageAction).when(message).replyEmbeds(anyCollection());
+
+        doReturn(auditableRestAction).when(message).delete();
+
+        doReturn(auditableRestAction).when(message).addReaction(any(Emote.class));
+        doReturn(auditableRestAction).when(message).addReaction(any(String.class));
+
+        doReturn(member).when(message).getMember();
+        doReturn(member.getUser()).when(message).getAuthor();
+    }
 }

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/PayloadMember.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/PayloadMember.java
@@ -1,6 +1,9 @@
-package org.togetherjava.tjbot.jda;
+package org.togetherjava.tjbot.jda.payloads;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -9,7 +12,7 @@ import java.util.Collections;
 import java.util.List;
 
 @SuppressWarnings("ClassWithTooManyFields")
-final class PayloadSlashCommandMember {
+public final class PayloadMember {
     @JsonProperty("premium_since")
     private String premiumSince;
     private String nick;
@@ -23,13 +26,13 @@ final class PayloadSlashCommandMember {
     private String avatar;
     @JsonProperty("is_pending")
     private boolean isPending;
-    private PayloadSlashCommandUser user;
+    private PayloadUser user;
 
     @SuppressWarnings("ConstructorWithTooManyParameters")
-    PayloadSlashCommandMember(@Nullable String premiumSince, @Nullable String nick,
+    public PayloadMember(@Nullable String premiumSince, @Nullable String nick,
             @NotNull String joinedAt, @NotNull String permissions, @NotNull List<String> roles,
             boolean pending, boolean deaf, boolean mute, @Nullable String avatar, boolean isPending,
-            PayloadSlashCommandUser user) {
+            PayloadUser user) {
         this.premiumSince = premiumSince;
         this.nick = nick;
         this.joinedAt = joinedAt;
@@ -43,11 +46,22 @@ final class PayloadSlashCommandMember {
         this.user = user;
     }
 
-    public @NotNull PayloadSlashCommandUser getUser() {
+    public static @NotNull PayloadMember of(@NotNull Member member) {
+        String permissions = Long
+            .toString(Permission.getRaw(member.getPermissions().toArray(Permission[]::new)));
+        List<String> roles = member.getRoles().stream().map(Role::getId).toList();
+        PayloadUser user = PayloadUser.of(member.getUser());
+
+        return new PayloadMember(null, member.getNickname(), member.getTimeJoined().toString(),
+                permissions, roles, member.isPending(), false, false, member.getAvatarId(),
+                member.isPending(), user);
+    }
+
+    public @NotNull PayloadUser getUser() {
         return user;
     }
 
-    public void setUser(@NotNull PayloadSlashCommandUser user) {
+    public void setUser(@NotNull PayloadUser user) {
         this.user = user;
     }
 

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/PayloadUser.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/PayloadUser.java
@@ -1,17 +1,20 @@
-package org.togetherjava.tjbot.jda;
+package org.togetherjava.tjbot.jda.payloads;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import net.dv8tion.jda.api.entities.User;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-final class PayloadSlashCommandUser {
+public final class PayloadUser {
+    private boolean bot;
     @JsonProperty("public_flags")
-    private int publicFlags;
+    private long publicFlags;
     private String id;
     private String avatar;
     private String username;
     private String discriminator;
 
-    PayloadSlashCommandUser(int publicFlags, @NotNull String id, @NotNull String avatar,
+    public PayloadUser(boolean bot, long publicFlags, @NotNull String id, @Nullable String avatar,
             @NotNull String username, @NotNull String discriminator) {
         this.publicFlags = publicFlags;
         this.id = id;
@@ -20,11 +23,24 @@ final class PayloadSlashCommandUser {
         this.discriminator = discriminator;
     }
 
-    public int getPublicFlags() {
+    public static @NotNull PayloadUser of(@NotNull User user) {
+        return new PayloadUser(user.isBot(), user.getFlagsRaw(), user.getId(), user.getAvatarId(),
+                user.getName(), user.getDiscriminator());
+    }
+
+    public boolean isBot() {
+        return bot;
+    }
+
+    public void setBot(boolean bot) {
+        this.bot = bot;
+    }
+
+    public long getPublicFlags() {
         return publicFlags;
     }
 
-    public void setPublicFlags(int publicFlags) {
+    public void setPublicFlags(long publicFlags) {
         this.publicFlags = publicFlags;
     }
 
@@ -37,12 +53,12 @@ final class PayloadSlashCommandUser {
         this.id = id;
     }
 
-    @NotNull
+    @Nullable
     public String getAvatar() {
         return avatar;
     }
 
-    public void setAvatar(@NotNull String avatar) {
+    public void setAvatar(@Nullable String avatar) {
         this.avatar = avatar;
     }
 

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommand.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommand.java
@@ -1,9 +1,10 @@
-package org.togetherjava.tjbot.jda;
+package org.togetherjava.tjbot.jda.payloads.slashcommand;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jetbrains.annotations.NotNull;
+import org.togetherjava.tjbot.jda.payloads.PayloadMember;
 
-final class PayloadSlashCommand {
+public final class PayloadSlashCommand {
     @JsonProperty("guild_id")
     private String guildId;
     private String id;
@@ -14,13 +15,13 @@ final class PayloadSlashCommand {
     @JsonProperty("application_id")
     private String applicationId;
     private String token;
-    private PayloadSlashCommandMember member;
+    private PayloadMember member;
     private PayloadSlashCommandData data;
 
     @SuppressWarnings("ConstructorWithTooManyParameters")
-    PayloadSlashCommand(@NotNull String guildId, @NotNull String id, int type, int version,
+    public PayloadSlashCommand(@NotNull String guildId, @NotNull String id, int type, int version,
             @NotNull String channelId, @NotNull String applicationId, @NotNull String token,
-            @NotNull PayloadSlashCommandMember member, @NotNull PayloadSlashCommandData data) {
+            @NotNull PayloadMember member, @NotNull PayloadSlashCommandData data) {
         this.guildId = guildId;
         this.id = id;
         this.type = type;
@@ -94,11 +95,11 @@ final class PayloadSlashCommand {
     }
 
     @NotNull
-    public PayloadSlashCommandMember getMember() {
+    public PayloadMember getMember() {
         return member;
     }
 
-    public void setMember(@NotNull PayloadSlashCommandMember member) {
+    public void setMember(@NotNull PayloadMember member) {
         this.member = member;
     }
 

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandData.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandData.java
@@ -1,4 +1,4 @@
-package org.togetherjava.tjbot.jda;
+package org.togetherjava.tjbot.jda.payloads.slashcommand;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.jetbrains.annotations.NotNull;
@@ -8,19 +8,23 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-final class PayloadSlashCommandData {
+public final class PayloadSlashCommandData {
     private String name;
     private String id;
     private int type;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private List<PayloadSlashCommandOption> options;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private PayloadSlashCommandResolved resolved;
 
-    PayloadSlashCommandData(@NotNull String name, @NotNull String id, int type,
-            @Nullable List<PayloadSlashCommandOption> options) {
+    public PayloadSlashCommandData(@NotNull String name, @NotNull String id, int type,
+            @Nullable List<PayloadSlashCommandOption> options,
+            @Nullable PayloadSlashCommandResolved resolved) {
         this.name = name;
         this.id = id;
         this.type = type;
         this.options = options == null ? null : new ArrayList<>(options);
+        this.resolved = resolved;
     }
 
     @NotNull
@@ -49,12 +53,19 @@ final class PayloadSlashCommandData {
         this.type = type;
     }
 
-    @Nullable
-    public List<PayloadSlashCommandOption> getOptions() {
+    public @Nullable List<PayloadSlashCommandOption> getOptions() {
         return options == null ? null : Collections.unmodifiableList(options);
     }
 
     public void setOptions(@Nullable List<PayloadSlashCommandOption> options) {
         this.options = options == null ? null : new ArrayList<>(options);
+    }
+
+    public @Nullable PayloadSlashCommandResolved getResolved() {
+        return resolved;
+    }
+
+    public void setResolved(@Nullable PayloadSlashCommandResolved resolved) {
+        this.resolved = resolved;
     }
 }

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandMembers.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandMembers.java
@@ -1,0 +1,28 @@
+package org.togetherjava.tjbot.jda.payloads.slashcommand;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import org.jetbrains.annotations.NotNull;
+import org.togetherjava.tjbot.jda.payloads.PayloadMember;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class PayloadSlashCommandMembers {
+    private Map<String, PayloadMember> idToMember;
+
+    public PayloadSlashCommandMembers(@NotNull Map<String, PayloadMember> idToMember) {
+        this.idToMember = new HashMap<>(idToMember);
+    }
+
+    @JsonAnyGetter
+    public @NotNull Map<String, PayloadMember> getIdToMember() {
+        return Collections.unmodifiableMap(idToMember);
+    }
+
+    @JsonAnySetter
+    public void setIdToMember(@NotNull Map<String, PayloadMember> idToMember) {
+        this.idToMember = new HashMap<>(idToMember);
+    }
+}

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandOption.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandOption.java
@@ -1,4 +1,4 @@
-package org.togetherjava.tjbot.jda;
+package org.togetherjava.tjbot.jda.payloads.slashcommand;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.jetbrains.annotations.NotNull;
@@ -8,14 +8,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-final class PayloadSlashCommandOption {
+public final class PayloadSlashCommandOption {
     private String name;
     private int type;
     private String value;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private List<PayloadSlashCommandOption> options;
 
-    PayloadSlashCommandOption(@NotNull String name, int type, @Nullable String value,
+    public PayloadSlashCommandOption(@NotNull String name, int type, @Nullable String value,
             @Nullable List<PayloadSlashCommandOption> options) {
         this.name = name;
         this.type = type;

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandResolved.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandResolved.java
@@ -1,0 +1,33 @@
+package org.togetherjava.tjbot.jda.payloads.slashcommand;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.jetbrains.annotations.Nullable;
+
+public final class PayloadSlashCommandResolved {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private PayloadSlashCommandMembers members;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private PayloadSlashCommandUsers users;
+
+    public PayloadSlashCommandResolved(@Nullable PayloadSlashCommandMembers members,
+            @Nullable PayloadSlashCommandUsers users) {
+        this.members = members;
+        this.users = users;
+    }
+
+    public @Nullable PayloadSlashCommandMembers getMembers() {
+        return members;
+    }
+
+    public void setMembers(@Nullable PayloadSlashCommandMembers members) {
+        this.members = members;
+    }
+
+    public @Nullable PayloadSlashCommandUsers getUsers() {
+        return users;
+    }
+
+    public void setUsers(@Nullable PayloadSlashCommandUsers users) {
+        this.users = users;
+    }
+}

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandUsers.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandUsers.java
@@ -1,0 +1,28 @@
+package org.togetherjava.tjbot.jda.payloads.slashcommand;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import org.jetbrains.annotations.NotNull;
+import org.togetherjava.tjbot.jda.payloads.PayloadUser;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class PayloadSlashCommandUsers {
+    private Map<String, PayloadUser> idToUser;
+
+    public PayloadSlashCommandUsers(@NotNull Map<String, PayloadUser> idToUser) {
+        this.idToUser = new HashMap<>(idToUser);
+    }
+
+    @JsonAnyGetter
+    public @NotNull Map<String, PayloadUser> getIdToUser() {
+        return Collections.unmodifiableMap(idToUser);
+    }
+
+    @JsonAnySetter
+    public void setIdToUser(@NotNull Map<String, PayloadUser> idToUser) {
+        this.idToUser = new HashMap<>(idToUser);
+    }
+}

--- a/application/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/application/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/database/src/main/java/org/togetherjava/tjbot/db/Database.java
+++ b/database/src/main/java/org/togetherjava/tjbot/db/Database.java
@@ -3,6 +3,7 @@ package org.togetherjava.tjbot.db;
 import org.flywaydb.core.Flyway;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
+import org.jooq.Table;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
 import org.sqlite.SQLiteConfig;
@@ -51,6 +52,22 @@ public final class Database {
         flyway.migrate();
 
         dslContext = DSL.using(dataSource.getConnection(), SQLDialect.SQLITE);
+    }
+
+    /**
+     * Creates a new empty database that is hold in memory.
+     *
+     * @param tables the tables the database will hold if desired, otherwise null
+     * @return the created database
+     */
+    public static Database createMemoryDatabase(Table<?>... tables) {
+        try {
+            Database database = new Database("jdbc:sqlite:");
+            database.write(context -> context.ddl(tables).executeBatch());
+            return database;
+        } catch (SQLException e) {
+            throw new DatabaseException(e);
+        }
     }
 
     /**


### PR DESCRIPTION
### Overview

Implements and closes #213 . Adds unit tests to the tag system, i.e.
* `TagSystem`,
* `TagCommand`,
* `TagsCommand` and
* `TagManageCommand`.

The tests themselves should be rather self-explanatory.

Majority of changes in this PR are not logic changes but come from the fact that we made `Config` mockable, and hence had to get rid of the **singleton** - which bleeds into almost all commands.

### Features

While at it, we had to implement multiple more general features from which other unit tests will also benefit in the future:

#### Database

We added a method `Database.createMemoryDatabase(...)` to conveniently use an in-memory database for testing. An usage can be seen in `TagsCommandTest`, where it is called `@Before` each test.

#### Mockito

The whole mockito test suite, in particular revolving around `JdaTester` has been enhanced and generally supports more calls now.

And we also added some bigger features to it:

##### Button events

In order to test button events, we added a `JdaTester#createButtonClickEvent()` method that returns a builder that can create mocks of the event, similar to how `JdaTester#createSlashCommandEvent(...)` works.

The API of this builder is very similar to JDAs `Method` interface and similar:
```java
// Default message with a delete button
jdaTester.createButtonClickEvent()
  .actionRows(ActionRow.of(Button.of(ButtonStyle.DANGER, "1", "Delete"))
  .buildWithSingleButton();
```
or
```java
// More complex message with a user who clicked the button that is not the message author and multiple buttons
Button clickedButton = Button.of(ButtonStyle.PRIMARY, "1", "Next");

jdaTester.createButtonClickEvent()
  .message(new MessageBuilder()
    .setContent("See the following entry")
    .setEmbeds(
      new EmbedBuilder()
        .setDescription("John")
        .build())
  .build())
  .userWhoClicked(jdaTester.createMemberSpy(5))
  .actionRows(
    ActionRow.of(Button.of(ButtonStyle.PRIMARY, "1", "PREVIOUS"),
    clickedButton)
  .build(clickedButton);
```

##### Command spies

There is now a method `JdaTester#spySlashCommand(command)` that makes it possible to work with a command that is spied upon and additionally is setup properly. For example, it works with a mocked component ID generator.

##### Member spies

We also added a method `JdaTester#createMemberSpy(userId)` that is able to create valid member instances which are spied upon. Useful for testing things that require members. For example buttons that have been clicked by a user different to the message author.

##### USER option for slash command events

We enhanced the `SlashCommandEventBuilder` and added overloads `option(String, User)` and `option(String, Member)`.

So now it also supports options with types `USER`, not just `String`. For example:
```java
Member member = jdaTester.createMemberSpy(1);

var event = jdaTester.createSlashCommandEvent(command)
  .option("id", "foo");
  .option("reply-to", member)
  .build();
```

To make this work, the implementation had to be changed a bit. Therefore, other types can now also easily be added in the future.

##### Setting the user who triggered a slash command event

The `SlashCommandEventBuilder` now has a method `userWhoTriggered(user)` that can be used to set the member who triggered the event. Useful for mocking, for example to adjust permissions of a user who wants to use the ban command.

##### `RestAction` mocking

`JdaTester` now has two methods to create **success** and **failure** mocks of `RestAction`s. This can be very useful when testing stuff that involves calls such as `TextChannel#retrieveMessageById` or similar. Example:
```java
var jdaTester = new JdaTester();

var message = new MessageBuilder("Hello World!").build();
var action = jdaTester.createSucceededActionMock(message);

doReturn(action).when(jdaTester.getTextChannelSpy()).retrieveMessageById("1");
```
or also
```java
var jdaTester = new JdaTester();

var reason = new FooException();
var action = jdaTester.createFailedActionMock(reason);

doReturn(action).when(jdaTester.getTextChannelSpy()).retrieveMessageById("1");
```

### Checklist

Unit tests
* [x] TagSystem
* [x] TagsCommand
* [x] TagCommand
* [x] TagManageCommand - raw
* [x] TagManageCommand - create
* [x] TagManageCommand - create-with-message
* [x] TagManageCommand - edit
* [x] TagManageCommand - edit-with-message
* [x] TagManageCommand - delete

Mocking
* [x] spySlashCommand
* [x] createButtonClickEvent
* [x] add `USER` as option to `SlashCommandEventBuilder`
* [x] `userWhoTriggered(user)` for `SlashCommandEventBuilder`
* [x] `Config.getInstance()` mocking
* [x] `RestAction<T>` mocking (success & failure)
* [x] Discord API exception mocking