### PR TITLE
Bugfix where top-helper uses wrong channel

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersMessageListener.java
@@ -21,6 +21,7 @@ public final class TopHelpersMessageListener extends MessageReceiverAdapter {
     private final Database database;
 
     private final Predicate<String> isStagingChannelName;
+    private final Predicate<String> isOverviewChannelName;
 
     /**
      * Creates a new listener to receive all message sent in help channels.
@@ -34,6 +35,8 @@ public final class TopHelpersMessageListener extends MessageReceiverAdapter {
         this.database = database;
 
         isStagingChannelName = Pattern.compile(config.getHelpSystem().getStagingChannelPattern())
+            .asMatchPredicate();
+        isOverviewChannelName = Pattern.compile(config.getHelpSystem().getOverviewChannelPattern())
             .asMatchPredicate();
     }
 
@@ -56,7 +59,9 @@ public final class TopHelpersMessageListener extends MessageReceiverAdapter {
         }
 
         ThreadChannel thread = event.getThreadChannel();
-        return isStagingChannelName.test(thread.getParentChannel().getName());
+        String rootChannelName = thread.getParentChannel().getName();
+        return isStagingChannelName.test(rootChannelName)
+                || isOverviewChannelName.test(rootChannelName);
     }
 
     private void addMessageRecord(@NotNull MessageReceivedEvent event) {


### PR DESCRIPTION
## Overview

Quick mini fix. The Top-Helper system listened to threads in the staging channel, but we recently changed the root channel for help threads to the overview channel, so the system did not count anymore.

Now, it is just using both channels to be extra safe in case we swap back and forth again.