### PR TITLE
Updated map of VC activities

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
@@ -98,8 +98,7 @@ public final class VcActivityCommand extends SlashCommandAdapter {
      * our best bet.
      */
     private static final Map<String, String> VC_APPLICATION_TO_ID =
-            Map.ofEntries(
-                    Map.entry(WATCH_TOGETHER_NAME, "880218394199220334"),
+            Map.ofEntries(Map.entry(WATCH_TOGETHER_NAME, "880218394199220334"),
                     Map.entry(POKER_NAME, "755827207812677713"),
                     Map.entry(BETRAYAL_IO_NAME, "773336526917861400"),
                     Map.entry(FISHINGTON_IO_NAME, "814288819477020702"),

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
@@ -52,15 +52,11 @@ public final class VcActivityCommand extends SlashCommandAdapter {
 
     public static final String WATCH_TOGETHER_NAME = "Watch Together";
     public static final String POKER_NAME = "Poker Night";
-    public static final String BETRAYAL_IO_NAME = "Betrayal.io";
-    public static final String FISHINGTON_IO_NAME = "Fishington.io";
     public static final String CHESS_NAME = "Chess In The Park";
-    public static final String AWKWORD_NAME = "Awkword";
     public static final String SPELLCAST_NAME = "SpellCast";
     public static final String DOODLE_CREW_NAME = "Doodle Crew";
     public static final String WORD_SNACKS_NAME = "Word Snacks";
     public static final String LETTER_LEAGUE_NAME = "Letter League";
-    public static final String SKETCHY_ARTIST_NAME = "Sketchy Artist";
     public static final String CHECKERS_NAME = "Checkers In The Park";
     public static final String BLAZING_EIGHTS_NAME = "Blazing 8s";
     public static final String SKETCH_HEADS_NAME = "Sketch Heads";
@@ -70,27 +66,21 @@ public final class VcActivityCommand extends SlashCommandAdapter {
     public static final String ASK_AWAY_NAME = "Ask Away";
     public static final String KNOW_WHAT_I_MEME_NAME = "Know What I Meme";
 
-
-    private static final List<Command.Choice> VC_APPLICATIONS =
-            List.of(new Command.Choice(WATCH_TOGETHER_NAME, WATCH_TOGETHER_NAME),
-                    new Command.Choice(POKER_NAME, POKER_NAME),
-                    new Command.Choice(BETRAYAL_IO_NAME, BETRAYAL_IO_NAME),
-                    new Command.Choice(FISHINGTON_IO_NAME, FISHINGTON_IO_NAME),
-                    new Command.Choice(CHESS_NAME, CHESS_NAME),
-                    new Command.Choice(AWKWORD_NAME, AWKWORD_NAME),
-                    new Command.Choice(SPELLCAST_NAME, SPELLCAST_NAME),
-                    new Command.Choice(DOODLE_CREW_NAME, DOODLE_CREW_NAME),
-                    new Command.Choice(WORD_SNACKS_NAME, WORD_SNACKS_NAME),
-                    new Command.Choice(LETTER_LEAGUE_NAME, LETTER_LEAGUE_NAME),
-                    new Command.Choice(SKETCHY_ARTIST_NAME, SKETCHY_ARTIST_NAME),
-                    new Command.Choice(CHECKERS_NAME, CHECKERS_NAME),
-                    new Command.Choice(BLAZING_EIGHTS_NAME, BLAZING_EIGHTS_NAME),
-                    new Command.Choice(SKETCH_HEADS_NAME, SKETCH_HEADS_NAME),
-                    new Command.Choice(PUTT_PARTY_NAME, PUTT_PARTY_NAME),
-                    new Command.Choice(LAND_IO_NAME, LAND_IO_NAME),
-                    new Command.Choice(BOBBLE_LEAGUE_NAME, BOBBLE_LEAGUE_NAME),
-                    new Command.Choice(ASK_AWAY_NAME, ASK_AWAY_NAME),
-                    new Command.Choice(KNOW_WHAT_I_MEME_NAME, KNOW_WHAT_I_MEME_NAME));
+    private static final List<Command.Choice> VC_APPLICATIONS = List.of(
+            new Command.Choice(WATCH_TOGETHER_NAME, WATCH_TOGETHER_NAME),
+            new Command.Choice(POKER_NAME, POKER_NAME), new Command.Choice(CHESS_NAME, CHESS_NAME),
+            new Command.Choice(SPELLCAST_NAME, SPELLCAST_NAME),
+            new Command.Choice(DOODLE_CREW_NAME, DOODLE_CREW_NAME),
+            new Command.Choice(WORD_SNACKS_NAME, WORD_SNACKS_NAME),
+            new Command.Choice(LETTER_LEAGUE_NAME, LETTER_LEAGUE_NAME),
+            new Command.Choice(CHECKERS_NAME, CHECKERS_NAME),
+            new Command.Choice(BLAZING_EIGHTS_NAME, BLAZING_EIGHTS_NAME),
+            new Command.Choice(SKETCH_HEADS_NAME, SKETCH_HEADS_NAME),
+            new Command.Choice(PUTT_PARTY_NAME, PUTT_PARTY_NAME),
+            new Command.Choice(LAND_IO_NAME, LAND_IO_NAME),
+            new Command.Choice(BOBBLE_LEAGUE_NAME, BOBBLE_LEAGUE_NAME),
+            new Command.Choice(ASK_AWAY_NAME, ASK_AWAY_NAME),
+            new Command.Choice(KNOW_WHAT_I_MEME_NAME, KNOW_WHAT_I_MEME_NAME));
 
     /**
      * List comes from <a href="https://github.com/DV8FromTheWorld/JDA/pull/1628">the "Implement
@@ -100,15 +90,11 @@ public final class VcActivityCommand extends SlashCommandAdapter {
     private static final Map<String, String> VC_APPLICATION_TO_ID =
             Map.ofEntries(Map.entry(WATCH_TOGETHER_NAME, "880218394199220334"),
                     Map.entry(POKER_NAME, "755827207812677713"),
-                    Map.entry(BETRAYAL_IO_NAME, "773336526917861400"),
-                    Map.entry(FISHINGTON_IO_NAME, "814288819477020702"),
                     Map.entry(CHESS_NAME, "832012586023256104"),
-                    Map.entry(AWKWORD_NAME, "879863881349087252"),
                     Map.entry(SPELLCAST_NAME, "852509694341283871"),
                     Map.entry(DOODLE_CREW_NAME, "878067389634314250"),
                     Map.entry(WORD_SNACKS_NAME, "879863976006127627"),
                     Map.entry(LETTER_LEAGUE_NAME, "879863686565621790"),
-                    Map.entry(SKETCHY_ARTIST_NAME, "879864070101172255"),
                     Map.entry(CHECKERS_NAME, "832013003968348200"),
                     Map.entry(BLAZING_EIGHTS_NAME, "832025144389533716"),
                     Map.entry(SKETCH_HEADS_NAME, "902271654783242291"),

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
@@ -50,23 +50,47 @@ public final class VcActivityCommand extends SlashCommandAdapter {
     private static final long MAX_AGE_DAYS_LIMIT = 7;
     private static final long MAX_USES_LIMIT = 100;
 
-    public static final String POKER_NAME = "Poker";
+    public static final String WATCH_TOGETHER_NAME = "Watch Together";
+    public static final String POKER_NAME = "Poker Night";
     public static final String BETRAYAL_IO_NAME = "Betrayal.io";
     public static final String FISHINGTON_IO_NAME = "Fishington.io";
-    public static final String SPELLCAST_NAME = "Spellcast";
-    public static final String DOODLECREW_NAME = "Doodlecrew";
-    public static final String WORDSNACK_NAME = "Wordsnack";
-    public static final String LETTERTILE_NAME = "Lettertile";
+    public static final String CHESS_NAME = "Chess In The Park";
+    public static final String AWKWORD_NAME = "Awkword";
+    public static final String SPELLCAST_NAME = "SpellCast";
+    public static final String DOODLE_CREW_NAME = "Doodle Crew";
+    public static final String WORD_SNACKS_NAME = "Word Snacks";
+    public static final String LETTER_LEAGUE_NAME = "Letter League";
+    public static final String SKETCHY_ARTIST_NAME = "Sketchy Artist";
+    public static final String CHECKERS_NAME = "Checkers In The Park";
+    public static final String BLAZING_EIGHTS_NAME = "Blazing 8s";
+    public static final String SKETCH_HEADS_NAME = "Sketch Heads";
+    public static final String PUTT_PARTY_NAME = "Putt Party";
+    public static final String LAND_IO_NAME = "Land-io";
+    public static final String BOBBLE_LEAGUE_NAME = "Bobble League";
+    public static final String ASK_AWAY_NAME = "Ask Away";
+    public static final String KNOW_WHAT_I_MEME_NAME = "Know What I Meme";
 
 
     private static final List<Command.Choice> VC_APPLICATIONS =
-            List.of(new Command.Choice(POKER_NAME, POKER_NAME),
+            List.of(new Command.Choice(WATCH_TOGETHER_NAME, WATCH_TOGETHER_NAME),
+                    new Command.Choice(POKER_NAME, POKER_NAME),
                     new Command.Choice(BETRAYAL_IO_NAME, BETRAYAL_IO_NAME),
                     new Command.Choice(FISHINGTON_IO_NAME, FISHINGTON_IO_NAME),
+                    new Command.Choice(CHESS_NAME, CHESS_NAME),
+                    new Command.Choice(AWKWORD_NAME, AWKWORD_NAME),
                     new Command.Choice(SPELLCAST_NAME, SPELLCAST_NAME),
-                    new Command.Choice(DOODLECREW_NAME, DOODLECREW_NAME),
-                    new Command.Choice(WORDSNACK_NAME, WORDSNACK_NAME),
-                    new Command.Choice(LETTERTILE_NAME, LETTERTILE_NAME));
+                    new Command.Choice(DOODLE_CREW_NAME, DOODLE_CREW_NAME),
+                    new Command.Choice(WORD_SNACKS_NAME, WORD_SNACKS_NAME),
+                    new Command.Choice(LETTER_LEAGUE_NAME, LETTER_LEAGUE_NAME),
+                    new Command.Choice(SKETCHY_ARTIST_NAME, SKETCHY_ARTIST_NAME),
+                    new Command.Choice(CHECKERS_NAME, CHECKERS_NAME),
+                    new Command.Choice(BLAZING_EIGHTS_NAME, BLAZING_EIGHTS_NAME),
+                    new Command.Choice(SKETCH_HEADS_NAME, SKETCH_HEADS_NAME),
+                    new Command.Choice(PUTT_PARTY_NAME, PUTT_PARTY_NAME),
+                    new Command.Choice(LAND_IO_NAME, LAND_IO_NAME),
+                    new Command.Choice(BOBBLE_LEAGUE_NAME, BOBBLE_LEAGUE_NAME),
+                    new Command.Choice(ASK_AWAY_NAME, ASK_AWAY_NAME),
+                    new Command.Choice(KNOW_WHAT_I_MEME_NAME, KNOW_WHAT_I_MEME_NAME));
 
     /**
      * List comes from <a href="https://github.com/DV8FromTheWorld/JDA/pull/1628">the "Implement
@@ -74,10 +98,26 @@ public final class VcActivityCommand extends SlashCommandAdapter {
      * our best bet.
      */
     private static final Map<String, String> VC_APPLICATION_TO_ID =
-            Map.of(POKER_NAME, "755827207812677713", BETRAYAL_IO_NAME, "773336526917861400",
-                    FISHINGTON_IO_NAME, "814288819477020702", SPELLCAST_NAME, "852509694341283871",
-                    DOODLECREW_NAME, "878067389634314250", WORDSNACK_NAME, "879863976006127627",
-                    LETTERTILE_NAME, "879863686565621790");
+            Map.ofEntries(
+                    Map.entry(WATCH_TOGETHER_NAME, "880218394199220334"),
+                    Map.entry(POKER_NAME, "755827207812677713"),
+                    Map.entry(BETRAYAL_IO_NAME, "773336526917861400"),
+                    Map.entry(FISHINGTON_IO_NAME, "814288819477020702"),
+                    Map.entry(CHESS_NAME, "832012586023256104"),
+                    Map.entry(AWKWORD_NAME, "879863881349087252"),
+                    Map.entry(SPELLCAST_NAME, "852509694341283871"),
+                    Map.entry(DOODLE_CREW_NAME, "878067389634314250"),
+                    Map.entry(WORD_SNACKS_NAME, "879863976006127627"),
+                    Map.entry(LETTER_LEAGUE_NAME, "879863686565621790"),
+                    Map.entry(SKETCHY_ARTIST_NAME, "879864070101172255"),
+                    Map.entry(CHECKERS_NAME, "832013003968348200"),
+                    Map.entry(BLAZING_EIGHTS_NAME, "832025144389533716"),
+                    Map.entry(SKETCH_HEADS_NAME, "902271654783242291"),
+                    Map.entry(PUTT_PARTY_NAME, "945737671223947305"),
+                    Map.entry(LAND_IO_NAME, "903769130790969345"),
+                    Map.entry(BOBBLE_LEAGUE_NAME, "947957217959759964"),
+                    Map.entry(ASK_AWAY_NAME, "976052223358406656"),
+                    Map.entry(KNOW_WHAT_I_MEME_NAME, "950505761862189096"));
 
     private static final List<OptionData> inviteOptions = List.of(new OptionData(OptionType.INTEGER,
             MAX_USES_OPTION,

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
@@ -83,9 +83,10 @@ public final class VcActivityCommand extends SlashCommandAdapter {
             new Command.Choice(KNOW_WHAT_I_MEME_NAME, KNOW_WHAT_I_MEME_NAME));
 
     /**
-     * List comes from <a href="https://github.com/DV8FromTheWorld/JDA/pull/1628">the "Implement
-     * invite targets" PR on JDA</a>. There is no official list from Discord themselves, so this is
-     * our best bet.
+     * List comes from
+     * <a href="https://gist.github.com/GeneralSadaf/42d91a2b6a93a7db7a39208f2d8b53ad">this public
+     * list obtained by GeneralSadaf.</a>. There is no official list from Discord themselves, so
+     * this is our best bet.
      */
     private static final Map<String, String> VC_APPLICATION_TO_ID =
             Map.ofEntries(Map.entry(WATCH_TOGETHER_NAME, "880218394199220334"),


### PR DESCRIPTION
## What?
Updated names of activities to match Discord and added activities to the map.

Closes  #378.

## Why?
This should make the list of VC activities be up-to-date in terms of currently available activities.
## How?
Adjusted variable values and changed the current VC_APPLICATION_TO_ID Map to work with Map.ofEntries() rather than Map.of() since the latter takes only up to 10 elements.
## Testing?
I've tested every activity including the ones I've added and the ones that did not require a boost worked properly. I couldn't verify if the boost-required activities worked but the game icons did appear (except Sketchy Artist) when using the /vc-activity command.
## Screenshots (optional)
## Anything Else?
It seems like there are 4 games on the list that are not available to the public (Sketchy Artist, Awkword, Betrayal.io, Fishington.io) as Discord will return "This server doesn't have access to the requested activity."