### PR TITLE
Added missing Javadoc for public return value

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/moderation/ModAuditLogWriter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/moderation/ModAuditLogWriter.java
@@ -83,6 +83,7 @@ public final class ModAuditLogWriter {
      * this method will return an empty optional, and a warning message will be written.
      *
      * @param guild the guild to look for the channel in
+     * @return the channel used for moderation audit logs, if present
      */
     public Optional<TextChannel> getAndHandleModAuditLogChannel(@NotNull Guild guild) {
         Optional<TextChannel> auditLogChannel = guild.getTextChannelCache()


### PR DESCRIPTION
## Overview

Closes #430.

Our Sonar is currently failing due to a missing Javadoc for a return value of a public method:

![report](https://i.imgur.com/VnB2S9R.png)

This was originally merged by #296. But nobody noticed back then, since our Sonar config was incorrect until recently.

This fixes the issue by adding the Javadoc, easy money.