### PR TITLE
Help thread improvements

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/CloseCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/CloseCommand.java
@@ -12,6 +12,7 @@ import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -22,8 +23,8 @@ import java.util.concurrent.TimeUnit;
  * use. Meant to be used once a question has been resolved.
  */
 public final class CloseCommand extends SlashCommandAdapter {
-    private static final int COOLDOWN_DURATION_VALUE = 1;
-    private static final ChronoUnit COOLDOWN_DURATION_UNIT = ChronoUnit.HOURS;
+    private static final int COOLDOWN_DURATION_VALUE = 30;
+    private static final ChronoUnit COOLDOWN_DURATION_UNIT = ChronoUnit.MINUTES;
 
     private final HelpSystemHelper helper;
     private final Cache<Long, Instant> helpThreadIdToLastClose;
@@ -58,8 +59,9 @@ public final class CloseCommand extends SlashCommandAdapter {
 
         if (isHelpThreadOnCooldown(helpThread)) {
             event
-                .reply("Please wait a bit, this command can only be used once per %d %s."
-                    .formatted(COOLDOWN_DURATION_VALUE, COOLDOWN_DURATION_UNIT))
+                .reply("Please wait a bit, this command can only be used once per %d %s.".formatted(
+                        COOLDOWN_DURATION_VALUE,
+                        COOLDOWN_DURATION_UNIT.toString().toLowerCase(Locale.US)))
                 .setEphemeral(true)
                 .queue();
             return;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -31,8 +31,8 @@ public final class HelpSystemHelper {
     private static final String CODE_SYNTAX_EXAMPLE_PATH = "codeSyntaxExample.png";
     private static final String CATEGORY_GROUP = "category";
     private static final String TITLE_GROUP = "title";
-    private static final Pattern EXTRACT_CATEGORY_TITLE_PATTERN =
-            Pattern.compile("(?:\\[(?<%s>.+)] )?(?<%s>.+)".formatted(CATEGORY_GROUP, TITLE_GROUP));
+    private static final Pattern EXTRACT_CATEGORY_TITLE_PATTERN = Pattern
+        .compile("(?:\\[(?<%s>[^\\[]+)] )?(?<%s>.+)".formatted(CATEGORY_GROUP, TITLE_GROUP));
 
     private static final Pattern TITLE_COMPACT_REMOVAL_PATTERN = Pattern.compile("\\W");
     static final int TITLE_COMPACT_LENGTH_MIN = 2;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
@@ -1,7 +1,7 @@
 package org.togetherjava.tjbot.commands.help;
 
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.requests.RestAction;
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter implements Routine {
     private static final Logger logger = LoggerFactory.getLogger(HelpThreadOverviewUpdater.class);
 
-    private static final String STATUS_TITLE = "Active questions";
+    private static final String STATUS_TITLE = "## __**Active questions**__ ##";
     private static final int OVERVIEW_QUESTION_LIMIT = 150;
 
     private final HelpSystemHelper helper;
@@ -131,19 +131,18 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
 
         logger.debug("Found {} active questions", activeThreads.size());
 
-        MessageEmbed embed = new EmbedBuilder().setTitle(STATUS_TITLE)
-            .setDescription(createDescription(activeThreads))
-            .setColor(HelpSystemHelper.AMBIENT_COLOR)
+        Message message = new MessageBuilder()
+            .setContent(STATUS_TITLE + "\n\n" + createDescription(activeThreads))
             .build();
 
         getStatusMessage(overviewChannel).flatMap(maybeStatusMessage -> {
             logger.debug("Sending the updated question overview");
             if (maybeStatusMessage.isEmpty()) {
-                return overviewChannel.sendMessageEmbeds(embed);
+                return overviewChannel.sendMessage(message);
             }
 
             String statusMessageId = maybeStatusMessage.orElseThrow().getId();
-            return overviewChannel.editMessageEmbedsById(statusMessageId, embed);
+            return overviewChannel.editMessageById(statusMessageId, message);
         }).queue();
     }
 
@@ -186,13 +185,8 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
             return false;
         }
 
-        List<MessageEmbed> embeds = message.getEmbeds();
-        if (embeds.isEmpty()) {
-            return false;
-        }
-
-        MessageEmbed embed = embeds.get(0);
-        return STATUS_TITLE.equals(embed.getTitle());
+        String content = message.getContentRaw();
+        return content.startsWith(STATUS_TITLE);
     }
 
     private enum ChannelType {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
@@ -44,7 +44,7 @@ import java.util.regex.Pattern;
 public final class ImplicitAskListener extends MessageReceiverAdapter {
     private static final Logger logger = LoggerFactory.getLogger(ImplicitAskListener.class);
 
-    private static final int TITLE_MAX_LENGTH = 30;
+    private static final int TITLE_MAX_LENGTH = 50;
 
     private static final int COOLDOWN_DURATION_VALUE = 15;
     private static final ChronoUnit COOLDOWN_DURATION_UNIT = ChronoUnit.SECONDS;


### PR DESCRIPTION
## Overview

Yet another small PR to fix some help thread issues:

* close command one hour rate limiting is too much
* increase auto-title length a bit
* make overview message a regular message instead of embed (clickable links on mobile)
* overview-regex pattern broke for `"[Java] remove duplicates from int[] in ordered way. How to use TreeSet?"` it extracted category: `"Java] remove duplicates from int["`
