### PR TITLE
Bugfixing some help thread issues

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -8,7 +8,6 @@
     "heavyModerationRolePattern": "Moderator",
     "softModerationRolePattern": "Moderator|Staff Assistant",
     "tagManageRolePattern": "Moderator|Staff Assistant|Top Helpers .+",
-   "helpChannelPattern": "([a-zA-Z_]+_)?help(_\\d+)?",
    "suggestions": {
        "channelPattern": "tj_suggestions",
        "upVoteEmoteName": "peepo_yes",

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
@@ -109,7 +109,7 @@ public final class AskCommand extends SlashCommandAdapter {
         }
 
         event.reply(
-                "Sorry, but the titel length (after removal of special characters) has to be between %d and %d."
+                "Sorry, but the title length (after removal of special characters) has to be between %d and %d."
                     .formatted(TITLE_COMPACT_LENGTH_MIN, TITLE_COMPACT_LENGTH_MAX))
             .setEphemeral(true)
             .queue();

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/BotMessageCleanup.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/BotMessageCleanup.java
@@ -108,10 +108,13 @@ public final class BotMessageCleanup implements Routine {
 
     private static @NotNull RestAction<Void> cleanupBotMessages(
             @NotNull GuildMessageChannel channel, @NotNull Collection<? extends Message> messages) {
+        logger.debug("Cleaning up old bot messages in the staging channel");
         List<String> messageIdsToDelete = messages.stream()
             .filter(BotMessageCleanup::shouldMessageBeCleanedUp)
             .map(Message::getId)
             .toList();
+
+        logger.debug("Found {} messages to delete", messageIdsToDelete.size());
 
         if (messageIdsToDelete.isEmpty()) {
             return new CompletedRestAction<>(channel.getJDA(), null, null);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -85,7 +85,7 @@ public final class HelpSystemHelper {
                                 If nobody is calling back, that usually means that your question was **not well asked** and \
                                     hence nobody feels confident enough answering. Try to use your time to elaborate, \
                                     **provide details**, context, more code, examples and maybe some screenshots. \
-                                    With enough info, someone knows the answer for sure ."""));
+                                    With enough info, someone knows the answer for sure."""));
 
         MessageAction action = threadChannel.sendMessage(message);
         if (useCodeSyntaxExampleImage) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
@@ -32,6 +32,7 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
     private static final Logger logger = LoggerFactory.getLogger(HelpThreadOverviewUpdater.class);
 
     private static final String STATUS_TITLE = "Active questions";
+    private static final int OVERVIEW_QUESTION_LIMIT = 150;
 
     private final HelpSystemHelper helper;
     private final List<String> allCategories;
@@ -148,6 +149,7 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
 
         return activeThreads.stream()
             .sorted(Comparator.comparing(ThreadChannel::getTimeCreated).reversed())
+            .limit(OVERVIEW_QUESTION_LIMIT)
             .collect(Collectors
                 .groupingBy(thread -> helper.getCategoryOfChannel(thread).orElse("Uncategorized")))
             .entrySet()

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
@@ -122,10 +122,14 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
 
     private void updateOverview(@NotNull IThreadContainer stagingChannel,
             @NotNull MessageChannel overviewChannel) {
+        logger.debug("Updating overview of active questions");
+
         List<ThreadChannel> activeThreads = stagingChannel.getThreadChannels()
             .stream()
             .filter(Predicate.not(ThreadChannel::isArchived))
             .toList();
+
+        logger.debug("Found {} active questions", activeThreads.size());
 
         MessageEmbed embed = new EmbedBuilder().setTitle(STATUS_TITLE)
             .setDescription(createDescription(activeThreads))
@@ -133,6 +137,7 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
             .build();
 
         getStatusMessage(overviewChannel).flatMap(maybeStatusMessage -> {
+            logger.debug("Sending the updated question overview");
             if (maybeStatusMessage.isEmpty()) {
                 return overviewChannel.sendMessageEmbeds(embed);
             }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
@@ -92,14 +92,19 @@ public final class BotCore extends ListenerAdapter implements SlashCommandProvid
             .filter(Routine.class::isInstance)
             .map(Routine.class::cast)
             .forEach(routine -> {
+                Runnable command = () -> {
+                    String routineName = routine.getClass().getSimpleName();
+                    logger.debug("Running routine %s...".formatted(routineName));
+                    routine.runRoutine(jda);
+                    logger.debug("Finished routine %s.".formatted(routineName));
+                };
+
                 Routine.Schedule schedule = routine.createSchedule();
                 switch (schedule.mode()) {
-                    case FIXED_RATE -> ROUTINE_SERVICE.scheduleAtFixedRate(
-                            () -> routine.runRoutine(jda), schedule.initialDuration(),
-                            schedule.duration(), schedule.unit());
-                    case FIXED_DELAY -> ROUTINE_SERVICE.scheduleWithFixedDelay(
-                            () -> routine.runRoutine(jda), schedule.initialDuration(),
-                            schedule.duration(), schedule.unit());
+                    case FIXED_RATE -> ROUTINE_SERVICE.scheduleAtFixedRate(command,
+                            schedule.initialDuration(), schedule.duration(), schedule.unit());
+                    case FIXED_DELAY -> ROUTINE_SERVICE.scheduleWithFixedDelay(command,
+                            schedule.initialDuration(), schedule.duration(), schedule.unit());
                     default -> throw new AssertionError("Unsupported schedule mode");
                 }
             });

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -22,7 +22,6 @@ public final class Config {
     private final String heavyModerationRolePattern;
     private final String softModerationRolePattern;
     private final String tagManageRolePattern;
-    private final String helpChannelPattern;
     private final SuggestionsConfig suggestions;
     private final String quarantinedRolePattern;
     private final ScamBlockerConfig scamBlocker;
@@ -40,7 +39,6 @@ public final class Config {
             @JsonProperty("heavyModerationRolePattern") String heavyModerationRolePattern,
             @JsonProperty("softModerationRolePattern") String softModerationRolePattern,
             @JsonProperty("tagManageRolePattern") String tagManageRolePattern,
-            @JsonProperty("helpChannelPattern") String helpChannelPattern,
             @JsonProperty("suggestions") SuggestionsConfig suggestions,
             @JsonProperty("quarantinedRolePattern") String quarantinedRolePattern,
             @JsonProperty("scamBlocker") ScamBlockerConfig scamBlocker,
@@ -55,7 +53,6 @@ public final class Config {
         this.heavyModerationRolePattern = heavyModerationRolePattern;
         this.softModerationRolePattern = softModerationRolePattern;
         this.tagManageRolePattern = tagManageRolePattern;
-        this.helpChannelPattern = helpChannelPattern;
         this.suggestions = suggestions;
         this.quarantinedRolePattern = quarantinedRolePattern;
         this.scamBlocker = scamBlocker;
@@ -158,16 +155,6 @@ public final class Config {
      */
     public String getTagManageRolePattern() {
         return tagManageRolePattern;
-    }
-
-    /**
-     * Gets the REGEX pattern used to identify channels that are used for helping people with their
-     * questions.
-     *
-     * @return the channel name pattern
-     */
-    public @NotNull String getHelpChannelPattern() {
-        return helpChannelPattern;
     }
 
     /**

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,6 @@ rootProject.name = 'TJ-Bot'
 include 'application'
 include 'database'
 include 'formatter'
-include 'logviewer'
+// NOTE The logviewer does not properly work as of today.
+//  But it is causing major build slowdowns, so we exclude it for the time being.
+// include 'logviewer'


### PR DESCRIPTION
## Overview

This is to address most of the help thread issues we discovered, and to prepare investigation of the routine-scheduling issue we are experiencing right now.

Contents:
* Disabled logviewer for now, its not working anyways
* Removed leftover `helpChannelPattern` in config
* fixed two minor typos (space before `.` and `titel` vs `title`)
* adding a limit of 150 questions for the overview to not run into Discord issues
* adding some debug-level logs for investigation