### PR TITLE
Utility for in-app URL's

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
@@ -2,10 +2,7 @@ package org.togetherjava.tjbot.commands;
 
 import net.dv8tion.jda.api.JDA;
 import org.jetbrains.annotations.NotNull;
-import org.togetherjava.tjbot.commands.basic.PingCommand;
-import org.togetherjava.tjbot.commands.basic.RoleSelectCommand;
-import org.togetherjava.tjbot.commands.basic.SuggestionsUpDownVoter;
-import org.togetherjava.tjbot.commands.basic.VcActivityCommand;
+import org.togetherjava.tjbot.commands.basic.*;
 import org.togetherjava.tjbot.commands.free.FreeCommand;
 import org.togetherjava.tjbot.commands.mathcommands.TeXCommand;
 import org.togetherjava.tjbot.commands.moderation.*;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/DiscordClientAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/DiscordClientAction.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 
 /**
  * Class which contains all actions a Discord client accepts.
- *
+ * <p>
  * This allows you to open DM's {@link Channels#DM_CHANNEL}, specific settings
  * {@link Settings.App#VOICE} and much more.
  *
@@ -19,6 +19,25 @@ import java.util.regex.Pattern;
  * <li>iOS and Android are NOT supported</li>
  * <li>It opens the LAST installed Discord version (Discord, Canary, PTB)</li>
  * </ul>
+ *
+ * <p>
+ * Example:
+ *
+ * <pre>
+ * <code>
+ * event.reply("Open Discord's secret home page!")
+ *      .addActionRow(DiscordClientAction.Guild.GUILD_HOME_CHANNEL.asLinkButton("Open home page!", event.getGuild().getId())
+ * </code>
+ * </pre>
+ *
+ * To improve readability, one might want to use a static import like:
+ *
+ * <pre>
+ * <code>
+ * event.reply(whoIsCommandOutput)
+ *      .addActionRow(USER.asLinkButton("Open home page!", target.getId())
+ * </code>
+ * </pre>
  */
 public class DiscordClientAction {
 
@@ -58,13 +77,17 @@ public class DiscordClientAction {
         public static final DiscordClientAction GUILDS_CREATE =
                 new DiscordClientAction("discord://-/guilds/create");
 
-        /** Beta Discord feature */
-        public static final DiscordClientAction GUILD_HOME_CHANNEL =
-                new DiscordClientAction("discord://-/channels/{GUILD-ID}/@home");
+
         public static final DiscordClientAction GUILD_EVENT =
                 new DiscordClientAction("discord://-/events/{GUILD-ID}/{EVENT-ID}");
         public static final DiscordClientAction GUILD_MEMBERSHIP_SCREENING =
                 new DiscordClientAction("discord://-/member-verification/{GUILD-ID}");
+
+        /**
+         * Beta Discord feature
+         */
+        public static final DiscordClientAction GUILD_HOME_CHANNEL =
+                new DiscordClientAction("discord://-/channels/{GUILD-ID}/@home");
     }
 
     /**
@@ -135,11 +158,15 @@ public class DiscordClientAction {
             public static final DiscordClientAction LOCALE =
                     new DiscordClientAction("discord://-/settings/locale");
 
-            /** @see #LINUX */
+            /**
+             * @see #LINUX
+             */
             public static final DiscordClientAction WINDOWS =
                     new DiscordClientAction("discord://-/settings/windows");
 
-            /** @see #WINDOWS */
+            /**
+             * @see #WINDOWS
+             */
             public static final DiscordClientAction LINUX =
                     new DiscordClientAction("discord://-/settings/linux");
 
@@ -195,7 +222,6 @@ public class DiscordClientAction {
      * argument is lacking.
      *
      * @return A {@link String} of the URL
-     *
      * @see #formatUrl(String...)
      */
     public String getRawUrl() {
@@ -206,9 +232,7 @@ public class DiscordClientAction {
      * Format's the URL with the given arguments.
      *
      * @param arguments An array of the arguments this action requires
-     *
      * @return The formatted URL as an {@link String}
-     *
      * @throws IllegalArgumentException When missing arguments
      */
     public String formatUrl(String @NotNull... arguments) {
@@ -231,9 +255,7 @@ public class DiscordClientAction {
      * @param label The label of the button, see {@link Button#link(String, String)} for the
      *        requirements
      * @param arguments An array of the arguments this action requires
-     *
      * @return A {@link Button} of {@link ButtonStyle#LINK} with the given label
-     *
      * @throws IllegalArgumentException When missing arguments
      */
     public Button asLinkButton(@NotNull String label, String... arguments) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/DiscordClientAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/DiscordClientAction.java
@@ -39,12 +39,14 @@ import java.util.regex.Pattern;
  * </code>
  * </pre>
  */
-public class DiscordClientAction {
+public final class DiscordClientAction {
 
     /**
      * Contains some of the more general actions
      */
-    public static class General {
+    public enum General {
+        ;
+
         public static final DiscordClientAction HOME = new DiscordClientAction("discord://-/");
         public static final DiscordClientAction FRIENDS = new DiscordClientAction("discord://-/");
 
@@ -66,7 +68,10 @@ public class DiscordClientAction {
     /**
      * Contains guild specific actions
      */
-    public static class Guild {
+    public enum Guild {
+        ;
+
+        @SuppressWarnings("squid:S1700")
         public static final DiscordClientAction GUILD =
                 new DiscordClientAction("discord://-/channels/{GUILD-ID}");
         public static final DiscordClientAction GUILD_CHANNEL =
@@ -93,7 +98,9 @@ public class DiscordClientAction {
     /**
      * Contains actions related to channels
      */
-    public static class Channels {
+    public enum Channels {
+        ;
+
         public static final DiscordClientAction DM_CHANNEL =
                 new DiscordClientAction("discord://-/channels/@me/{CHANNEL-ID}");
         public static final DiscordClientAction DM_CHANNEL_MESSAGE =
@@ -107,12 +114,21 @@ public class DiscordClientAction {
     /**
      * Contains actions related to the settings menu
      */
-    public static class Settings {
+    /*
+     * The warning is about this inner class being too long, and that it should be external This
+     * won't become an external class since it makes no sense for the design, and it requires the
+     * developer to remember all classes.
+     */
+    @SuppressWarnings("squid:S2972")
+    public enum Settings {
+        ;
 
         /**
          * Contains all user settings
          */
-        public static class User {
+        public enum User {
+            ;
+
             public static final DiscordClientAction ACCOUNT =
                     new DiscordClientAction("discord://-/settings/account");
             public static final DiscordClientAction PROFILE_CUSTOMIZATION =
@@ -128,7 +144,9 @@ public class DiscordClientAction {
         /**
          * Contains all payment settings
          */
-        public static class Payment {
+        public enum Payment {
+            ;
+
             public static final DiscordClientAction PREMIUM =
                     new DiscordClientAction("discord://-/settings/premium");
             public static final DiscordClientAction SUBSCRIPTIONS =
@@ -142,7 +160,9 @@ public class DiscordClientAction {
         /**
          * Contains all app settings
          */
-        public static class App {
+        public enum App {
+            ;
+
             public static final DiscordClientAction APPEARANCE =
                     new DiscordClientAction("discord://-/settings/appearance");
             public static final DiscordClientAction ACCESSIBILITY =
@@ -179,7 +199,9 @@ public class DiscordClientAction {
         /**
          * Contains some of the more general settings
          */
-        public static class General {
+        public enum General {
+            ;
+
             public static final DiscordClientAction ACTIVITY_STATUS =
                     new DiscordClientAction("discord://-/settings/activity-status");
             public static final DiscordClientAction ACTIVITY_OVERLAY =
@@ -191,7 +213,9 @@ public class DiscordClientAction {
         }
     }
 
-    public static class Library {
+    public enum Library {
+        ;
+
         public static final DiscordClientAction LIBRARY_GAMES =
                 new DiscordClientAction("discord://-/library");
         public static final DiscordClientAction LIBRARY_SETTINGS =
@@ -204,13 +228,15 @@ public class DiscordClientAction {
                 new DiscordClientAction("discord://-/store/applications/{APPLICATION-ID}");
     }
 
-    /* pattern for the arguments, finds everything within {} */
-    public final static Pattern argumentPattern = Pattern.compile("\\{[^}]*}");
+    /**
+     * Pattern for the arguments, finds everything within brackets
+     */
+    public static final Pattern argumentPattern = Pattern.compile("\\{[^}]*}");
 
     private final String url;
 
     @Contract(pure = true)
-    private DiscordClientAction(String url) {
+    private DiscordClientAction(final String url) {
         this.url = url;
     }
 
@@ -235,10 +261,10 @@ public class DiscordClientAction {
      * @return The formatted URL as an {@link String}
      * @throws IllegalArgumentException When missing arguments
      */
-    public String formatUrl(String @NotNull... arguments) {
+    public String formatUrl(final String @NotNull... arguments) {
         String localUrl = url;
 
-        for (String argument : arguments) {
+        for (final String argument : arguments) {
             localUrl = argumentPattern.matcher(localUrl).replaceFirst(argument);
         }
 
@@ -258,7 +284,12 @@ public class DiscordClientAction {
      * @return A {@link Button} of {@link ButtonStyle#LINK} with the given label
      * @throws IllegalArgumentException When missing arguments
      */
-    public Button asLinkButton(@NotNull String label, String... arguments) {
+    public Button asLinkButton(@NotNull final String label, final String... arguments) {
         return Button.link(formatUrl(arguments), label);
+    }
+
+    @Override
+    public String toString() {
+        return "DiscordClientAction{" + "url='" + url + '\'' + '}';
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/DiscordClientAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/DiscordClientAction.java
@@ -1,0 +1,242 @@
+package org.togetherjava.tjbot.commands.utils;
+
+import net.dv8tion.jda.api.interactions.components.Button;
+import net.dv8tion.jda.api.interactions.components.ButtonStyle;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Pattern;
+
+/**
+ * Class which contains all actions a Discord client accepts.
+ *
+ * This allows you to open DM's {@link Channels#DM_CHANNEL}, specific settings
+ * {@link Settings.App#VOICE} and much more.
+ *
+ * <p>
+ * A few notes;
+ * <ul>
+ * <li>iOS and Android are NOT supported</li>
+ * <li>It opens the LAST installed Discord version (Discord, Canary, PTB)</li>
+ * </ul>
+ */
+public class DiscordClientAction {
+
+    /**
+     * Contains some of the more general actions
+     */
+    public static class General {
+        public static final DiscordClientAction HOME = new DiscordClientAction("discord://-/");
+        public static final DiscordClientAction FRIENDS = new DiscordClientAction("discord://-/");
+
+        public static final DiscordClientAction USER =
+                new DiscordClientAction("discord://-/users/{USER-ID}");
+        public static final DiscordClientAction JOIN_INVITE =
+                new DiscordClientAction("discord://-/invite/{INVITE-CODE}");
+        public static final DiscordClientAction HUB_MEMBERSHIP_SCREENING =
+                new DiscordClientAction("discord://-/member-verification-for-hub/{HUB-ID}");
+        public static final DiscordClientAction STORE =
+                new DiscordClientAction("discord://-/store");
+
+        public static final DiscordClientAction HYPESQUAD =
+                new DiscordClientAction("discord://-/settings/hypesquad_online");
+        public static final DiscordClientAction CHANGELOGS =
+                new DiscordClientAction("discord://-/settings/changelogs");
+    }
+
+    /**
+     * Contains guild specific actions
+     */
+    public static class Guild {
+        public static final DiscordClientAction GUILD =
+                new DiscordClientAction("discord://-/channels/{GUILD-ID}");
+        public static final DiscordClientAction GUILD_CHANNEL =
+                new DiscordClientAction("discord://-/channels/{GUILD-ID}/{CHANNEL-ID}");
+
+        public static final DiscordClientAction GUILD_DISCOVERY =
+                new DiscordClientAction("discord://-/guild-discovery");
+        public static final DiscordClientAction GUILDS_CREATE =
+                new DiscordClientAction("discord://-/guilds/create");
+
+        /** Beta Discord feature */
+        public static final DiscordClientAction GUILD_HOME_CHANNEL =
+                new DiscordClientAction("discord://-/channels/{GUILD-ID}/@home");
+        public static final DiscordClientAction GUILD_EVENT =
+                new DiscordClientAction("discord://-/events/{GUILD-ID}/{EVENT-ID}");
+        public static final DiscordClientAction GUILD_MEMBERSHIP_SCREENING =
+                new DiscordClientAction("discord://-/member-verification/{GUILD-ID}");
+    }
+
+    /**
+     * Contains actions related to channels
+     */
+    public static class Channels {
+        public static final DiscordClientAction DM_CHANNEL =
+                new DiscordClientAction("discord://-/channels/@me/{CHANNEL-ID}");
+        public static final DiscordClientAction DM_CHANNEL_MESSAGE =
+                new DiscordClientAction("discord://-/channels/@me/{CHANNEL-ID}/{MESSAGE-ID}");
+        public static final DiscordClientAction GUILD_CHANNEL =
+                new DiscordClientAction("discord://-/channels/{GUILD-ID}/{CHANNEL-ID}");
+        public static final DiscordClientAction GUILD_CHANNEL_MESSAGE = new DiscordClientAction(
+                "discord://-/channels/{GUILD-ID}/{CHANNEL-ID}/{MESSAGE-ID}");
+    }
+
+    /**
+     * Contains actions related to the settings menu
+     */
+    public static class Settings {
+
+        /**
+         * Contains all user settings
+         */
+        public static class User {
+            public static final DiscordClientAction ACCOUNT =
+                    new DiscordClientAction("discord://-/settings/account");
+            public static final DiscordClientAction PROFILE_CUSTOMIZATION =
+                    new DiscordClientAction("discord://-/settings/profile-customization");
+            public static final DiscordClientAction PRIVACY_AND_SAFETY =
+                    new DiscordClientAction("discord://-/settings/privacy-and-safety");
+            public static final DiscordClientAction AUTHORIZED_APPS =
+                    new DiscordClientAction("discord://-/settings/authorized-apps");
+            public static final DiscordClientAction CONNECTIONS =
+                    new DiscordClientAction("discord://-/settings/connections");
+        }
+
+        /**
+         * Contains all payment settings
+         */
+        public static class Payment {
+            public static final DiscordClientAction PREMIUM =
+                    new DiscordClientAction("discord://-/settings/premium");
+            public static final DiscordClientAction SUBSCRIPTIONS =
+                    new DiscordClientAction("discord://-/settings/subscriptions");
+            public static final DiscordClientAction INVENTORY =
+                    new DiscordClientAction("discord://-/settings/inventory");
+            public static final DiscordClientAction BILLING =
+                    new DiscordClientAction("discord://-/settings/billing");
+        }
+
+        /**
+         * Contains all app settings
+         */
+        public static class App {
+            public static final DiscordClientAction APPEARANCE =
+                    new DiscordClientAction("discord://-/settings/appearance");
+            public static final DiscordClientAction ACCESSIBILITY =
+                    new DiscordClientAction("discord://-/settings/accessibility");
+            public static final DiscordClientAction VOICE =
+                    new DiscordClientAction("discord://-/settings/voice");
+            public static final DiscordClientAction TEXT =
+                    new DiscordClientAction("discord://-/settings/text");
+            public static final DiscordClientAction NOTIFICATIONS =
+                    new DiscordClientAction("discord://-/settings/notifications");
+            public static final DiscordClientAction KEYBINDS =
+                    new DiscordClientAction("discord://-/settings/keybinds");
+            public static final DiscordClientAction LOCALE =
+                    new DiscordClientAction("discord://-/settings/locale");
+
+            /** @see #LINUX */
+            public static final DiscordClientAction WINDOWS =
+                    new DiscordClientAction("discord://-/settings/windows");
+
+            /** @see #WINDOWS */
+            public static final DiscordClientAction LINUX =
+                    new DiscordClientAction("discord://-/settings/linux");
+
+            public static final DiscordClientAction STREAMER_MODE =
+                    new DiscordClientAction("discord://-/settings/streamer-mode");
+            public static final DiscordClientAction ADVANCED =
+                    new DiscordClientAction("discord://-/settings/advanced");
+        }
+
+        /**
+         * Contains some of the more general settings
+         */
+        public static class General {
+            public static final DiscordClientAction ACTIVITY_STATUS =
+                    new DiscordClientAction("discord://-/settings/activity-status");
+            public static final DiscordClientAction ACTIVITY_OVERLAY =
+                    new DiscordClientAction("discord://-/settings/overlay");
+            public static final DiscordClientAction HYPESQUAD =
+                    new DiscordClientAction("discord://-/settings/hypesquad_online");
+            public static final DiscordClientAction CHANGELOGS =
+                    new DiscordClientAction("discord://-/settings/changelogs");
+        }
+    }
+
+    public static class Library {
+        public static final DiscordClientAction LIBRARY_GAMES =
+                new DiscordClientAction("discord://-/library");
+        public static final DiscordClientAction LIBRARY_SETTINGS =
+                new DiscordClientAction("discord://-/library/settings");
+        public static final DiscordClientAction LIBRARY_ITEM_ACTION =
+                new DiscordClientAction("discord://-/library/{SKU-ID}/LAUNCH");
+        public static final DiscordClientAction SKU_STORE_PAGE =
+                new DiscordClientAction("discord://-/store/skus/{SKU-ID}");
+        public static final DiscordClientAction APPLICATION_STORE_PAGE =
+                new DiscordClientAction("discord://-/store/applications/{APPLICATION-ID}");
+    }
+
+    /* pattern for the arguments, finds everything within {} */
+    public final static Pattern argumentPattern = Pattern.compile("\\{[^}]*}");
+
+    private final String url;
+
+    @Contract(pure = true)
+    private DiscordClientAction(String url) {
+        this.url = url;
+    }
+
+    /**
+     * The raw URL without any arguments.
+     *
+     * <p>
+     * Most likely you should use {@link #formatUrl(String...)} instead, that one throws when an
+     * argument is lacking.
+     *
+     * @return A {@link String} of the URL
+     *
+     * @see #formatUrl(String...)
+     */
+    public String getRawUrl() {
+        return url;
+    }
+
+    /**
+     * Format's the URL with the given arguments.
+     *
+     * @param arguments An array of the arguments this action requires
+     *
+     * @return The formatted URL as an {@link String}
+     *
+     * @throws IllegalArgumentException When missing arguments
+     */
+    public String formatUrl(String @NotNull... arguments) {
+        String localUrl = url;
+
+        for (String argument : arguments) {
+            localUrl = argumentPattern.matcher(localUrl).replaceFirst(argument);
+        }
+
+        if (argumentPattern.matcher(localUrl).find()) {
+            throw new IllegalArgumentException("Missing arguments for URL " + localUrl + "!");
+        }
+
+        return localUrl;
+    }
+
+    /**
+     * Format's the action as a link button.
+     *
+     * @param label The label of the button, see {@link Button#link(String, String)} for the
+     *        requirements
+     * @param arguments An array of the arguments this action requires
+     *
+     * @return A {@link Button} of {@link ButtonStyle#LINK} with the given label
+     *
+     * @throws IllegalArgumentException When missing arguments
+     */
+    public Button asLinkButton(@NotNull String label, String... arguments) {
+        return Button.link(formatUrl(arguments), label);
+    }
+}


### PR DESCRIPTION
This implements a class which eases the developer to generate URL's to items within the Discord app.

A feature should **NOT** rely on this class, Discord can change something anytime, and iOS + Android aren't supported. They're there to enhance the functionality without making it worse.

If anyone has ideas for screens I could look at to find or there's URL(s) for, you can always send a message and I'll take a look or I can find anything.


Closes #387 