### PR TITLE
Fixed broken encoding for unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,8 +51,7 @@ subprojects {
         }
     }
 
-
-    compileJava {
+    def compileTasks = {
         options.encoding = 'UTF-8'
 
         // Makes spotlessApply task run on every compile/build.
@@ -63,16 +62,8 @@ subprojects {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    compileTestJava {
-        options.encoding = 'UTF-8'
-
-        // Makes spotlessApply task run on every compile/build.
-        dependsOn 'spotlessApply'
-
-        // Nails the Java-Version of every Subproject
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
+    compileJava(compileTasks)
+    compileTestJava(compileTasks)
 
     spotless {
         java {


### PR DESCRIPTION
### Overview

Apparently the previous setup didnt work and unit tests have been executed on the wrong encoding.

Resulting in minor issues, such as unicode usage inside tests not working as expected. For example the following test fails:
```java
assertEquals("\u2022 foo", "• foo");
```
> expected: <• foo> but was: <â€¢ foo>
> Expected :• foo
> Actual   :â€¢ foo

This fixes the issue.