### PR TITLE
Moved question threads under overview channel instead of staging channel

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
@@ -16,6 +16,8 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
+import java.util.Optional;
+
 import static org.togetherjava.tjbot.commands.help.HelpSystemHelper.TITLE_COMPACT_LENGTH_MAX;
 import static org.togetherjava.tjbot.commands.help.HelpSystemHelper.TITLE_COMPACT_LENGTH_MIN;
 
@@ -83,8 +85,14 @@ public final class AskCommand extends SlashCommandAdapter {
             return;
         }
 
-        TextChannel helpStagingChannel = event.getTextChannel();
-        helpStagingChannel.createThreadChannel("[%s] %s".formatted(category, title))
+        Optional<TextChannel> maybeOverviewChannel =
+                helper.handleRequireOverviewChannelForAsk(event.getGuild(), event.getChannel());
+        if (maybeOverviewChannel.isEmpty()) {
+            return;
+        }
+        TextChannel overviewChannel = maybeOverviewChannel.orElseThrow();
+
+        overviewChannel.createThreadChannel("[%s] %s".formatted(category, title))
             .flatMap(threadChannel -> handleEvent(event, threadChannel, event.getMember(), title,
                     category))
             .queue(any -> {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
@@ -85,8 +85,14 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
 
         String title = createTitle(message.getContentDisplay());
 
-        TextChannel helpStagingChannel = event.getTextChannel();
-        helpStagingChannel.createThreadChannel(title)
+        Optional<TextChannel> maybeOverviewChannel =
+                helper.handleRequireOverviewChannelForAsk(event.getGuild(), event.getChannel());
+        if (maybeOverviewChannel.isEmpty()) {
+            return;
+        }
+        TextChannel overviewChannel = maybeOverviewChannel.orElseThrow();
+
+        overviewChannel.createThreadChannel(title)
             .flatMap(threadChannel -> handleEvent(threadChannel, message, title))
             .queue(any -> {
             }, ImplicitAskListener::handleFailure);
@@ -143,7 +149,6 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
         }
 
         return HelpSystemHelper.isTitleValid(titleCandidate) ? titleCandidate : "Untitled";
-
     }
 
     private @NotNull RestAction<?> handleEvent(@NotNull ThreadChannel threadChannel,


### PR DESCRIPTION
## Overview

Conceptionally, this is quite simple. Before, question threads were rooted under the `#ask_here` channel. Now they are moved under the `#active_questions` channel. Everything else stays the same. So people still post in `#ask_here`, its just that the threads are created elsewhere.

That way we can split the channels and move them further apart. For example `#ask_here` to the very top of the server and `#active_questions` (with the long list of questions) to the bottom.

![overview](https://i.imgur.com/f0P1Skm.png)