### PR TITLE
Auto-free inactive help channels

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     implementation 'org.scilab.forge:jlatexmath-font-cyrillic:1.0.7'
 
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.13.0'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.0'
 
 	implementation 'com.github.freva:ascii-table:1.2.0'

--- a/application/config.json.template
+++ b/application/config.json.template
@@ -10,6 +10,8 @@
     "tagManageRolePattern": "Moderator|Staff Assistant|Top Helpers .+",
     "freeCommand": [
         {
+            "inactiveChannelDuration": "PT2H",
+            "messageRetrieveLimit": 10,
             "statusChannel": <put_a_channel_id_here>,
             "monitoredChannels": [
                     <put_a_channel_id_here>

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
@@ -6,6 +6,8 @@ import org.togetherjava.tjbot.commands.basic.PingCommand;
 import org.togetherjava.tjbot.commands.basic.RoleSelectCommand;
 import org.togetherjava.tjbot.commands.basic.SuggestionsUpDownVoter;
 import org.togetherjava.tjbot.commands.basic.VcActivityCommand;
+import org.togetherjava.tjbot.commands.free.AutoFreeRoutine;
+import org.togetherjava.tjbot.commands.free.FreeChannelMonitor;
 import org.togetherjava.tjbot.commands.free.FreeCommand;
 import org.togetherjava.tjbot.commands.mathcommands.TeXCommand;
 import org.togetherjava.tjbot.commands.moderation.*;
@@ -59,6 +61,7 @@ public enum Features {
         ModerationActionsStore actionsStore = new ModerationActionsStore(database);
         ModAuditLogWriter modAuditLogWriter = new ModAuditLogWriter(config);
         ScamHistoryStore scamHistoryStore = new ScamHistoryStore(database);
+        FreeChannelMonitor freeChannelMonitor = new FreeChannelMonitor(config);
 
         // NOTE The system can add special system relevant commands also by itself,
         // hence this list may not necessarily represent the full list of all commands actually
@@ -71,6 +74,7 @@ public enum Features {
         features.add(new TopHelpersPurgeMessagesRoutine(database));
         features.add(new RemindRoutine(database));
         features.add(new ScamHistoryPurgeRoutine(scamHistoryStore));
+        features.add(new AutoFreeRoutine(freeChannelMonitor));
 
         // Message receivers
         features.add(new TopHelpersMessageListener(database, config));
@@ -102,7 +106,7 @@ public enum Features {
         features.add(new UnquarantineCommand(actionsStore, config));
 
         // Mixtures
-        features.add(new FreeCommand(config));
+        features.add(new FreeCommand(config, freeChannelMonitor));
 
         return features;
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/free/AutoFreeRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/free/AutoFreeRoutine.java
@@ -1,0 +1,55 @@
+package org.togetherjava.tjbot.commands.free;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.TextChannel;
+import org.jetbrains.annotations.NotNull;
+import org.togetherjava.tjbot.commands.Routine;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Routine that automatically marks busy help channels free after a certain time without any
+ * activity.
+ */
+public final class AutoFreeRoutine implements Routine {
+    private final FreeChannelMonitor channelMonitor;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param channelMonitor used to monitor and control the free-status of channels
+     */
+    public AutoFreeRoutine(@NotNull FreeChannelMonitor channelMonitor) {
+        this.channelMonitor = channelMonitor;
+    }
+
+    @Override
+    public void runRoutine(@NotNull JDA jda) {
+        channelMonitor.guildIds()
+            .map(jda::getGuildById)
+            .filter(Objects::nonNull)
+            .forEach(this::processGuild);
+    }
+
+    private void processGuild(@NotNull Guild guild) {
+        // Mark inactive channels free
+        Collection<TextChannel> inactiveChannels = channelMonitor.freeInactiveChannels(guild);
+
+        // Then update the status
+        channelMonitor.displayStatus(guild);
+
+        // Finally, send the messages (the order is important to ensure sane behavior in case of
+        // crashes)
+        inactiveChannels.forEach(inactiveChannel -> inactiveChannel
+            .sendMessage(UserStrings.AUTO_MARK_AS_FREE.message())
+            .queue());
+    }
+
+    @Override
+    public @NotNull Schedule createSchedule() {
+        return new Schedule(ScheduleMode.FIXED_RATE, 1, 5, TimeUnit.MINUTES);
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/commands/free/ChannelStatus.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/free/ChannelStatus.java
@@ -101,11 +101,11 @@ final class ChannelStatus {
      *
      * @param guild the {@link Guild} that the channel belongs to, to retrieve its name from.
      * @throws IllegalArgumentException if the guild has not been added, see
-     *         {@link ChannelMonitor#addChannelForStatus(TextChannel)}
+     *         {@link FreeChannelMonitor#addChannelForStatus(TextChannel)}
      * @throws IllegalStateException if a channel was added, see
-     *         {@link ChannelMonitor#addChannelToMonitor(long)}, that is not a {@link TextChannel}.
-     *         Since addChannelToMonitor does not access the {@link JDA} the entry can only be
-     *         validated before use instead of on addition.
+     *         {@link FreeChannelMonitor#addChannelToMonitor(long)}, that is not a
+     *         {@link TextChannel}. Since addChannelToMonitor does not access the {@link JDA} the
+     *         entry can only be validated before use instead of on addition.
      */
     public void updateChannelName(@NotNull final Guild guild) {
         GuildChannel channel = guild.getGuildChannelById(channelId);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/free/FreeChannelMonitor.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/free/FreeChannelMonitor.java
@@ -1,38 +1,56 @@
 package org.togetherjava.tjbot.commands.free;
 
-import net.dv8tion.jda.api.entities.Category;
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.GuildChannel;
-import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.utils.TimeUtil;
 import org.jetbrains.annotations.NotNull;
+import org.togetherjava.tjbot.config.Config;
+import org.togetherjava.tjbot.config.FreeCommandConfig;
 
+import java.awt.Color;
+import java.time.Instant;
 import java.util.*;
+import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 
 /**
  * A class responsible for monitoring the status of channels and reporting on their busy/free status
  * for use by {@link FreeCommand}.
- *
+ * <p>
  * Channels for monitoring are added via {@link #addChannelToMonitor(long)} however the monitoring
  * will not be accessible/visible until a channel in the same {@link Guild} is registered for the
  * output via {@link #addChannelForStatus(TextChannel)}. This will all happen automatically for any
  * channels listed in {@link org.togetherjava.tjbot.config.FreeCommandConfig}.
- *
+ * <p>
  * When a status channel is added for a guild, all monitored channels for that guild are tested and
  * an {@link IllegalStateException} is thrown if any of them are not {@link TextChannel}s.
- *
+ * <p>
  * After successful configuration, any changes in busy/free status will automatically be displayed
  * in the configured {@code Status Channel} for that guild.
  */
-final class ChannelMonitor {
+public final class FreeChannelMonitor {
     // Map to store channel ID's, use Guild.getChannels() to guarantee order for display
     private final Map<Long, ChannelStatus> channelsToMonitorById;
     private final Map<Long, Long> guildIdToStatusChannel;
+    private final Map<Long, Long> channelIdToMessageIdForStatus;
 
-    ChannelMonitor() {
+    private static final String STATUS_TITLE = "**__CHANNEL STATUS__**\n\n";
+    private static final Color MESSAGE_HIGHLIGHT_COLOR = Color.decode("#CCCC00");
+
+    private final Config config;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param config the config to use
+     */
+    public FreeChannelMonitor(@NotNull Config config) {
         guildIdToStatusChannel = new HashMap<>(); // JDA required to populate map
         channelsToMonitorById = new HashMap<>();
+        channelIdToMessageIdForStatus = new HashMap<>();
+        this.config = config;
     }
 
     /**
@@ -48,7 +66,7 @@ final class ChannelMonitor {
      * Method for adding the channel that the status will be printed in. Even though the method only
      * stores the long id it requires, the method requires the actual {@link TextChannel} to be
      * passed because it needs to verify it as well as store the guild id.
-     *
+     * <p>
      * This method also calls a method which updates the status of the channels in the
      * {@link Guild}. So always add the status channel <strong>after</strong> you have added all
      * monitored channels for the guild, see {@link #addChannelToMonitor(long)}.
@@ -57,14 +75,14 @@ final class ChannelMonitor {
      */
     public void addChannelForStatus(@NotNull final TextChannel channel) {
         guildIdToStatusChannel.put(channel.getGuild().getIdLong(), channel.getIdLong());
-        updateStatusFor(channel.getGuild());
+        freeInactiveChannels(channel.getGuild());
     }
 
     /**
      * This method tests whether a guild id is configured for monitoring in the free command system.
      * To add a guild for monitoring see {@link org.togetherjava.tjbot.config.FreeCommandConfig} or
      * {@link #addChannelForStatus(TextChannel)}.
-     * 
+     *
      * @param guildId the id of the guild to test.
      * @return whether the guild is configured in the free command system or not.
      */
@@ -77,7 +95,7 @@ final class ChannelMonitor {
      * system. To add a channel for monitoring see
      * {@link org.togetherjava.tjbot.config.FreeCommandConfig} or
      * {@link #addChannelToMonitor(long)}.
-     * 
+     *
      * @param channelId the id of the channel to test.
      * @return {@code true} if the channel is configured in the system, {@code false} otherwise.
      */
@@ -107,36 +125,38 @@ final class ChannelMonitor {
 
     /**
      * This method tests if a channel is currently active by fetching the latest message and testing
-     * if it was posted more recently than the configured time limit, see
-     * {@link FreeUtil#inactiveTimeLimit()} and
-     * {@link org.togetherjava.tjbot.config.FreeCommandConfig#INACTIVE_DURATION},
-     * {@link org.togetherjava.tjbot.config.FreeCommandConfig#INACTIVE_UNIT}.
+     * if it was posted more recently than the configured time limit.
      *
      * @param channel the channel to test.
+     * @param when the reference moment, usually "now"
      * @return {@code true} if the channel is inactive, false if it has received messages more
      *         recently than the configured duration.
      * @throws IllegalArgumentException if the channel passed is not monitored. See
      *         {@link #addChannelToMonitor(long)}
      */
-    public boolean isChannelInactive(@NotNull final TextChannel channel) {
+    public boolean isChannelInactive(@NotNull final TextChannel channel, @NotNull Instant when) {
         requiresIsMonitored(channel.getIdLong());
 
-        // TODO change the entire inactive test to work via rest-actions
-        return FreeUtil.getLastMessageId(channel)
-            // black magic to convert OptionalLong into Optional<Long> because OptionalLong does not
-            // have .map
+        OptionalLong maybeLastMessageId = FreeUtil.getLastMessageId(channel);
+        if (maybeLastMessageId.isEmpty()) {
+            return true;
+        }
+
+        FreeCommandConfig configForChannel = config.getFreeCommandConfig()
             .stream()
-            .boxed()
-            .findFirst()
-            .map(FreeUtil::timeFromId)
-            .map(createdTime -> createdTime.isBefore(FreeUtil.inactiveTimeLimit()))
-            .orElse(true); // if no channel history could be fetched assume channel is free
+            .filter(freeConfig -> freeConfig.getMonitoredChannels().contains(channel.getIdLong()))
+            .findAny()
+            .orElseThrow();
+
+        return TimeUtil.getTimeCreated(maybeLastMessageId.orElseThrow())
+            .toInstant()
+            .isBefore(when.minus(configForChannel.getInactiveChannelDuration()));
     }
 
     /**
      * This method sets the channel's status to 'busy' see {@link ChannelStatus#setBusy(long)} for
      * details.
-     * 
+     *
      * @param channelId the id for the channel status to modify.
      * @param userId the id of the user changing the status to busy.
      * @throws IllegalArgumentException if the channel passed is not monitored. See
@@ -149,7 +169,7 @@ final class ChannelMonitor {
     /**
      * This method sets the channel's status to 'free', see {@link ChannelStatus#setFree()} for
      * details.
-     * 
+     *
      * @param channelId the id for the channel status to modify.
      * @throws IllegalArgumentException if the channel passed is not monitored. See
      *         {@link #addChannelToMonitor(long)}
@@ -171,7 +191,7 @@ final class ChannelMonitor {
     /**
      * This method provides a stream of the id's for channels where statuses are displayed. This is
      * streamed purely as a simple method of encapsulation.
-     * 
+     *
      * @return a stream of channel id's
      */
     public @NotNull Stream<Long> statusIds() {
@@ -188,13 +208,25 @@ final class ChannelMonitor {
     }
 
     /**
+     * Gets a stream with IDs of all monitored channels that are currently marked busy.
+     *
+     * @return stream with IDs of all busy channels
+     */
+    public LongStream getBusyChannelIds() {
+        return channelsToMonitorById.values()
+            .stream()
+            .filter(ChannelStatus::isBusy)
+            .mapToLong(ChannelStatus::getChannelId);
+    }
+
+    /**
      * Creates the status message (specific to the guild specified) that shows which channels are
      * busy/free.
      * <p>
      * It first updates the channel names, order and grouping(categories) according to
      * {@link net.dv8tion.jda.api.JDA} for the monitored channels. So that the output is always
      * consistent with remote changes.
-     * 
+     *
      * @param guild the guild the message is intended for.
      * @return a string representing the busy/free status of channels in this guild. The String
      *         includes emojis and other discord specific markup. Attempting to display this
@@ -232,26 +264,30 @@ final class ChannelMonitor {
 
     /**
      * This method checks all channels in a guild that are currently being monitored and are busy
-     * and determines if the last time it was updated is more recent than the configured time see
-     * {@link org.togetherjava.tjbot.config.FreeCommandConfig#INACTIVE_UNIT}. If so it changes the
-     * channel's status to free, see {@link ChannelMonitor#isChannelInactive(TextChannel)}.
+     * and determines if the last time it was updated is more recent than the configured time. If so
+     * it changes the channel's status to free, see
+     * {@link FreeChannelMonitor#isChannelInactive(TextChannel, Instant)}.
      * <p>
-     * This method is run automatically during startup and should be run on a set schedule, as
-     * defined in {@link org.togetherjava.tjbot.config.FreeCommandConfig}. The scheduled execution
-     * is not currently implemented
-     * 
+     * This method is run automatically during startup and on a set schedule, as defined in
+     * {@link org.togetherjava.tjbot.config.FreeCommandConfig}.
+     *
      * @param guild the guild for which to test the channel statuses of.
+     * @return all inactive channels that have been updated
      */
-    public void updateStatusFor(@NotNull Guild guild) {
-        // TODO add automation after Routine support (#235) is pushed
-        guildMonitoredChannelsList(guild).parallelStream()
+    public @NotNull Collection<TextChannel> freeInactiveChannels(@NotNull Guild guild) {
+        Instant now = Instant.now();
+
+        List<TextChannel> inactiveChannels = guildMonitoredChannelsList(guild).parallelStream()
             .filter(ChannelStatus::isBusy)
             .map(ChannelStatus::getChannelId)
             .map(guild::getTextChannelById)
             .filter(Objects::nonNull) // pointless, added for warnings
-            .filter(this::isChannelInactive)
-            .map(TextChannel::getIdLong)
-            .forEach(this::setChannelFree);
+            .filter(busyChannel -> isChannelInactive(busyChannel, now))
+            .toList();
+
+        inactiveChannels.stream().map(TextChannel::getIdLong).forEach(this::setChannelFree);
+
+        return inactiveChannels;
     }
 
     /**
@@ -282,9 +318,105 @@ final class ChannelMonitor {
     }
 
     /**
+     * Displays the message that will be displayed for users.
+     * <p>
+     * This method detects if any messages have been posted in the channel below the status message.
+     * If that is the case this will delete the existing status message and post another one so that
+     * it's the last message in the channel.
+     * <p>
+     * If it cannot find an existing status message it will create a new one.
+     * <p>
+     * Otherwise it will edit the existing message.
+     *
+     * @param guild the guild to display the status in.
+     */
+    public void displayStatus(@NotNull Guild guild) {
+        TextChannel channel = getStatusChannelFor(guild);
+
+        String messageTxt = buildStatusMessage(guild);
+        MessageEmbed embed = new EmbedBuilder().setTitle(STATUS_TITLE)
+            .setDescription(messageTxt)
+            .setFooter(channel.getJDA().getSelfUser().getName())
+            .setTimestamp(Instant.now())
+            .setColor(MESSAGE_HIGHLIGHT_COLOR)
+            .build();
+
+        getStatusMessageIn(channel).flatMap(this::deleteIfNotLatest)
+            .ifPresentOrElse(message -> message.editMessageEmbeds(embed).queue(),
+                    () -> channel.sendMessageEmbeds(embed)
+                        .queue(message -> channelIdToMessageIdForStatus.put(channel.getIdLong(),
+                                message.getIdLong())));
+    }
+
+    private @NotNull Optional<Message> deleteIfNotLatest(@NotNull Message message) {
+        OptionalLong lastId = FreeUtil.getLastMessageId(message.getTextChannel());
+        if (lastId.isPresent() && lastId.getAsLong() != message.getIdLong()) {
+            message.delete().queue();
+            return Optional.empty();
+        }
+
+        return Optional.of(message);
+    }
+
+    private @NotNull Optional<Message> getStatusMessageIn(@NotNull TextChannel channel) {
+        if (!channelIdToMessageIdForStatus.containsKey(channel.getIdLong())) {
+            return findExistingStatusMessage(channel);
+        }
+        return Optional.ofNullable(channelIdToMessageIdForStatus.get(channel.getIdLong()))
+            .map(channel::retrieveMessageById)
+            .map(RestAction::complete);
+    }
+
+    private @NotNull Optional<Message> findExistingStatusMessage(@NotNull TextChannel channel) {
+        // will only run when bot starts, afterwards its stored in a map
+
+        FreeCommandConfig configForChannel = config.getFreeCommandConfig()
+            .stream()
+            .filter(freeConfig -> freeConfig.getStatusChannel() == channel.getIdLong())
+            .findAny()
+            .orElseThrow();
+
+        Optional<Message> statusMessage = FreeUtil
+            .getChannelHistory(channel, configForChannel.getMessageRetrieveLimit())
+            .flatMap(history -> history.stream()
+                .filter(message -> !message.getEmbeds().isEmpty())
+                .filter(message -> message.getAuthor().equals(channel.getJDA().getSelfUser()))
+                // TODO the equals is not working, i believe its because there is no getTitleRaw()
+                // .filter(message -> STATUS_TITLE.equals(message.getEmbeds().get(0).getTitle()))
+                .findFirst());
+
+        channelIdToMessageIdForStatus.put(channel.getIdLong(),
+                statusMessage.map(Message::getIdLong).orElse(null));
+        return statusMessage;
+    }
+
+    /**
+     * Method for creating the message that shows the channel statuses for the specified guild.
+     * <p>
+     * This method dynamically builds the status message as per the current values on the guild,
+     * including the channel categories. This method will detect any changes made on the guild and
+     * represent those changes in the status message.
+     *
+     * @param guild the guild that the message is required for.
+     * @return the message to display showing the channel statuses. Includes Discord specific
+     *         formatting, trying to display elsewhere may have unpredictable results.
+     * @throws IllegalArgumentException if the guild passed in is not configured in the free command
+     *         system, see {@link FreeChannelMonitor#addChannelForStatus(TextChannel)}.
+     */
+    public @NotNull String buildStatusMessage(@NotNull Guild guild) {
+        if (!isMonitoringGuild(guild.getIdLong())) {
+            throw new IllegalArgumentException(
+                    "The guild '%s(%s)' is not configured in the free command system"
+                        .formatted(guild.getName(), guild.getIdLong()));
+        }
+
+        return statusMessage(guild);
+    }
+
+    /**
      * The toString method for this class, it generates a human-readable text string of the
      * currently monitored channels and the channels the status are printed in.
-     * 
+     *
      * @return the human-readable text string that describes this class.
      */
     @Override

--- a/application/src/main/java/org/togetherjava/tjbot/commands/free/FreeChannelMonitor.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/free/FreeChannelMonitor.java
@@ -269,7 +269,7 @@ public final class FreeChannelMonitor {
      * {@link FreeChannelMonitor#isChannelInactive(TextChannel, Instant)}.
      * <p>
      * This method is run automatically during startup and on a set schedule, as defined in
-     * {@link org.togetherjava.tjbot.config.FreeCommandConfig}.
+     * {@link FreeCommandConfig}.
      *
      * @param guild the guild for which to test the channel statuses of.
      * @return all inactive channels that have been updated

--- a/application/src/main/java/org/togetherjava/tjbot/commands/free/FreeUtil.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/free/FreeUtil.java
@@ -3,13 +3,10 @@ package org.togetherjava.tjbot.commands.free;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
-import net.dv8tion.jda.api.utils.TimeUtil;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.togetherjava.tjbot.config.FreeCommandConfig;
 
-import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -65,34 +62,11 @@ enum FreeUtil {
      * @return the id of the latest message or empty if it could not be retrieved.
      */
     public static @NotNull OptionalLong getLastMessageId(@NotNull TextChannel channel) {
-
         // black magic to convert Optional<Long> into OptionalLong because Optional does not have
         // .mapToLong
         return getChannelHistory(channel, 1).stream()
             .flatMap(List::stream)
             .mapToLong(Message::getIdLong)
             .findFirst();
-    }
-
-    /**
-     * Method that returns the time data from a discord snowflake.
-     *
-     * @param id the snowflake containing the time desired
-     * @return the creation time of the entity the id represents
-     */
-    public static @NotNull OffsetDateTime timeFromId(long id) {
-        return TimeUtil.getTimeCreated(id);
-    }
-
-    /**
-     * Method that calculates a time value a specific duration before now. The duration is
-     * configured in {@link FreeCommandConfig#INACTIVE_UNIT} and
-     * {@link FreeCommandConfig#INACTIVE_DURATION}.
-     * 
-     * @return the time value a set duration before now.
-     */
-    public static @NotNull OffsetDateTime inactiveTimeLimit() {
-        return OffsetDateTime.now()
-            .minus(FreeCommandConfig.INACTIVE_DURATION, FreeCommandConfig.INACTIVE_UNIT);
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/free/UserStrings.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/free/UserStrings.java
@@ -18,6 +18,10 @@ enum UserStrings {
     MARK_AS_FREE("""
             This channel is now available for a question to be asked.
             """),
+    AUTO_MARK_AS_FREE(
+            """
+                    This channel seems to be inactive and was now marked available for a question to be asked.
+                    """),
     ALREADY_FREE_ERROR("""
             This channel is already free, no changes made.
             """),

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -3,6 +3,7 @@ package org.togetherjava.tjbot.config;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -70,7 +71,8 @@ public final class Config {
      * @throws IOException if the file could not be loaded
      */
     public static Config load(Path path) throws IOException {
-        return new ObjectMapper().readValue(path.toFile(), Config.class);
+        return new ObjectMapper().registerModule(new JavaTimeModule())
+            .readValue(path.toFile(), Config.class);
     }
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/config/FreeCommandConfig.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/FreeCommandConfig.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import org.jetbrains.annotations.NotNull;
 
-import java.time.temporal.ChronoUnit;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -19,6 +19,8 @@ import java.util.List;
  * <pre>
  * "freeCommand": [
  *   {
+ *       "inactiveChannelDuration": duration,
+ *       "messageRetrieveLimit": int_number,
  *       "statusChannel": long_number,
  *       "monitoredChannels": [long_number, long_number]
  *   }]
@@ -31,21 +33,20 @@ import java.util.List;
 @SuppressWarnings("ClassCanBeRecord")
 @JsonRootName("freeCommand")
 public final class FreeCommandConfig {
-    // TODO make constants configurable via config file once config templating (#234) is pushed
-    public static final long INACTIVE_DURATION = 1;
-    public static final ChronoUnit INACTIVE_UNIT = ChronoUnit.HOURS;
-    public static final long INACTIVE_TEST_INTERVAL = 15;
-    public static final ChronoUnit INACTIVE_TEST_UNIT = ChronoUnit.MINUTES;
-    public static final int MESSAGE_RETRIEVE_LIMIT = 10;
-
     private final long statusChannel;
     private final List<Long> monitoredChannels;
+    private final Duration inactiveChannelDuration;
+    private final int messageRetrieveLimit;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     private FreeCommandConfig(@JsonProperty("statusChannel") long statusChannel,
-            @JsonProperty("monitoredChannels") List<Long> monitoredChannels) {
+            @JsonProperty("monitoredChannels") List<Long> monitoredChannels,
+            @JsonProperty("inactiveChannelDuration") Duration inactiveChannelDuration,
+            @JsonProperty("messageRetrieveLimit") int messageRetrieveLimit) {
         this.statusChannel = statusChannel;
         this.monitoredChannels = Collections.unmodifiableList(monitoredChannels);
+        this.messageRetrieveLimit = messageRetrieveLimit;
+        this.inactiveChannelDuration = inactiveChannelDuration;
     }
 
     /**
@@ -65,5 +66,23 @@ public final class FreeCommandConfig {
      */
     public @NotNull Collection<Long> getMonitoredChannels() {
         return monitoredChannels; // already unmodifiable
+    }
+
+    /**
+     * Gets the duration of inactivity after which a channel is considered inactive.
+     * 
+     * @return inactivity duration
+     */
+    public @NotNull Duration getInactiveChannelDuration() {
+        return inactiveChannelDuration;
+    }
+
+    /**
+     * Gets the limit of messages to retrieve when searching for previous status messages.
+     * 
+     * @return the message retrieve limit
+     */
+    public int getMessageRetrieveLimit() {
+        return messageRetrieveLimit;
     }
 }


### PR DESCRIPTION
## Overview

Implements and closes #392.

Automatically frees all help channels that are **inactive for more than 2 hours**:

![auto-free](https://i.imgur.com/nG304e0.png)

## Details

Solved by introducing a `AutoFreeRoutine` which executes each 5 minutes, processing the channels.

Functionality that has to be used by both, `FreeCommand` and the `AutoFreeRoutine`, has been moved over to `FreeChannelMonitor`, which both now take as constructor parameter.

## Config changes

The config slightly changed, introducing two new args to the `FreeCommandConfig`, looks like this:
```json
    "freeCommand": [
        {
            "inactiveChannelDuration": "PT2H",
            "messageRetrieveLimit": 10,
            "statusChannel": <put_a_channel_id_here>,
            "monitoredChannels": [
                    <put_a_channel_id_here>
                  ]
        }
   ],
```