### PR TITLE
Colorblind support for help system emojis

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/free/ChannelStatusType.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/free/ChannelStatusType.java
@@ -3,8 +3,8 @@ package org.togetherjava.tjbot.commands.free;
 import org.jetbrains.annotations.NotNull;
 
 enum ChannelStatusType {
-    FREE("free", ":green_circle:"),
-    BUSY("busy", ":red_circle:");
+    FREE("free", ":white_check_mark:"),
+    BUSY("busy", ":x:");
 
     private final String description;
     private final String emoji;


### PR DESCRIPTION
## Overview

Implements and closes #409.

As suggested by someone in #tj_suggestions who is red/green colorblind, the existing emojis for the help system status messages are barely distinguishable (🟢 🔴).

This changes the emojis to something that also has a different shape, while still having nice color coding for people who are not colorblind (✅ ❌).

![free](https://i.imgur.com/ESogsHa.png)
![busy](https://i.imgur.com/TlAScuB.png)

Looks for example like this for a colorblind person (deuteranopia):

![colorblind](https://i.imgur.com/in4Xukq.png)