### PR TITLE
Upgrade to Java 18

### DIFF
--- a/.github/workflows/basic-checks.yml
+++ b/.github/workflows/basic-checks.yml
@@ -3,7 +3,7 @@ name: Basic checks
 on: [pull_request]
 
 env:
-  JAVA_VERSION: 17
+  JAVA_VERSION: 18
 
 jobs:
   spotless:

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -8,7 +8,7 @@ on:
     - cron: '0 20 * * 4'
 
 env:
-  JAVA_VERSION: 17
+  JAVA_VERSION: 18
 
 jobs:
   sonar:

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -7,7 +7,7 @@ on:
       - 'master'
 
 env:
-  JAVA_VERSION: 17
+  JAVA_VERSION: 18
 
 jobs:
   docker:

--- a/.github/workflows/docker-verify.yaml
+++ b/.github/workflows/docker-verify.yaml
@@ -3,7 +3,7 @@ name: Docker Verify
 on: [pull_request]
 
 env:
-  JAVA_VERSION: 17
+  JAVA_VERSION: 18
 
 jobs:
   docker:

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -10,7 +10,7 @@ defaults:
     shell: bash
 
 env:
-  JAVA_VERSION: 17
+  JAVA_VERSION: 18
 
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TJ-Bot
 
 [![codefactor](https://img.shields.io/codefactor/grade/github/together-java/tj-bot)](https://www.codefactor.io/repository/github/together-java/tj-bot)
-![Java](https://img.shields.io/badge/Java-17%2B-ff696c)
+![Java](https://img.shields.io/badge/Java-18-ff696c)
 [![license](https://img.shields.io/github/license/Together-Java/TJ-Bot)](https://github.com/Together-Java/TJ-Bot/blob/master/LICENSE)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/Together-Java/TJ-Bot?label=release)
 

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -18,7 +18,7 @@ repositories {
 var outputImage = 'togetherjava.duckdns.org:5001/togetherjava/tjbot:' + System.getenv('BRANCH_NAME') ?: 'latest'
 
 jib {
-    from.image = 'eclipse-temurin:17'
+    from.image = 'eclipse-temurin:18'
     to {
         image = outputImage
         auth {

--- a/build.gradle
+++ b/build.gradle
@@ -63,8 +63,8 @@ subprojects {
         options.encoding = 'UTF-8'
 
         // Nails the Java-Version of every Subproject
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_18
+        targetCompatibility = JavaVersion.VERSION_18
     }
 
     compileJava(compileTasks)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-rc-5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Overview

This upgrades the project from Java 17 to Java 18 🚀

Gradle has no official support for it yet, we use the latest release candidate instead (7.5 rc 5), should be fine.