### PR TITLE
Adding Tex Inline support for the issue #386

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/TeXCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/TeXCommand.java
@@ -6,6 +6,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.components.Button;
 import net.dv8tion.jda.api.interactions.components.ButtonStyle;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.scilab.forge.jlatexmath.ParseException;
 import org.scilab.forge.jlatexmath.TeXConstants;
 import org.scilab.forge.jlatexmath.TeXFormula;
@@ -21,6 +22,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Implementation of a tex command which takes a string and renders an image corresponding to the
@@ -34,6 +37,11 @@ import java.util.Objects;
 public class TeXCommand extends SlashCommandAdapter {
 
     private static final String LATEX_OPTION = "latex";
+    // Matches regions between two dollars, like '$foo$'.
+    private static final String MATH_REGION = "(\\$[^$]+\\$)";
+    private static final String TEXT_REGION = "([^$]+)";
+    private static final Pattern INLINE_LATEX_REPLACEMENT =
+            Pattern.compile(MATH_REGION + "|" + TEXT_REGION);
     private static final String RENDERING_ERROR = "There was an error generating the image";
     private static final float DEFAULT_IMAGE_SIZE = 40F;
     private static final Color BACKGROUND_COLOR = Color.decode("#36393F");
@@ -44,8 +52,7 @@ public class TeXCommand extends SlashCommandAdapter {
      * Creates a new Instance.
      */
     public TeXCommand() {
-        super("tex",
-                "This command accepts a latex expression and generates an image corresponding to it.",
+        super("tex", "Renders LaTeX, also supports inline $-regions like 'see this $frac[x}{2}$'.",
                 SlashCommandVisibility.GUILD);
         getData().addOption(OptionType.STRING, LATEX_OPTION,
                 "The latex which is rendered as an image", true);
@@ -57,6 +64,9 @@ public class TeXCommand extends SlashCommandAdapter {
         String userID = (Objects.requireNonNull(event.getMember()).getId());
         TeXFormula formula;
         try {
+            if (latex.contains("$")) {
+                latex = convertInlineLatexToFull(latex);
+            }
             formula = new TeXFormula(latex);
         } catch (ParseException e) {
             event.reply("That is an invalid latex: " + e.getMessage()).setEphemeral(true).queue();
@@ -90,6 +100,35 @@ public class TeXCommand extends SlashCommandAdapter {
             .editOriginal(renderedTextImageStream.toByteArray(), "tex.png")
             .setActionRow(Button.of(ButtonStyle.DANGER, generateComponentId(userID), "Delete"))
             .queue();
+    }
+
+    /**
+     *
+     * Converts inline latex like: {@code hello $\frac{x}{2}$ world} to full latex
+     * {@code \text{hello}\frac{x}{2}\text{ world}}.
+     *
+     */
+    @NotNull
+    private String convertInlineLatexToFull(@NotNull String latex) {
+        if (isInvalidInlineFormat(latex)) {
+            throw new ParseException("One dollar sign is invalid, wrap whole expression with it. ");
+        }
+        Matcher matcher = INLINE_LATEX_REPLACEMENT.matcher(latex);
+        StringBuilder sb = new StringBuilder();
+        while (matcher.find()) {
+            boolean isInsideMathRegion = matcher.group(1) != null;
+            if (isInsideMathRegion) {
+                sb.append(matcher.group(1).replace("$", ""));
+            } else {
+                sb.append("\\text{").append(matcher.group(2)).append("}");
+            }
+        }
+
+        return sb.toString();
+    }
+
+    private boolean isInvalidInlineFormat(String latex) {
+        return latex.chars().filter(ch -> ch == '$').count() % 2 == 1;
     }
 
     @Override


### PR DESCRIPTION

How it looks like 
![image](https://user-images.githubusercontent.com/58050604/155294387-82276398-5e0a-431d-9856-86537815e517.png)

The inputs
`A$B$C`
`$Hello$, look at this $\frac{x}{2}$, nice stuff!`
The Outputs
`\text{A}B\text{C}`
`Hello\text{, look at this }\frac{x}{2}\text{, nice stuff!}`