### PR TITLE
Adding Tex inline support

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/TeXCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/TeXCommand.java
@@ -36,13 +36,16 @@ import java.util.regex.Pattern;
  */
 
 public final class TeXCommand extends SlashCommandAdapter {
-    private static final String LATEX_OPTION = "latex";
+    static final String LATEX_OPTION = "latex";
     // Matches regions between two dollars, like '$foo$'.
     private static final String MATH_REGION = "(\\$[^$]+\\$)";
     private static final String TEXT_REGION = "([^$]+)";
     private static final Pattern INLINE_LATEX_REPLACEMENT =
             Pattern.compile(MATH_REGION + "|" + TEXT_REGION);
     private static final String RENDERING_ERROR = "There was an error generating the image";
+    static final String BAD_LATEX_ERROR_PREFIX = "That is an invalid latex: ";
+    static final String INVALID_INLINE_FORMAT_ERROR_MESSAGE =
+            "The amount of $-symbols must be divisible by two. Did you forget to close an expression?";
     private static final float DEFAULT_IMAGE_SIZE = 40.0F;
     private static final Color BACKGROUND_COLOR = Color.decode("#36393F");
     private static final Color FOREGROUND_COLOR = Color.decode("#FFFFFF");
@@ -70,7 +73,7 @@ public final class TeXCommand extends SlashCommandAdapter {
             }
             formula = new TeXFormula(latex);
         } catch (ParseException e) {
-            event.reply("That is an invalid latex: " + e.getMessage()).setEphemeral(true).queue();
+            event.reply(BAD_LATEX_ERROR_PREFIX + e.getMessage()).setEphemeral(true).queue();
             return;
         }
 
@@ -137,8 +140,7 @@ public final class TeXCommand extends SlashCommandAdapter {
     @NotNull
     private String convertInlineLatexToFull(@NotNull String latex) {
         if (isInvalidInlineFormat(latex)) {
-            throw new ParseException(
-                    "The amount of $-symbols must be divisible by two. Did you forget to close an expression? ");
+            throw new ParseException(INVALID_INLINE_FORMAT_ERROR_MESSAGE);
         }
 
         Matcher matcher = INLINE_LATEX_REPLACEMENT.matcher(latex);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/TeXCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/TeXCommand.java
@@ -2,8 +2,10 @@ package org.togetherjava.tjbot.commands.mathcommands;
 
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.interactions.callbacks.IDeferrableCallback;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 import org.jetbrains.annotations.NotNull;
 import org.scilab.forge.jlatexmath.ParseException;
 import org.scilab.forge.jlatexmath.TeXConstants;
@@ -21,6 +23,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Implementation of a tex command which takes a string and renders an image corresponding to the
@@ -31,11 +35,15 @@ import java.util.Objects;
  * message.
  */
 
-public class TeXCommand extends SlashCommandAdapter {
-
+public final class TeXCommand extends SlashCommandAdapter {
     private static final String LATEX_OPTION = "latex";
+    // Matches regions between two dollars, like '$foo$'.
+    private static final String MATH_REGION = "(\\$[^$]+\\$)";
+    private static final String TEXT_REGION = "([^$]+)";
+    private static final Pattern INLINE_LATEX_REPLACEMENT =
+            Pattern.compile(MATH_REGION + "|" + TEXT_REGION);
     private static final String RENDERING_ERROR = "There was an error generating the image";
-    private static final float DEFAULT_IMAGE_SIZE = 40F;
+    private static final float DEFAULT_IMAGE_SIZE = 40.0F;
     private static final Color BACKGROUND_COLOR = Color.decode("#36393F");
     private static final Color FOREGROUND_COLOR = Color.decode("#FFFFFF");
     private static final Logger logger = LoggerFactory.getLogger(TeXCommand.class);
@@ -44,8 +52,7 @@ public class TeXCommand extends SlashCommandAdapter {
      * Creates a new Instance.
      */
     public TeXCommand() {
-        super("tex",
-                "This command accepts a latex expression and generates an image corresponding to it.",
+        super("tex", "Renders LaTeX, also supports inline $-regions like 'see this $\frac{x}{2}$'.",
                 SlashCommandVisibility.GUILD);
         getData().addOption(OptionType.STRING, LATEX_OPTION,
                 "The latex which is rendered as an image", true);
@@ -56,40 +63,101 @@ public class TeXCommand extends SlashCommandAdapter {
         String latex = Objects.requireNonNull(event.getOption(LATEX_OPTION)).getAsString();
         String userID = (Objects.requireNonNull(event.getMember()).getId());
         TeXFormula formula;
+
         try {
+            if (latex.contains("$")) {
+                latex = convertInlineLatexToFull(latex);
+            }
             formula = new TeXFormula(latex);
         } catch (ParseException e) {
             event.reply("That is an invalid latex: " + e.getMessage()).setEphemeral(true).queue();
             return;
         }
+
         event.deferReply().queue();
-        Image image = formula.createBufferedImage(TeXConstants.STYLE_DISPLAY, DEFAULT_IMAGE_SIZE,
-                FOREGROUND_COLOR, BACKGROUND_COLOR);
-        if (image.getWidth(null) == -1 || image.getHeight(null) == -1) {
-            event.getHook().setEphemeral(true).editOriginal(RENDERING_ERROR).queue();
-            logger.warn(
-                    "Unable to render latex, image does not have an accessible width or height. Formula was {}",
-                    latex);
-            return;
-        }
-        BufferedImage renderedTextImage = new BufferedImage(image.getWidth(null),
-                image.getHeight(null), BufferedImage.TYPE_4BYTE_ABGR);
-        renderedTextImage.getGraphics().drawImage(image, 0, 0, null);
-        ByteArrayOutputStream renderedTextImageStream = new ByteArrayOutputStream();
 
         try {
-            ImageIO.write(renderedTextImage, "png", renderedTextImageStream);
+            Image image = renderImage(formula);
+            sendImage(event, userID, image);
         } catch (IOException e) {
-            event.getHook().setEphemeral(true).editOriginal(RENDERING_ERROR).queue();
+            event.getHook().editOriginal(RENDERING_ERROR).queue();
             logger.warn(
                     "Unable to render latex, could not convert the image into an attachable form. Formula was {}",
                     latex, e);
-            return;
+
+        } catch (IllegalStateException e) {
+            event.getHook().editOriginal(RENDERING_ERROR).queue();
+
+            logger.warn(
+                    "Unable to render latex, image does not have an accessible width or height. Formula was {}",
+                    latex, e);
         }
+    }
+
+    private @NotNull Image renderImage(@NotNull TeXFormula formula) {
+        Image image = formula.createBufferedImage(TeXConstants.STYLE_DISPLAY, DEFAULT_IMAGE_SIZE,
+                FOREGROUND_COLOR, BACKGROUND_COLOR);
+
+        if (image.getWidth(null) == -1 || image.getHeight(null) == -1) {
+            throw new IllegalStateException("Image has no height or width");
+        }
+        return image;
+    }
+
+    private void sendImage(@NotNull IDeferrableCallback event, @NotNull String userID,
+            @NotNull Image image) throws IOException {
+        ByteArrayOutputStream renderedTextImageStream = getRenderedTextImageStream(image);
         event.getHook()
             .editOriginal(renderedTextImageStream.toByteArray(), "tex.png")
-            .setActionRow(Button.danger(generateComponentId(userID), "Delete"))
+            .setActionRow(Button.of(ButtonStyle.DANGER, generateComponentId(userID), "Delete"))
             .queue();
+    }
+
+    @NotNull
+    private ByteArrayOutputStream getRenderedTextImageStream(@NotNull Image image)
+            throws IOException {
+        BufferedImage renderedTextImage = new BufferedImage(image.getWidth(null),
+                image.getHeight(null), BufferedImage.TYPE_4BYTE_ABGR);
+
+        renderedTextImage.getGraphics().drawImage(image, 0, 0, null);
+        ByteArrayOutputStream renderedTextImageStream = new ByteArrayOutputStream();
+
+        ImageIO.write(renderedTextImage, "png", renderedTextImageStream);
+
+        return renderedTextImageStream;
+    }
+
+    /**
+     * Converts inline latex like: {@code hello $\frac{x}{2}$ world} to full latex
+     * {@code \text{hello}\frac{x}{2}\text{ world}}.
+     *
+     * @param latex the latex to convert
+     * @return the converted latex
+     */
+    @NotNull
+    private String convertInlineLatexToFull(@NotNull String latex) {
+        if (isInvalidInlineFormat(latex)) {
+            throw new ParseException(
+                    "The amount of $-symbols must be divisible by two. Did you forget to close an expression? ");
+        }
+
+        Matcher matcher = INLINE_LATEX_REPLACEMENT.matcher(latex);
+        StringBuilder sb = new StringBuilder(latex.length());
+
+        while (matcher.find()) {
+            boolean isInsideMathRegion = matcher.group(1) != null;
+            if (isInsideMathRegion) {
+                sb.append(matcher.group(1).replace("$", ""));
+            } else {
+                sb.append("\\text{").append(matcher.group(2)).append("}");
+            }
+        }
+
+        return sb.toString();
+    }
+
+    private boolean isInvalidInlineFormat(@NotNull String latex) {
+        return latex.chars().filter(charAsInt -> charAsInt == '$').count() % 2 == 1;
     }
 
     @Override

--- a/application/src/test/java/org/togetherjava/tjbot/commands/mathcommands/TeXCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/mathcommands/TeXCommandTest.java
@@ -1,0 +1,109 @@
+package org.togetherjava.tjbot.commands.mathcommands;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.togetherjava.tjbot.commands.SlashCommand;
+import org.togetherjava.tjbot.jda.JdaTester;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.description;
+import static org.mockito.Mockito.verify;
+
+final class TeXCommandTest {
+    private JdaTester jdaTester;
+    private SlashCommand command;
+
+    @BeforeEach
+    void setUp() {
+        jdaTester = new JdaTester();
+        command = jdaTester.spySlashCommand(new TeXCommand());
+    }
+
+    private @NotNull SlashCommandInteractionEvent triggerSlashCommand(@NotNull String latex) {
+        SlashCommandInteractionEvent event = jdaTester.createSlashCommandInteractionEvent(command)
+            .setOption(TeXCommand.LATEX_OPTION, latex)
+            .build();
+
+        command.onSlashCommand(event);
+        return event;
+    }
+
+    private void verifySuccessfulResponse(@NotNull SlashCommandInteractionEvent event,
+            @NotNull String query) {
+        verify(jdaTester.getInteractionHookMock(), description("Testing query: " + query))
+            .editOriginal(any(byte[].class), eq("tex.png"));
+    }
+
+    private static List<String> provideSupportedQueries() {
+        List<String> fullLatex = List.of("\\frac{x}{2}", "f \\in \\mathcal{O}(n^2)",
+                "a^{\\varphi(n)} \\equiv 1\\ (\\textrm{mod}\\ n)", "\\textrm{I like } \\xi");
+
+        List<String> inlineLatex = List.of("$\\frac{x}{2}$", "$x$ hello", "hello $x$",
+                "hello $x$ world $y$", "$x$$y$$z$", "$x \\cdot y$");
+
+        List<String> edgeCases = List.of("", "   ", " \n ");
+
+        List<String> allQueries = new ArrayList<>();
+        allQueries.addAll(fullLatex);
+        allQueries.addAll(inlineLatex);
+        allQueries.addAll(edgeCases);
+
+        return allQueries;
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSupportedQueries")
+    @DisplayName("The command supports and renders all supported latex queries")
+    void canRenderSupportedQuery(@NotNull String supportedQuery) {
+        // GIVEN a supported latex query
+
+        // WHEN triggering the command
+        SlashCommandInteractionEvent event = triggerSlashCommand(supportedQuery);
+
+        // THEN the command send a successful response
+        verifySuccessfulResponse(event, supportedQuery);
+    }
+
+    private static List<String> provideBadInlineQueries() {
+        return List.of("hello $x world", "$", "  $  ", "hello $x$ world$", "$$$$$", "$x$$y$$z");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideBadInlineQueries")
+    @DisplayName("The command does not support bad inline latex queries, for example with missing dollars")
+    void failsOnBadInlineQuery(@NotNull String badInlineQuery) {
+        // GIVEN a bad inline latex query
+
+        // WHEN triggering the command
+        SlashCommandInteractionEvent event = triggerSlashCommand(badInlineQuery);
+
+        // THEN the command send a failure response
+        verify(event, description("Testing query: " + badInlineQuery))
+            .reply(contains(TeXCommand.INVALID_INLINE_FORMAT_ERROR_MESSAGE));
+    }
+
+    private static List<String> provideBadQueries() {
+        return List.of("__", "\\foo", "\\left(x + y)");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideBadQueries")
+    @DisplayName("The command does not support bad latex queries, for example with unknown symbols or incomplete braces")
+    void failsOnBadQuery(@NotNull String badQuery) {
+        // GIVEN a bad inline latex query
+
+        // WHEN triggering the command
+        SlashCommandInteractionEvent event = triggerSlashCommand(badQuery);
+
+        // THEN the command send a failure response
+        verify(event, description("Testing query: " + badQuery))
+            .reply(startsWith(TeXCommand.BAD_LATEX_ERROR_PREFIX));
+    }
+}


### PR DESCRIPTION
## Overview

Implements and closes #386.

A copy of #397 with some minor edits.

Adds support for inline latex, so `/tex latex: see this $\frac{x}{2}$`.

The code is also covered with unit tests.

![example](https://i.imgur.com/wIi3sUy.png)