### PR TITLE
Temp revocation should use opposing type

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryModerationRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryModerationRoutine.java
@@ -125,12 +125,13 @@ public final class TemporaryModerationRoutine implements Routine {
             @NotNull ModerationAction actionType) {
         logger.info("Revoked temporary action {} against user '{}' ({}).", actionType,
                 target.getAsTag(), target.getId());
+        RevocableModerationAction action = getRevocableActionByType(actionType);
 
         String reason = "Automatic revocation of temporary action.";
         actionsStore.addAction(guild.getIdLong(), jda.getSelfUser().getIdLong(), target.getIdLong(),
-                actionType, null, reason);
+                action.getRevokeType(), null, reason);
 
-        return getRevocableActionByType(actionType).revokeAction(guild, target, reason);
+        return action.revokeAction(guild, target, reason);
     }
 
     private void handleFailure(@NotNull Throwable failure,


### PR DESCRIPTION
### Overview

Fixes and closes #371.

Revocations of temporary moderation actions (such as temp bans) have to be logged with the opposing action type (unban) in the `/audit` command:

![audit example](https://i.imgur.com/aOU5f3d.png)

### Details

The relevant section in the code is `TemporaryModerationRoutine.java#130`:
```java
actionsStore.addAction(
  guild.getIdLong(),
  jda.getSelfUser().getIdLong(),
  target.getIdLong(),
  actionType, // <--- should be UNBAN not BAN
  null,
  reason);
```
The opposing type information already exists and can be grabbed from the `RevocableModerationAction` computed in the next line, such as:
```java
var action = getRevocableActionByType(actionType);
var opposingType = action.getRevokeType();
...
```

So we just moved the line above and use the `getRevokeType()` instead now.