### PR TITLE
Top helpers based on message length

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersMessageListener.java
@@ -44,6 +44,7 @@ public final class TopHelpersMessageListener extends MessageReceiverAdapter {
             .setChannelId(event.getChannel().getIdLong())
             .setAuthorId(event.getAuthor().getIdLong())
             .setSentAt(event.getMessage().getTimeCreated().toInstant())
+            .setMessageLength((long) event.getMessage().getContentRaw().length())
             .insert());
     }
 }

--- a/application/src/main/resources/db/V10__Alter_Top_Helper_Message_Length.sql
+++ b/application/src/main/resources/db/V10__Alter_Top_Helper_Message_Length.sql
@@ -1,0 +1,1 @@
+ALTER TABLE help_channel_messages ADD message_length BIGINT DEFAULT 1 NOT NULL;


### PR DESCRIPTION
## Overview

Since determining top helpers on message count is indeed quite unfair to helpers who prefer to type out their messages instead of posting multiple mini messages, this changes the metric to measure and determine them based on the **length of the messages**.

Not perfect, but gets the job done and is fairer.

![example](https://i.imgur.com/I4Nepob.png)

Existing data stays untouched. We could revert back at any time. Also, for previous months, the new code can still output the same results as before (by defaulting to message length 1 for migrated content).

## When to release

Note that this should ideally be released near the end or start of a month, to not mess up the metric for that month. It should definitely not be released in the middle of a month. Alternatively, it can of course still be manually retrieved from the database with the old query.