### PR TITLE
Added /change-help-title command

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
@@ -111,6 +111,7 @@ public enum Features {
         features.add(new AskCommand(config, helpSystemHelper));
         features.add(new CloseCommand(helpSystemHelper));
         features.add(new ChangeHelpCategoryCommand(config, helpSystemHelper));
+        features.add(new ChangeHelpTitleCommand(helpSystemHelper));
 
         // Mixtures
         features.add(new HelpThreadOverviewUpdater(config, helpSystemHelper));

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpCategoryCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpCategoryCommand.java
@@ -18,6 +18,7 @@ import org.togetherjava.tjbot.config.Config;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -34,8 +35,8 @@ import java.util.concurrent.TimeUnit;
 public final class ChangeHelpCategoryCommand extends SlashCommandAdapter {
     private static final String CATEGORY_OPTION = "category";
 
-    private static final int COOLDOWN_DURATION_VALUE = 1;
-    private static final ChronoUnit COOLDOWN_DURATION_UNIT = ChronoUnit.HOURS;
+    private static final int COOLDOWN_DURATION_VALUE = 30;
+    private static final ChronoUnit COOLDOWN_DURATION_UNIT = ChronoUnit.MINUTES;
 
     private final HelpSystemHelper helper;
     private final Cache<Long, Instant> helpThreadIdToLastCategoryChange;
@@ -82,8 +83,9 @@ public final class ChangeHelpCategoryCommand extends SlashCommandAdapter {
 
         if (isHelpThreadOnCooldown(helpThread)) {
             event
-                .reply("Please wait a bit, this command can only be used once per %d %s."
-                    .formatted(COOLDOWN_DURATION_VALUE, COOLDOWN_DURATION_UNIT))
+                .reply("Please wait a bit, this command can only be used once per %d %s.".formatted(
+                        COOLDOWN_DURATION_VALUE,
+                        COOLDOWN_DURATION_UNIT.toString().toLowerCase(Locale.US)))
                 .setEphemeral(true)
                 .queue();
             return;
@@ -92,7 +94,7 @@ public final class ChangeHelpCategoryCommand extends SlashCommandAdapter {
 
         event.deferReply().queue();
 
-        helper.renameChannelToCategoryTitle(helpThread, category)
+        helper.renameChannelToCategory(helpThread, category)
             .flatMap(any -> sendCategoryChangedMessage(helpThread.getGuild(), event.getHook(),
                     helpThread, category))
             .queue();

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpTitleCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpTitleCommand.java
@@ -1,0 +1,105 @@
+package org.togetherjava.tjbot.commands.help;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.ThreadChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.InteractionHook;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.requests.RestAction;
+import org.jetbrains.annotations.NotNull;
+import org.togetherjava.tjbot.commands.SlashCommandAdapter;
+import org.togetherjava.tjbot.commands.SlashCommandVisibility;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Implements the {@code /change-help-title} command, which is able to change the title of a help
+ * thread.
+ * <p>
+ * This is to adjust a bad title in hindsight, for example if it was automatically created by
+ * {@link ImplicitAskListener}.
+ */
+public final class ChangeHelpTitleCommand extends SlashCommandAdapter {
+    private static final String TITLE_OPTION = "title";
+
+    private static final int COOLDOWN_DURATION_VALUE = 30;
+    private static final ChronoUnit COOLDOWN_DURATION_UNIT = ChronoUnit.MINUTES;
+
+    private final HelpSystemHelper helper;
+    private final Cache<Long, Instant> helpThreadIdToLastTitleChange;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param helper the helper to use
+     */
+    public ChangeHelpTitleCommand(@NotNull HelpSystemHelper helper) {
+        super("change-help-title", "changes the title of a help thread",
+                SlashCommandVisibility.GUILD);
+
+        getData().addOption(OptionType.STRING, TITLE_OPTION, "short and to the point", true);
+
+        helpThreadIdToLastTitleChange = Caffeine.newBuilder()
+            .maximumSize(1_000)
+            .expireAfterAccess(COOLDOWN_DURATION_VALUE, TimeUnit.of(COOLDOWN_DURATION_UNIT))
+            .build();
+
+        this.helper = helper;
+    }
+
+    @Override
+    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+        String title = event.getOption(TITLE_OPTION).getAsString();
+
+        if (!helper.handleIsHelpThread(event)) {
+            return;
+        }
+
+        ThreadChannel helpThread = event.getThreadChannel();
+        if (helpThread.isArchived()) {
+            event.reply("This thread is already closed.").setEphemeral(true).queue();
+            return;
+        }
+
+        if (isHelpThreadOnCooldown(helpThread)) {
+            event
+                .reply("Please wait a bit, this command can only be used once per %d %s.".formatted(
+                        COOLDOWN_DURATION_VALUE,
+                        COOLDOWN_DURATION_UNIT.toString().toLowerCase(Locale.US)))
+                .setEphemeral(true)
+                .queue();
+            return;
+        }
+        helpThreadIdToLastTitleChange.put(helpThread.getIdLong(), Instant.now());
+
+        event.deferReply().queue();
+
+        helper.renameChannelToTitle(helpThread, title)
+            .flatMap(any -> sendTitleChangedMessage(helpThread.getGuild(), event.getHook(),
+                    helpThread, title))
+            .queue();
+    }
+
+    private @NotNull RestAction<Message> sendTitleChangedMessage(@NotNull Guild guild,
+            @NotNull InteractionHook hook, @NotNull ThreadChannel helpThread,
+            @NotNull String title) {
+        String changedContent = "Changed the title to **%s**.".formatted(title);
+        return hook.editOriginal(changedContent);
+    }
+
+    private boolean isHelpThreadOnCooldown(@NotNull ThreadChannel helpThread) {
+        return Optional
+            .ofNullable(helpThreadIdToLastTitleChange.getIfPresent(helpThread.getIdLong()))
+            .map(lastCategoryChange -> lastCategoryChange.plus(COOLDOWN_DURATION_VALUE,
+                    COOLDOWN_DURATION_UNIT))
+            .filter(Instant.now()::isBefore)
+            .isPresent();
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpTitleCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpTitleCommand.java
@@ -2,13 +2,9 @@ package org.togetherjava.tjbot.commands.help;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.ThreadChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
-import net.dv8tion.jda.api.requests.RestAction;
 import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
@@ -79,19 +75,9 @@ public final class ChangeHelpTitleCommand extends SlashCommandAdapter {
         }
         helpThreadIdToLastTitleChange.put(helpThread.getIdLong(), Instant.now());
 
-        event.deferReply().queue();
-
         helper.renameChannelToTitle(helpThread, title)
-            .flatMap(any -> sendTitleChangedMessage(helpThread.getGuild(), event.getHook(),
-                    helpThread, title))
+            .flatMap(any -> event.reply("Changed the title to **%s**.".formatted(title)))
             .queue();
-    }
-
-    private @NotNull RestAction<Message> sendTitleChangedMessage(@NotNull Guild guild,
-            @NotNull InteractionHook hook, @NotNull ThreadChannel helpThread,
-            @NotNull String title) {
-        String changedContent = "Changed the title to **%s**.".formatted(title);
-        return hook.editOriginal(changedContent);
     }
 
     private boolean isHelpThreadOnCooldown(@NotNull ThreadChannel helpThread) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -192,7 +192,8 @@ public final class HelpSystemHelper {
             return new HelpThreadName(matcher.group(CATEGORY_GROUP), matcher.group(TITLE_GROUP));
         }
 
-        public @NotNull String toChannelName() {
+        @NotNull
+        String toChannelName() {
             return category == null ? title : "[%s] %s".formatted(category, title);
         }
     }


### PR DESCRIPTION
## Overview

This adds the `/change-help-title` command, upon request. Pretty straightforward:

![example](https://i.imgur.com/IiudFbQ.png)

While at it, the code for dealing with categories and titles has been simplified a bit by introducing a helper record.

Also, changed the cooldown of other commands to 30mins as well.