### PR TITLE
Bugfix with temp actions being revoked too early

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ActionRecord.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ActionRecord.java
@@ -26,7 +26,7 @@ public record ActionRecord(int caseId, @NotNull Instant issuedAt, long guildId, 
 
     /**
      * Creates the action record that corresponds to the given action entry from the database table.
-     * 
+     *
      * @param action the action to convert
      * @return the corresponding action record
      */
@@ -36,5 +36,15 @@ public record ActionRecord(int caseId, @NotNull Instant issuedAt, long guildId, 
                 action.getAuthorId(), action.getTargetId(),
                 ModerationAction.valueOf(action.getActionType()), action.getActionExpiresAt(),
                 action.getReason());
+    }
+
+    /**
+     * Whether this action is still effective. That is, it is either a permanent action or temporary
+     * but not expired yet.
+     *
+     * @return True when still effective, false otherwise
+     */
+    public boolean isEffective() {
+        return actionExpiresAt == null || actionExpiresAt.isAfter(Instant.now());
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/RejoinModerationRoleListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/RejoinModerationRoleListener.java
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.EventReceiver;
 import org.togetherjava.tjbot.config.Config;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -82,21 +81,16 @@ public final class RejoinModerationRoleListener implements EventReceiver {
                 member.getGuild().getIdLong(), member.getIdLong(), moderationRole.revokeAction);
         if (lastRevokeAction.isEmpty()) {
             // User was never e.g. unmuted
-            return isActionEffective(lastApplyAction.orElseThrow());
+            return lastApplyAction.orElseThrow().isEffective();
         }
 
         // The last issued action takes priority
         if (lastApplyAction.orElseThrow()
             .issuedAt()
             .isAfter(lastRevokeAction.orElseThrow().issuedAt())) {
-            return isActionEffective(lastApplyAction.orElseThrow());
+            return lastApplyAction.orElseThrow().isEffective();
         }
         return false;
-    }
-
-    private static boolean isActionEffective(@NotNull ActionRecord action) {
-        // Effective if permanent or expires in the future
-        return action.actionExpiresAt() == null || action.actionExpiresAt().isAfter(Instant.now());
     }
 
     private static void applyModerationRole(@NotNull ModerationRole moderationRole,

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryModerationRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryModerationRoutine.java
@@ -81,13 +81,14 @@ public final class TemporaryModerationRoutine implements Routine {
 
     private void processGroupedActions(@NotNull RevocationGroupIdentifier groupIdentifier) {
         // Do not revoke an action which was overwritten by a permanent action that was issued
-        // afterwards
+        // afterwards, or if the last action has not even expired yet
         // For example if a user was perm-banned after being temp-banned
         ActionRecord lastApplyAction = actionsStore
             .findLastActionAgainstTargetByType(groupIdentifier.guildId, groupIdentifier.targetId,
                     groupIdentifier.type)
             .orElseThrow();
-        if (lastApplyAction.actionExpiresAt() == null) {
+        if (lastApplyAction.actionExpiresAt() == null
+                || lastApplyAction.actionExpiresAt().isAfter(Instant.now())) {
             return;
         }
 


### PR DESCRIPTION
## Overview

Fixes a bug with temporary moderation actions being revoked too early in certain edge cases.

Basically, the issue occurs if a user already had a temporary action in the past, which was also revoked already. The next temporary action will then be revoked too early, since the code picks up the old expired action and figures _"oh, lets revoke it"_.

This introduces a small fix where the code will always look at the last apply-action first and only proceeds revoking if that one has already expired.