### PR TITLE
Adding /set-log-level command

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
@@ -17,6 +17,7 @@ import org.togetherjava.tjbot.commands.moderation.temp.TemporaryModerationRoutin
 import org.togetherjava.tjbot.commands.reminder.RemindCommand;
 import org.togetherjava.tjbot.commands.reminder.RemindRoutine;
 import org.togetherjava.tjbot.commands.system.BotCore;
+import org.togetherjava.tjbot.commands.system.LogLevelCommand;
 import org.togetherjava.tjbot.commands.tags.TagCommand;
 import org.togetherjava.tjbot.commands.tags.TagManageCommand;
 import org.togetherjava.tjbot.commands.tags.TagSystem;
@@ -85,6 +86,7 @@ public enum Features {
         features.add(new RejoinModerationRoleListener(actionsStore, config));
 
         // Slash commands
+        features.add(new LogLevelCommand());
         features.add(new PingCommand());
         features.add(new TeXCommand());
         features.add(new TagCommand(tagSystem));

--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/LogLevelCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/LogLevelCommand.java
@@ -1,0 +1,61 @@
+package org.togetherjava.tjbot.commands.system;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.jetbrains.annotations.NotNull;
+import org.togetherjava.tjbot.commands.SlashCommandAdapter;
+import org.togetherjava.tjbot.commands.SlashCommandVisibility;
+
+import java.util.stream.Stream;
+
+/**
+ * Implements the '/set-log-level' command which can be used to change the log level used by the
+ * bot, while it is running.
+ * <p>
+ * Example usage:
+ *
+ * <pre>
+ * {@code
+ * /set-log-level level: INFO
+ * }
+ * </pre>
+ */
+public final class LogLevelCommand extends SlashCommandAdapter {
+    private static final String LOG_LEVEL_OPTION = "level";
+
+    /**
+     * Creates a new instance.
+     */
+    public LogLevelCommand() {
+        super("set-log-level", "Changes the log level of the bot while it is running.",
+                SlashCommandVisibility.GUILD);
+
+        OptionData option =
+                new OptionData(OptionType.STRING, LOG_LEVEL_OPTION, "the log level to set", true);
+        Stream.of(Level.values()).map(Level::name).forEach(level -> option.addChoice(level, level));
+
+        getData().addOptions(option);
+    }
+
+    // Security warning about changing log configs. We only change the level, that is safe.
+    @SuppressWarnings("squid:S4792")
+    @Override
+    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+        String levelText = event.getOption(LOG_LEVEL_OPTION).getAsString();
+        Level level = Level.getLevel(levelText);
+
+        if (level == null) {
+            event.reply("The selected log level '%s' is unknown.".formatted(levelText))
+                .setEphemeral(true)
+                .queue();
+            return;
+        }
+
+        Configurator.setAllLevels(LogManager.getRootLogger().getName(), level);
+        event.reply("Set the log level to '%s'.".formatted(levelText)).queue();
+    }
+}


### PR DESCRIPTION
## Overview

This adds the `/set-log-level` command, which changes the log level hot, while the bot runs.

Code stolen from the idiomatic SO: https://stackoverflow.com/a/44678752/2411243