### PR TITLE
Up- and down-voting on suggestions

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -16,5 +16,6 @@
                   ]
         }
    ],
-   "helpChannelPattern": "([a-zA-Z_]+_)?help(_\\d+)?"
+   "helpChannelPattern": "([a-zA-Z_]+_)?help(_\\d+)?",
+   "suggestionChannelPattern": "tj_suggestions"
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
@@ -4,6 +4,7 @@ import net.dv8tion.jda.api.JDA;
 import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.basic.PingCommand;
 import org.togetherjava.tjbot.commands.basic.RoleSelectCommand;
+import org.togetherjava.tjbot.commands.basic.SuggestionsUpDownVoter;
 import org.togetherjava.tjbot.commands.basic.VcActivityCommand;
 import org.togetherjava.tjbot.commands.free.FreeCommand;
 import org.togetherjava.tjbot.commands.mathcommands.TeXCommand;
@@ -63,6 +64,7 @@ public enum Features {
 
         // Message receivers
         features.add(new TopHelpersMessageListener(database, config));
+        features.add(new SuggestionsUpDownVoter(config));
 
         // Event receivers
         features.add(new RejoinMuteListener(actionsStore, config));

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/SuggestionsUpDownVoter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/SuggestionsUpDownVoter.java
@@ -1,0 +1,33 @@
+package org.togetherjava.tjbot.commands.basic;
+
+import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
+import org.jetbrains.annotations.NotNull;
+import org.togetherjava.tjbot.commands.MessageReceiverAdapter;
+import org.togetherjava.tjbot.config.Config;
+
+import java.util.regex.Pattern;
+
+/**
+ * Listener that receives all sent messages from suggestion channels and reacts with an up- and
+ * down-vote on them to indicate to users that they can vote on the suggestion.
+ */
+public final class SuggestionsUpDownVoter extends MessageReceiverAdapter {
+    /**
+     * Creates a new listener to receive all message sent in suggestion channels.
+     *
+     * @param config the config to use for this
+     */
+    public SuggestionsUpDownVoter(@NotNull Config config) {
+        super(Pattern.compile(config.getSuggestionChannelPattern()));
+    }
+
+    @Override
+    public void onMessageReceived(@NotNull GuildMessageReceivedEvent event) {
+        if (event.getAuthor().isBot() || event.isWebhookMessage()) {
+            return;
+        }
+
+        event.getMessage().addReaction("👍").queue();
+        event.getMessage().addReaction("👎").queue();
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -27,6 +27,7 @@ public final class Config {
     private final String tagManageRolePattern;
     private final List<FreeCommandConfig> freeCommand;
     private final String helpChannelPattern;
+    private final String suggestionChannelPattern;
 
     @SuppressWarnings("ConstructorWithTooManyParameters")
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
@@ -40,7 +41,8 @@ public final class Config {
             @JsonProperty("softModerationRolePattern") String softModerationRolePattern,
             @JsonProperty("tagManageRolePattern") String tagManageRolePattern,
             @JsonProperty("freeCommand") List<FreeCommandConfig> freeCommand,
-            @JsonProperty("helpChannelPattern") String helpChannelPattern) {
+            @JsonProperty("helpChannelPattern") String helpChannelPattern,
+            @JsonProperty("suggestionChannelPattern") String suggestionChannelPattern) {
         this.token = token;
         this.databasePath = databasePath;
         this.projectWebsite = projectWebsite;
@@ -52,6 +54,7 @@ public final class Config {
         this.tagManageRolePattern = tagManageRolePattern;
         this.freeCommand = Collections.unmodifiableList(freeCommand);
         this.helpChannelPattern = helpChannelPattern;
+        this.suggestionChannelPattern = suggestionChannelPattern;
     }
 
     /**
@@ -169,5 +172,14 @@ public final class Config {
      */
     public String getHelpChannelPattern() {
         return helpChannelPattern;
+    }
+
+    /**
+     * Gets the REGEX pattern used to identify channels that are used for sending suggestions.
+     *
+     * @return the channel name pattern
+     */
+    public String getSuggestionChannelPattern() {
+        return suggestionChannelPattern;
     }
 }


### PR DESCRIPTION
### Overview

Implements and closes #375. Added a message listener `SuggestionsUpDownVoter` which listens to all messages in **suggestion channels** (config) and reacts with an up- and down-vote to them:

![example](https://i.imgur.com/WdaAYeQ.png)

The code for that is pretty trivial actually.

### Config

The config had to be adjusted for this, please add the following (see the adjusted `config.json.template`):
```json
"suggestionChannelPattern": "tj_suggestions"
```