### PR TITLE
Bugfix with /change_help_title allowing too long titles

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpTitleCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpTitleCommand.java
@@ -4,6 +4,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import net.dv8tion.jda.api.entities.ThreadChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
@@ -14,6 +15,9 @@ import java.time.temporal.ChronoUnit;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+
+import static org.togetherjava.tjbot.commands.help.HelpSystemHelper.TITLE_COMPACT_LENGTH_MAX;
+import static org.togetherjava.tjbot.commands.help.HelpSystemHelper.TITLE_COMPACT_LENGTH_MIN;
 
 /**
  * Implements the {@code /change-help-title} command, which is able to change the title of a help
@@ -57,6 +61,9 @@ public final class ChangeHelpTitleCommand extends SlashCommandAdapter {
         if (!helper.handleIsHelpThread(event)) {
             return;
         }
+        if (!handleIsValidTitle(title, event)) {
+            return;
+        }
 
         ThreadChannel helpThread = event.getThreadChannel();
         if (helpThread.isArchived()) {
@@ -87,5 +94,19 @@ public final class ChangeHelpTitleCommand extends SlashCommandAdapter {
                     COOLDOWN_DURATION_UNIT))
             .filter(Instant.now()::isBefore)
             .isPresent();
+    }
+
+    private boolean handleIsValidTitle(@NotNull CharSequence title, @NotNull IReplyCallback event) {
+        if (HelpSystemHelper.isTitleValid(title)) {
+            return true;
+        }
+
+        event.reply(
+                "Sorry, but the title length (after removal of special characters) has to be between %d and %d."
+                    .formatted(TITLE_COMPACT_LENGTH_MIN, TITLE_COMPACT_LENGTH_MAX))
+            .setEphemeral(true)
+            .queue();
+
+        return false;
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpTitleCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpTitleCommand.java
@@ -58,10 +58,7 @@ public final class ChangeHelpTitleCommand extends SlashCommandAdapter {
     public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
         String title = event.getOption(TITLE_OPTION).getAsString();
 
-        if (!helper.handleIsHelpThread(event)) {
-            return;
-        }
-        if (!handleIsValidTitle(title, event)) {
+        if (!helper.handleIsHelpThread(event) || !handleIsValidTitle(title, event)) {
             return;
         }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -36,7 +36,7 @@ public final class HelpSystemHelper {
 
     private static final Pattern TITLE_COMPACT_REMOVAL_PATTERN = Pattern.compile("\\W");
     static final int TITLE_COMPACT_LENGTH_MIN = 2;
-    static final int TITLE_COMPACT_LENGTH_MAX = 80;
+    static final int TITLE_COMPACT_LENGTH_MAX = 70;
 
     private final Predicate<String> isOverviewChannelName;
     private final String overviewChannelPattern;


### PR DESCRIPTION
## Overview

This addresses two bugs with long titles:

1. the `/change_help_title` had no verification on title length and hence had a really bad UX for too long titles with exceptions and no user response
2. the max title length in our verification was `80`, which is too long and exceeds the true limit of `100` when long categories are added, such as `[Together Java Bot]`

Both issues have been fixed with this PR.