### PR TITLE
Bugfix - Handling blocked users gracefully when reacting to their messages

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/SuggestionsUpDownVoter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/SuggestionsUpDownVoter.java
@@ -62,6 +62,8 @@ public final class SuggestionsUpDownVoter extends MessageReceiverAdapter {
         }, exception -> {
             if (exception instanceof ErrorResponseException responseException
                     && responseException.getErrorResponse() == ErrorResponse.REACTION_BLOCKED) {
+                // User blocked the bot, hence the bot can not add reactions to their messages.
+                // Nothing we can do here.
                 return;
             }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/SuggestionsUpDownVoter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/SuggestionsUpDownVoter.java
@@ -60,8 +60,8 @@ public final class SuggestionsUpDownVoter extends MessageReceiverAdapter {
             return message.addReaction(fallbackUnicodeEmote);
         }).queue(ignored -> {
         }, exception -> {
-            if (exception instanceof ErrorResponseException responseException &&
-                responseException.getErrorResponse() == ErrorResponse.REACTION_BLOCKED) {
+            if (exception instanceof ErrorResponseException responseException
+                    && responseException.getErrorResponse() == ErrorResponse.REACTION_BLOCKED) {
                 return;
             }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/SuggestionsUpDownVoter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/SuggestionsUpDownVoter.java
@@ -60,8 +60,8 @@ public final class SuggestionsUpDownVoter extends MessageReceiverAdapter {
             return message.addReaction(fallbackUnicodeEmote);
         }).queue(ignored -> {
         }, exception -> {
-            if (exception instanceof ErrorResponseException && ((ErrorResponseException) exception)
-                .getErrorResponse() == ErrorResponse.REACTION_BLOCKED) {
+            if (exception instanceof ErrorResponseException responseException &&
+                responseException.getErrorResponse() == ErrorResponse.REACTION_BLOCKED) {
                 return;
             }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/SuggestionsUpDownVoter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/SuggestionsUpDownVoter.java
@@ -65,7 +65,7 @@ public final class SuggestionsUpDownVoter extends MessageReceiverAdapter {
                 return;
             }
 
-            logger.error(exception.getMessage(), exception);
+            logger.error("Attempted to react to a suggestion, but failed", exception);
         });
     }
 


### PR DESCRIPTION
warped the line that reacts to the message in a `try catch` block. see file changes.
resolves #406.