### PR TITLE
Fixing thread help system bugs

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
@@ -16,18 +16,21 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
+import static org.togetherjava.tjbot.commands.help.HelpSystemHelper.TITLE_COMPACT_LENGTH_MAX;
+import static org.togetherjava.tjbot.commands.help.HelpSystemHelper.TITLE_COMPACT_LENGTH_MIN;
+
 /**
  * Implements the {@code /ask} command, which is the main way of asking questions. The command can
  * only be used in the staging channel.
- *
+ * <p>
  * Upon use, it will create a new thread for the question and invite all helpers interested in the
  * given category to it. It will also introduce the user to the system and give a quick explanation
  * message.
- *
+ * <p>
  * The other way to ask questions is by {@link ImplicitAskListener}.
- *
+ * <p>
  * Example usage:
- * 
+ *
  * <pre>
  * {@code
  * /ask title: How to send emails? category: Frameworks
@@ -76,6 +79,10 @@ public final class AskCommand extends SlashCommandAdapter {
             return;
         }
 
+        if (!handleIsValidTitle(title, event)) {
+            return;
+        }
+
         TextChannel helpStagingChannel = event.getTextChannel();
         helpStagingChannel.createThreadChannel("[%s] %s".formatted(category, title))
             .flatMap(threadChannel -> handleEvent(event, threadChannel, event.getMember(), title,
@@ -90,6 +97,20 @@ public final class AskCommand extends SlashCommandAdapter {
         }
 
         event.reply("Sorry, but this command can only be used in the help staging channel.")
+            .setEphemeral(true)
+            .queue();
+
+        return false;
+    }
+
+    private boolean handleIsValidTitle(@NotNull CharSequence title, @NotNull IReplyCallback event) {
+        if (HelpSystemHelper.isTitleValid(title)) {
+            return true;
+        }
+
+        event.reply(
+                "Sorry, but the titel length (after removal of special characters) has to be between %d and %d."
+                    .formatted(TITLE_COMPACT_LENGTH_MIN, TITLE_COMPACT_LENGTH_MAX))
             .setEphemeral(true)
             .queue();
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpCategoryCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpCategoryCommand.java
@@ -1,5 +1,7 @@
 package org.togetherjava.tjbot.commands.help;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.Role;
@@ -14,7 +16,10 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Implements the {@code /change-help-category} command, which is able to change the category of a
@@ -29,7 +34,11 @@ import java.util.Optional;
 public final class ChangeHelpCategoryCommand extends SlashCommandAdapter {
     private static final String CATEGORY_OPTION = "category";
 
+    private static final int COOLDOWN_DURATION_VALUE = 1;
+    private static final ChronoUnit COOLDOWN_DURATION_UNIT = ChronoUnit.HOURS;
+
     private final HelpSystemHelper helper;
+    private final Cache<Long, Instant> helpThreadIdToLastCategoryChange;
 
     /**
      * Creates a new instance.
@@ -49,6 +58,11 @@ public final class ChangeHelpCategoryCommand extends SlashCommandAdapter {
 
         getData().addOptions(category);
 
+        helpThreadIdToLastCategoryChange = Caffeine.newBuilder()
+            .maximumSize(1_000)
+            .expireAfterAccess(COOLDOWN_DURATION_VALUE, TimeUnit.of(COOLDOWN_DURATION_UNIT))
+            .build();
+
         this.helper = helper;
     }
 
@@ -65,6 +79,16 @@ public final class ChangeHelpCategoryCommand extends SlashCommandAdapter {
             event.reply("This thread is already closed.").setEphemeral(true).queue();
             return;
         }
+
+        if (isHelpThreadOnCooldown(helpThread)) {
+            event
+                .reply("Please wait a bit, this command can only be used once per %d %s."
+                    .formatted(COOLDOWN_DURATION_VALUE, COOLDOWN_DURATION_UNIT))
+                .setEphemeral(true)
+                .queue();
+            return;
+        }
+        helpThreadIdToLastCategoryChange.put(helpThread.getIdLong(), Instant.now());
 
         event.deferReply().queue();
 
@@ -95,5 +119,14 @@ public final class ChangeHelpCategoryCommand extends SlashCommandAdapter {
                 headsUpPattern.formatted(helperRole.orElseThrow().getAsMention() + " ");
         return action.flatMap(any -> helpThread.sendMessage(headsUpWithoutRole)
             .flatMap(message -> message.editMessage(headsUpWithRole)));
+    }
+
+    private boolean isHelpThreadOnCooldown(@NotNull ThreadChannel helpThread) {
+        return Optional
+            .ofNullable(helpThreadIdToLastCategoryChange.getIfPresent(helpThread.getIdLong()))
+            .map(lastCategoryChange -> lastCategoryChange.plus(COOLDOWN_DURATION_VALUE,
+                    COOLDOWN_DURATION_UNIT))
+            .filter(Instant.now()::isBefore)
+            .isPresent();
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -34,6 +34,10 @@ public final class HelpSystemHelper {
     private static final Pattern EXTRACT_CATEGORY_TITLE_PATTERN =
             Pattern.compile("(?:\\[(?<%s>.+)] )?(?<%s>.+)".formatted(CATEGORY_GROUP, TITLE_GROUP));
 
+    private static final Pattern TITLE_COMPACT_REMOVAL_PATTERN = Pattern.compile("\\W");
+    static final int TITLE_COMPACT_LENGTH_MIN = 2;
+    static final int TITLE_COMPACT_LENGTH_MAX = 80;
+
     private final Predicate<String> isOverviewChannelName;
     private final String overviewChannelPattern;
     private final Predicate<String> isStagingChannelName;
@@ -174,5 +178,12 @@ public final class HelpSystemHelper {
     @NotNull
     String getStagingChannelPattern() {
         return stagingChannelPattern;
+    }
+
+    static boolean isTitleValid(@NotNull CharSequence title) {
+        String titleCompact = TITLE_COMPACT_REMOVAL_PATTERN.matcher(title).replaceAll("");
+
+        return titleCompact.length() >= TITLE_COMPACT_LENGTH_MIN
+                && titleCompact.length() <= TITLE_COMPACT_LENGTH_MAX;
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
@@ -27,11 +27,11 @@ import java.util.regex.Pattern;
  * <p>
  * Listens to plain messages in the staging channel, picks them up and transfers them into a proper
  * question thread.
- *
+ * <p>
  * The system can handle spam appropriately and will not create multiple threads for each message.
- *
+ * <p>
  * For example:
- * 
+ *
  * <pre>
  * {@code
  * John sends: How to send emails?
@@ -128,17 +128,22 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
     }
 
     private static @NotNull String createTitle(@NotNull String message) {
+        String titleCandidate;
         if (message.length() < TITLE_MAX_LENGTH) {
-            return message;
-        }
-        // Attempt to end at the last word before hitting the limit
-        // e.g. "[foo bar] baz" for a limit somewhere in between "baz"
-        int lastWordEnd = message.lastIndexOf(' ', TITLE_MAX_LENGTH);
-        if (lastWordEnd == -1) {
-            lastWordEnd = TITLE_MAX_LENGTH;
+            titleCandidate = message;
+        } else {
+            // Attempt to end at the last word before hitting the limit
+            // e.g. "[foo bar] baz" for a limit somewhere in between "baz"
+            int lastWordEnd = message.lastIndexOf(' ', TITLE_MAX_LENGTH);
+            if (lastWordEnd == -1) {
+                lastWordEnd = TITLE_MAX_LENGTH;
+            }
+
+            titleCandidate = message.substring(0, lastWordEnd);
         }
 
-        return message.substring(0, lastWordEnd);
+        return HelpSystemHelper.isTitleValid(titleCandidate) ? titleCandidate : "Untitled";
+
     }
 
     private @NotNull RestAction<?> handleEvent(@NotNull ThreadChannel threadChannel,


### PR DESCRIPTION
## Overview

We recently pushed the new thread based help system and quickly discovered a couple of bugs. This PR fixes most of the known issues:

* `/ask` command with too long title:

![ask too long title](https://i.imgur.com/Q51qTFG.png)

* just uploading a file, no actual text content:

![file upload](https://i.imgur.com/89mKmc7.png)

* issue with rate limits on `/change-help-category`

![channel rename](https://i.imgur.com/NOSnuha.png)

* issue with rate limits on `/close`

![close](https://i.imgur.com/bIYNs7Z.png)

* title containing invalid characters