### PR TITLE
Too many roles bugfix role-select

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -39,6 +39,8 @@ shadowJar {
 }
 
 dependencies {
+    implementation 'org.jetbrains:annotations:23.0.0'
+
     implementation project(':database')
 
     implementation 'net.dv8tion:JDA:5.0.0-alpha.9'

--- a/application/src/main/java/org/togetherjava/tjbot/commands/SlashCommandAdapter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/SlashCommandAdapter.java
@@ -6,8 +6,8 @@ import net.dv8tion.jda.api.events.interaction.component.SelectMenuInteractionEve
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
-import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Range;
 import org.jetbrains.annotations.Unmodifiable;
@@ -18,7 +18,7 @@ import org.togetherjava.tjbot.commands.componentids.Lifespan;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /**
  * Adapter implementation of a {@link SlashCommand}. The minimal setup only requires implementation
@@ -179,10 +179,11 @@ public abstract class SlashCommandAdapter implements SlashCommand {
     @Unmodifiable
     protected static @NotNull List<OptionData> generateOptionalVarArgList(
             final @NotNull OptionData optionData, @Range(from = 1, to = 25) final int amount) {
+        // Copy is immutable and explicitly optional, even if the parent option is required
         OptionData varArgOption = new OptionData(optionData.getType(), optionData.getName(),
                 optionData.getDescription());
 
-        return IntStream.range(0, amount).mapToObj(i -> varArgOption).toList();
+        return Stream.generate(() -> varArgOption).limit(amount).toList();
     }
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/commands/SlashCommandAdapter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/SlashCommandAdapter.java
@@ -6,14 +6,18 @@ import net.dv8tion.jda.api.events.interaction.component.SelectMenuInteractionEve
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Range;
+import org.jetbrains.annotations.Unmodifiable;
 import org.togetherjava.tjbot.commands.componentids.ComponentId;
 import org.togetherjava.tjbot.commands.componentids.ComponentIdGenerator;
 import org.togetherjava.tjbot.commands.componentids.Lifespan;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Adapter implementation of a {@link SlashCommand}. The minimal setup only requires implementation
@@ -156,5 +160,47 @@ public abstract class SlashCommandAdapter implements SlashCommand {
             @NotNull String... args) {
         return Objects.requireNonNull(componentIdGenerator)
             .generate(new ComponentId(getName(), Arrays.asList(args)), lifespan);
+    }
+
+    /**
+     * This method copies the given {@link OptionData} for the given amount of times into a
+     * {@link List}. <br>
+     * This makes all the {@link OptionData OptionData's} optional! Everything else gets exactly
+     * copied.
+     *
+     * @param optionData The {@link OptionData} to copy.
+     * @param amount The amount of times to copy
+     *
+     * @return An unmodifiable {@link List} of the copied {@link OptionData OptionData's}
+     *
+     * @see #varArgOptionsToList(Collection, Function)
+     */
+    @Unmodifiable
+    protected static final @NotNull List<OptionData> generateOptionalVarArgList(
+            final @NotNull OptionData optionData, @Range(from = 1, to = 25) final int amount) {
+
+        OptionData varArgOption = new OptionData(optionData.getType(), optionData.getName(),
+                optionData.getDescription());
+
+        return IntStream.range(0, amount).mapToObj(i -> varArgOption).toList();
+    }
+
+    /**
+     * This method takes a {@link Collection} of {@link OptionMapping OptionMapping's}, these get
+     * mapped using the given {@link Function}
+     *
+     * @param options A {@link Collection} of {@link OptionMapping OptionMapping's}.
+     * @param mapper The mapper {@link Function}
+     * @param <T> The type to map it to.
+     *
+     * @return A modifiable {@link List} of the given type
+     *
+     * @see #generateOptionalVarArgList(OptionData, int)
+     */
+    protected static <T> List<T> varArgOptionsToList(
+            final @NotNull Collection<? extends OptionMapping> options,
+            final @NotNull Function<? super OptionMapping, ? extends T> mapper) {
+
+        return options.stream().map(mapper).collect(Collectors.toCollection(ArrayList::new));
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/SlashCommandAdapter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/SlashCommandAdapter.java
@@ -3,6 +3,7 @@ package org.togetherjava.tjbot.commands;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.SelectMenuInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
@@ -72,9 +73,9 @@ public abstract class SlashCommandAdapter implements SlashCommand {
      * Creates a new adapter with the given data.
      *
      * @param name the name of this command, requirements for this are documented in
-     *        {@link CommandData#CommandData(String, String)}
+     *        {@link SlashCommandData#setName(String)}
      * @param description the description of this command, requirements for this are documented in
-     *        {@link CommandData#CommandData(String, String)}
+     *        {@link SlashCommandData#setDescription(String)}
      * @param visibility the visibility of the command
      */
     protected SlashCommandAdapter(@NotNull String name, @NotNull String description,
@@ -176,9 +177,8 @@ public abstract class SlashCommandAdapter implements SlashCommand {
      * @see #varArgOptionsToList(Collection, Function)
      */
     @Unmodifiable
-    protected static final @NotNull List<OptionData> generateOptionalVarArgList(
+    protected static @NotNull List<OptionData> generateOptionalVarArgList(
             final @NotNull OptionData optionData, @Range(from = 1, to = 25) final int amount) {
-
         OptionData varArgOption = new OptionData(optionData.getType(), optionData.getName(),
                 optionData.getDescription());
 
@@ -187,7 +187,7 @@ public abstract class SlashCommandAdapter implements SlashCommand {
 
     /**
      * This method takes a {@link Collection} of {@link OptionMapping OptionMapping's}, these get
-     * mapped using the given {@link Function}
+     * mapped using the given {@link Function}.
      *
      * @param options A {@link Collection} of {@link OptionMapping OptionMapping's}.
      * @param mapper The mapper {@link Function}

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/RoleSelectCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/RoleSelectCommand.java
@@ -103,7 +103,7 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
      *
      * @return A modified {@link MessageEmbed} for this error
      */
-    private static @NotNull MessageEmbed generateLackingNonSystemRoles(
+    private static @NotNull MessageEmbed generateLackingNonSystemRolesEmbed(
             @NotNull final Collection<? extends Role> systemRoles) {
 
         return makeEmbed("Error: The given roles are all system roles!", """
@@ -170,7 +170,7 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
         List<Role> roles = filterToBotAccessibleRoles(rawRoles);
 
         if (roles.isEmpty()) {
-            event.replyEmbeds(generateLackingNonSystemRoles(rawRoles)).queue();
+            event.replyEmbeds(generateLackingNonSystemRolesEmbed(rawRoles)).queue();
             return;
         }
 
@@ -193,15 +193,13 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
      *
      * @param roles The {@link Collection} of the {@link Role roles} to filter
      *
-     * @return A modifiable {@link List} of all filtered roles
+     * @return An unmodifiable {@link List} of all filtered roles
      */
     @NotNull
-    private static List<Role> filterToBotAccessibleRoles(
-            @NotNull final Collection<? extends Role> roles) {
+    private static <T extends Role> List<T> filterToBotAccessibleRoles(
+            @NotNull final Collection<T> roles) {
 
-        return roles.stream()
-            .filter(RoleSelectCommand::handleIsSystemRole)
-            .collect(Collectors.toCollection(ArrayList::new));
+        return roles.stream().filter(RoleSelectCommand::handleIsSystemRole).toList();
     }
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/RoleSelectCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/RoleSelectCommand.java
@@ -45,14 +45,14 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
 
     private static final String TITLE_OPTION = "title";
     private static final String DESCRIPTION_OPTION = "description";
-    private static final String ROLE_OPTION = "Selectable role";
+    private static final String ROLE_OPTION = "selectable-role";
 
     private static final Color AMBIENT_COLOR = new Color(24, 221, 136, 255);
 
     private static final List<OptionData> messageOptions = List.of(
-            new OptionData(OptionType.STRING, TITLE_OPTION, "The title for the message", false),
+            new OptionData(OptionType.STRING, TITLE_OPTION, "The title for the message", true),
             new OptionData(OptionType.STRING, DESCRIPTION_OPTION, "A description for the message",
-                    false));
+                    true));
 
     /**
      * Amount of times the role-option will be copied ({@value})
@@ -151,7 +151,6 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
 
     @Override
     public void onSlashCommand(@NotNull final SlashCommandInteractionEvent event) {
-
         if (!event.getMember().hasPermission(Permission.MANAGE_ROLES)) {
             event.reply("You dont have the required manage role permission to use this command")
                 .setEphemeral(true)
@@ -166,7 +165,6 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
             return;
         }
 
-
         List<Role> rawRoles =
                 varArgOptionsToList(event.getOptionsByName(ROLE_OPTION), OptionMapping::getAsRole);
         List<Role> roles = filterToBotAccessibleRoles(rawRoles);
@@ -176,7 +174,6 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
             return;
         }
 
-
         List<Role> rolesBotCantInteractWith =
                 roles.stream().filter(role -> !selfMember.canInteract(role)).toList();
 
@@ -185,7 +182,6 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
                 .queue();
             return;
         }
-
 
         handleCommandSuccess(event, roles);
     }
@@ -246,11 +242,10 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
     private void handleCommandSuccess(@NotNull final CommandInteraction event,
             @NotNull final Collection<? extends Role> roles) {
 
-        SelectionMenu.Builder menu =
-                SelectionMenu.create(generateComponentId(event.getUser().getId()))
-                    .setPlaceholder("Select your roles")
-                    .setMaxValues(roles.size())
-                    .setMinValues(0);
+        SelectMenu.Builder menu = SelectMenu.create(generateComponentId(event.getUser().getId()))
+            .setPlaceholder("Select your roles")
+            .setMaxValues(roles.size())
+            .setMinValues(0);
 
         roles.forEach(role -> menu.addOptions(mapToSelectOption(role)));
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/RoleSelectCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/RoleSelectCommand.java
@@ -5,7 +5,6 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.SelectMenuInteractionEvent;
-import net.dv8tion.jda.api.interactions.Interaction;
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import net.dv8tion.jda.api.interactions.commands.CommandInteraction;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
@@ -15,29 +14,36 @@ import net.dv8tion.jda.api.interactions.components.selections.SelectMenu;
 import net.dv8tion.jda.api.interactions.components.selections.SelectOption;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
+import org.togetherjava.tjbot.commands.componentids.Lifespan;
 
 import java.awt.Color;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 
 /**
- * Implements the {@code roleSelect} command.
- *
+ * Implements the {@code /role-select} command.
  * <p>
- * Allows users to select their roles without using reactions, instead it uses selection menus where
- * you can select multiple roles. <br />
- * Note: the bot can only use roles with a position below its highest one
+ * The command works in two stages. First, a user sets up a role selection dialog by using the
+ * command:
+ * 
+ * <pre>
+ * {@code
+ * /role-select
+ *   title: Star Wars
+ *   description: Pick your preference
+ *   selectable-role: @Jedi
+ *   selectable-role1: @Sith
+ *   selectable-role2: @Droid
+ * }
+ * </pre>
+ * 
+ * Afterwards, users can pick their roles in a menu, upon which the command adjusts their roles.
  */
 public final class RoleSelectCommand extends SlashCommandAdapter {
 
@@ -84,23 +90,15 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
             .filter(RoleSelectCommand::handleIsBotAccessibleRole)
             .toList();
 
-        if (selectedRoles.isEmpty()) {
-            // TODO Used to use the list of roles without the accessible-filter
-            event.replyEmbeds(generateLackingNonSystemRolesEmbed(rawRoles)).queue();
+        if (!handleAccessibleRolesSelected(event, selectedRoles)) {
             return;
         }
 
-        List<Role> rolesBotCantInteractWith = selectedRoles.stream()
-            .filter(role -> !event.getGuild().getSelfMember().canInteract(role))
-            .toList();
-
-        if (!rolesBotCantInteractWith.isEmpty()) {
-            event.replyEmbeds(generateCannotInteractWithRolesEmbed(rolesBotCantInteractWith))
-                .queue();
+        if (!handleInteractableRolesSelected(event, selectedRoles)) {
             return;
         }
 
-        handleCommandSuccess(event, selectedRoles);
+        sendRoleSelectionMenu(event, selectedRoles);
     }
 
     private boolean handleHasPermissions(@NotNull SlashCommandInteractionEvent event) {
@@ -124,21 +122,6 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
         return true;
     }
 
-    /**
-     * Tests whether the given role is a role accessible to the bot or a system role.
-     *
-     * <p>
-     * A system role is a role where one of the following is true:
-     * <ul>
-     * <li>the {@code @everyone} role</li>
-     * <li>a bot/integration role</li>
-     * <li>the booster role</li>
-     * <li>the Twitch Subscriber role</li>
-     * </ul>
-     *
-     * @param role the role to test
-     * @return Whenever the given role is accessible to the bot, i.e. not a system role
-     */
     @Contract(pure = true)
     private static boolean handleIsBotAccessibleRole(@NotNull Role role) {
         boolean isSystemRole = role.isPublicRole() || role.getTags().isBot()
@@ -152,222 +135,143 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
         return !isSystemRole;
     }
 
-    /**
-     * Collects the given {@link Collection} of {@link IMentionable IMentionables} to a comma
-     * separated String within {@code ()} <br/>
-     * It maps the {@link IMentionable IMentionables} to their mention using
-     * {@link IMentionable#getAsMention()}.
-     *
-     * @param mentionables The {@link Collection} of {@link IMentionable IMentionables} to collect
-     *        into a {@link String}
-     * @return The given mentionables their mention collected into a {@link String}
-     */
-    private static String mentionablesToJoinedString(
-            @NotNull final Collection<? extends IMentionable> mentionables) {
-        return mentionables.stream()
+    private static boolean handleAccessibleRolesSelected(@NotNull IReplyCallback event,
+            @NotNull Collection<Role> selectedRoles) {
+        if (!selectedRoles.isEmpty()) {
+            return true;
+        }
+
+        MessageEmbed embed = createEmbed("Only system roles selected",
+                """
+                        I can not interact with system roles, these roles are special roles created by Discord, such as
+                        `@everyone`, or the role given automatically to boosters.
+                        Please pick non-system roles.""");
+
+        event.replyEmbeds(embed).setEphemeral(true).queue();
+        return false;
+    }
+
+    private static boolean handleInteractableRolesSelected(@NotNull IReplyCallback event,
+            @NotNull Collection<Role> selectedRoles) {
+        List<Role> nonInteractableRoles = selectedRoles.stream()
+            .filter(role -> !event.getGuild().getSelfMember().canInteract(role))
+            .toList();
+
+        if (nonInteractableRoles.isEmpty()) {
+            return true;
+        }
+
+        String nonInteractableRolesText = nonInteractableRoles.stream()
             .map(IMentionable::getAsMention)
             .collect(Collectors.joining(", ", "(", ")"));
+
+        MessageEmbed embed = createEmbed("Lacking permission",
+                "I can not interact with %s, please contact someone to give me appropriate permissions or select other roles."
+                    .formatted(nonInteractableRolesText));
+
+        event.replyEmbeds(embed).setEphemeral(true).queue();
+        return false;
     }
 
-    /**
-     * Handles the event when all the given roles are system roles.
-     *
-     * @param systemRoles A {@link Collection} of the {@link Role roles} the bot cannot interact
-     *        with.
-     * @return A modified {@link MessageEmbed} for this error
-     */
-    private static @NotNull MessageEmbed generateLackingNonSystemRolesEmbed(
-            @NotNull final Collection<? extends Role> systemRoles) {
+    private void sendRoleSelectionMenu(@NotNull final CommandInteraction event,
+            @NotNull final Collection<? extends Role> selectableRoles) {
+        SelectMenu.Builder menu =
+                SelectMenu.create(generateComponentId(Lifespan.PERMANENT, event.getUser().getId()))
+                    .setPlaceholder("Select your roles")
+                    .setMinValues(0)
+                    .setMaxValues(selectableRoles.size());
 
-        return makeEmbed("Error: The given roles are all system roles!", """
-                The bot can't/shouldn't interact with %s, these roles are created by Discord.
-                Examples are @everyone, or the role given automatically to boosters.
-                Are you sure you picked the correct role?
-                """.formatted(mentionablesToJoinedString(systemRoles)));
+        selectableRoles.stream()
+            .map(RoleSelectCommand::mapToSelectOption)
+            .forEach(menu::addOptions);
+
+        OptionMapping titleOption = event.getOption(TITLE_OPTION);
+        String title = titleOption == null ? "Select your roles:" : titleOption.getAsString();
+
+        MessageEmbed embed = createEmbed(title, event.getOption(DESCRIPTION_OPTION).getAsString());
+
+        event.replyEmbeds(embed).addActionRow(menu.build()).queue();
     }
 
-    /**
-     * Handles the event when the bot cannot interact with certain roles.
-     *
-     * @param rolesBotCantInteractWith A {@link Collection} of the {@link Role roles} the bot cannot
-     *        interact with.
-     * @return A modified {@link MessageEmbed} for this error
-     */
-    private static @NotNull MessageEmbed generateCannotInteractWithRolesEmbed(
-            @NotNull final Collection<? extends Role> rolesBotCantInteractWith) {
-
-        return makeEmbed("Error: The role of the bot is too low!",
-                "The bot can't interact with %s, contact a staff member to move the bot above these roles."
-                    .formatted(mentionablesToJoinedString(rolesBotCantInteractWith)));
-    }
-
-    /**
-     * Creates an embed to send with the selection menu. <br>
-     * This embed is specifically designed for this command and might have unwanted side effects.
-     *
-     * @param title The title for {@link EmbedBuilder#setTitle(String)}.
-     * @param description The description for {@link EmbedBuilder#setDescription(CharSequence)}
-     * @return The formatted {@link MessageEmbed}.
-     */
-    private static @NotNull MessageEmbed makeEmbed(@Nullable final String title,
-            @Nullable final CharSequence description) {
-
-        return new EmbedBuilder().setTitle(title)
-            .setDescription(description)
-            .setColor(AMBIENT_COLOR)
-            .setTimestamp(Instant.now())
-            .build();
-    }
-
-    /**
-     * Handles the event when no issues were found and the message can be sent.
-     *
-     * @param event The {@link CommandInteraction} to reply to.
-     * @param roles A {@link List} of the {@link Role roles} that the users should be able to pick.
-     */
-    private void handleCommandSuccess(@NotNull final CommandInteraction event,
-            @NotNull final Collection<? extends Role> roles) {
-
-        SelectMenu.Builder menu = SelectMenu.create(generateComponentId(event.getUser().getId()))
-            .setPlaceholder("Select your roles")
-            .setMaxValues(roles.size())
-            .setMinValues(0);
-
-        roles.forEach(role -> menu.addOptions(mapToSelectOption(role)));
-
-        String title = null == event.getOption(TITLE_OPTION) ? "Select your roles:"
-                : event.getOption(TITLE_OPTION).getAsString();
-
-        MessageEmbed generatedEmbed =
-                makeEmbed(title, event.getOption(DESCRIPTION_OPTION).getAsString());
-
-        event.replyEmbeds(generatedEmbed).addActionRow(menu.build()).queue();
-    }
-
-    /**
-     * Maps the given role to a {@link SelectOption} with the {@link SelectOption SelectOption's}
-     * emoji, if it has one.
-     *
-     * @param role The {@link Role} to base the option from.
-     * @return The generated {@link SelectOption}.
-     */
     @NotNull
-    private static SelectOption mapToSelectOption(@NotNull final Role role) {
+    private static SelectOption mapToSelectOption(@NotNull Role role) {
         RoleIcon roleIcon = role.getIcon();
 
-        if (null == roleIcon || !roleIcon.isEmoji()) {
-            return SelectOption.of(role.getName(), role.getId());
-        } else {
-            return SelectOption.of(role.getName(), role.getId())
-                .withEmoji((Emoji.fromUnicode(roleIcon.getEmoji())));
+        SelectOption option = SelectOption.of(role.getName(), role.getId());
+        if (null != roleIcon && roleIcon.isEmoji()) {
+            option = option.withEmoji((Emoji.fromUnicode(roleIcon.getEmoji())));
         }
+
+        return option;
     }
 
-
     @Override
-    public void onSelectionMenu(@NotNull final SelectMenuInteractionEvent event,
-            @NotNull final List<String> args) {
-
-        Guild guild = Objects.requireNonNull(event.getGuild(), "The given guild cannot be null");
-        List<SelectOption> selectedOptions = Objects.requireNonNull(event.getSelectedOptions(),
-                "The given selectedOptions cannot be null");
-
-        List<Role> roles = selectedOptions.stream()
+    public void onSelectionMenu(@NotNull SelectMenuInteractionEvent event,
+            @NotNull List<String> args) {
+        Guild guild = event.getGuild();
+        List<Role> selectedRoles = event.getSelectedOptions()
+            .stream()
             .map(SelectOption::getValue)
             .map(guild::getRoleById)
             .filter(Objects::nonNull)
             .toList();
 
-        List<Role> rolesBotCantInteractWith =
-                roles.stream().filter(role -> !guild.getSelfMember().canInteract(role)).toList();
-
-        if (!rolesBotCantInteractWith.isEmpty()) {
-            event.getChannel()
-                .sendMessageEmbeds(generateCannotInteractWithRolesEmbed(rolesBotCantInteractWith))
-                .queue();
+        if (!handleInteractableRolesSelected(event, selectedRoles)) {
+            return;
         }
 
-        List<Role> usableRoles =
-                roles.stream().filter(role -> guild.getSelfMember().canInteract(role)).toList();
-
-        handleRoleSelection(event, usableRoles, guild);
+        handleRoleSelection(event, guild, selectedRoles);
     }
 
-    /**
-     * Handles selection of a {@link SelectMenuInteractionEvent}.
-     *
-     * @param event the <b>unacknowledged</b> {@link SelectMenuInteractionEvent}.
-     * @param selectedRoles The {@link Role roles} selected.
-     * @param guild The {@link Guild}.
-     */
-    private static void handleRoleSelection(final @NotNull SelectMenuInteractionEvent event,
-            final @NotNull Collection<Role> selectedRoles, final Guild guild) {
+    private static void handleRoleSelection(@NotNull SelectMenuInteractionEvent event,
+            @NotNull Guild guild, @NotNull Collection<Role> selectedRoles) {
         Collection<Role> rolesToAdd = new ArrayList<>(selectedRoles.size());
         Collection<Role> rolesToRemove = new ArrayList<>(selectedRoles.size());
 
+        // Diff the selected roles from all selectable roles
         event.getInteraction()
             .getComponent()
             .getOptions()
             .stream()
-            .map(roleFromSelectOptionFunction(guild))
-            .filter(Objects::nonNull)
-            .forEach((Role role) -> {
-                if (selectedRoles.contains(role)) {
-                    rolesToAdd.add(role);
-                } else {
-                    rolesToRemove.add(role);
-                }
+            .map(optionToRole(guild))
+            .filter(Optional::isPresent)
+            .map(Optional::orElseThrow)
+            .forEach(role -> {
+                Collection<Role> target = selectedRoles.contains(role) ? rolesToAdd : rolesToRemove;
+                target.add(role);
             });
 
-        handleRoleModifications(event, event.getMember(), guild, rolesToAdd, rolesToRemove);
+        modifyRoles(event, event.getMember(), guild, rolesToAdd, rolesToRemove);
     }
 
-    /**
-     * Creates a function that maps the {@link SelectOption} to a {@link Role} from the given
-     * {@link Guild}.
-     *
-     * @param guild The {@link Guild} to grab the roles from.
-     * @return A {@link Function} which maps {@link SelectOption} to the relating {@link Role}.
-     */
-    @Contract(pure = true)
     @NotNull
-    private static Function<SelectOption, Role> roleFromSelectOptionFunction(final Guild guild) {
-        return (SelectOption selectedOption) -> {
-            Role role = guild.getRoleById(selectedOption.getValue());
+    private static Function<SelectOption, Optional<Role>> optionToRole(@NotNull Guild guild) {
+        return option -> {
+            Role role = guild.getRoleById(option.getValue());
 
             if (null == role) {
-                logRemovedRole(selectedOption);
+                logger.info(
+                        "The {} ({}) role has been removed but is still an option in a selection menu.",
+                        option.getLabel(), option.getValue());
             }
 
-            return role;
+            return Optional.ofNullable(role);
         };
     }
 
-    /**
-     * Logs that the role of the given {@link SelectOption} doesn't exist anymore.
-     *
-     * @param selectedOption the {@link SelectOption}
-     */
-    private static void logRemovedRole(final @NotNull SelectOption selectedOption) {
-        logger.info(
-                "The {} ({}) role has been removed but is still an option in the selection menu",
-                selectedOption.getLabel(), selectedOption.getValue());
+    private static void modifyRoles(@NotNull IReplyCallback event, @NotNull Member target,
+            @NotNull Guild guild, @NotNull Collection<Role> rolesToAdd,
+            @NotNull Collection<Role> rolesToRemove) {
+        guild.modifyMemberRoles(target, rolesToAdd, rolesToRemove)
+            .flatMap(empty -> event.reply("Your roles have been updated.").setEphemeral(true))
+            .queue();
     }
 
-    /**
-     * Updates the roles of the given member.
-     *
-     * @param event an <b>unacknowledged</b> {@link Interaction} event
-     * @param member the member to update the roles of
-     * @param guild what guild to update the roles in
-     * @param additionRoles the roles to add
-     * @param removalRoles the roles to remove
-     */
-    private static void handleRoleModifications(@NotNull final IReplyCallback event,
-            final Member member, final @NotNull Guild guild, final Collection<Role> additionRoles,
-            final Collection<Role> removalRoles) {
-        guild.modifyMemberRoles(member, additionRoles, removalRoles)
-            .flatMap(empty -> event.reply("Your roles have been updated!").setEphemeral(true))
-            .queue();
+    private static @NotNull MessageEmbed createEmbed(@NotNull String title,
+            @NotNull CharSequence description) {
+        return new EmbedBuilder().setTitle(title)
+            .setDescription(description)
+            .setColor(AMBIENT_COLOR)
+            .build();
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/RoleSelectCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/RoleSelectCommand.java
@@ -73,7 +73,7 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
 
         getData().addOptions(messageOptions)
             .addOptions(roleOption)
-            .addOptions(generateOptionalVarArgList(roleOption, ROLE_VAR_ARG_OPTION_AMOUNT));
+            .addOptions(generateMultipleOptions(roleOption, ROLE_VAR_ARG_OPTION_AMOUNT));
     }
 
     /**
@@ -84,7 +84,6 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
      *
      * @param mentionables The {@link Collection} of {@link IMentionable IMentionables} to collect
      *        into a {@link String}
-     *
      * @return The given mentionables their mention collected into a {@link String}
      */
     private static String mentionablesToJoinedString(
@@ -100,7 +99,6 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
      *
      * @param systemRoles A {@link Collection} of the {@link Role roles} the bot cannot interact
      *        with.
-     *
      * @return A modified {@link MessageEmbed} for this error
      */
     private static @NotNull MessageEmbed generateLackingNonSystemRolesEmbed(
@@ -118,7 +116,6 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
      *
      * @param rolesBotCantInteractWith A {@link Collection} of the {@link Role roles} the bot cannot
      *        interact with.
-     *
      * @return A modified {@link MessageEmbed} for this error
      */
     private static @NotNull MessageEmbed generateCannotInteractWithRolesEmbed(
@@ -135,7 +132,6 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
      *
      * @param title The title for {@link EmbedBuilder#setTitle(String)}.
      * @param description The description for {@link EmbedBuilder#setDescription(CharSequence)}
-     *
      * @return The formatted {@link MessageEmbed}.
      */
     private static @NotNull MessageEmbed makeEmbed(@Nullable final String title,
@@ -165,8 +161,9 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
             return;
         }
 
-        List<Role> rawRoles =
-                varArgOptionsToList(event.getOptionsByName(ROLE_OPTION), OptionMapping::getAsRole);
+        List<Role> rawRoles = getMultipleOptionsByNamePrefix(event, ROLE_OPTION).stream()
+            .map(OptionMapping::getAsRole)
+            .toList();
         List<Role> roles = filterToBotAccessibleRoles(rawRoles);
 
         if (roles.isEmpty()) {
@@ -188,11 +185,10 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
 
     /**
      * Filters the given {@link Collection} of {@link Role roles} to not contain system roles. <br>
-     *
+     * <p>
      * See {@link #handleIsSystemRole(Role)} for more info on what this exactly filters.
      *
      * @param roles The {@link Collection} of the {@link Role roles} to filter
-     *
      * @return An unmodifiable {@link List} of all filtered roles
      */
     @NotNull
@@ -215,7 +211,6 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
      * </ul>
      *
      * @param role The {@link Role} to test
-     *
      * @return Whenever the given {@link Role} is a system-role
      */
     @Contract(pure = true)
@@ -261,7 +256,6 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
      * emoji, if it has one.
      *
      * @param role The {@link Role} to base the option from.
-     *
      * @return The generated {@link SelectOption}.
      */
     @NotNull
@@ -340,7 +334,6 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
      * {@link Guild}.
      *
      * @param guild The {@link Guild} to grab the roles from.
-     *
      * @return A {@link Function} which maps {@link SelectOption} to the relating {@link Role}.
      */
     @Contract(pure = true)


### PR DESCRIPTION
## Overview

This fixes the bug with `/role-select` crashing on servers having too many roles. And by that closes #400 .

It is done by redesigning the command. Instead of having two dialogs (one for the moderator to create the actual dialog and one final for the user to pick), the moderator now picks their options directly as arguments to the command.

![creation](https://i.imgur.com/MEkbqdT.png)
![dialog](https://i.imgur.com/lG1JNgc.png)
![dialog selection](https://i.imgur.com/SbOJ4DK.png)
![result](https://i.imgur.com/AqrR684.png)

## Helper

While at it, we introduced a little helper method to `SlashCommandAdapter`:

* `generateMultipleOptions` and
* `getMultipleOptionsByNamePrefix`

Former basically takes a given option, such as `"foo"` and create a list of optional options:
* `"foo1"`
* `"foo2"`
* `"foo3"`
* ...

And latter can parse that back conveniently.