### PR TITLE
Made #active_questions post more robust against hicups

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
@@ -5,7 +5,9 @@ import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.internal.requests.CompletedRestAction;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.MessageReceiverAdapter;
@@ -16,6 +18,7 @@ import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -33,6 +36,9 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
 
     private static final String STATUS_TITLE = "## __**Active questions**__ ##";
     private static final int OVERVIEW_QUESTION_LIMIT = 150;
+    private static final AtomicInteger FIND_STATUS_MESSAGE_CONSECUTIVE_FAILURES =
+            new AtomicInteger(0);
+    private static final int FIND_STATUS_MESSAGE_FAILURE_THRESHOLD = 3;
 
     private final HelpSystemHelper helper;
     private final List<String> allCategories;
@@ -124,15 +130,10 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
             .setContent(STATUS_TITLE + "\n\n" + createDescription(activeThreads))
             .build();
 
-        getStatusMessage(overviewChannel).flatMap(maybeStatusMessage -> {
-            logger.debug("Sending the updated question overview");
-            if (maybeStatusMessage.isEmpty()) {
-                return overviewChannel.sendMessage(message);
-            }
-
-            String statusMessageId = maybeStatusMessage.orElseThrow().getId();
-            return overviewChannel.editMessageById(statusMessageId, message);
-        }).queue();
+        getStatusMessage(overviewChannel)
+            .flatMap(maybeStatusMessage -> sendUpdatedOverview(maybeStatusMessage.orElse(null),
+                    message, overviewChannel))
+            .queue();
     }
 
     private @NotNull String createDescription(@NotNull Collection<ThreadChannel> activeThreads) {
@@ -176,6 +177,30 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
 
         String content = message.getContentRaw();
         return content.startsWith(STATUS_TITLE);
+    }
+
+    private @NotNull RestAction<Message> sendUpdatedOverview(@Nullable Message statusMessage,
+            @NotNull Message updatedStatusMessage, @NotNull MessageChannel overviewChannel) {
+        logger.debug("Sending the updated question overview");
+        if (statusMessage == null) {
+            int currentFailures = FIND_STATUS_MESSAGE_CONSECUTIVE_FAILURES.incrementAndGet();
+            if (currentFailures >= FIND_STATUS_MESSAGE_FAILURE_THRESHOLD) {
+                logger.warn(
+                        "Failed to locate the question overview too often ({} times), sending a fresh message instead.",
+                        currentFailures);
+                FIND_STATUS_MESSAGE_CONSECUTIVE_FAILURES.set(0);
+                return overviewChannel.sendMessage(updatedStatusMessage);
+            }
+
+            logger.info(
+                    "Failed to locate the question overview ({} times), trying again next time.",
+                    currentFailures);
+            return new CompletedRestAction<>(overviewChannel.getJDA(), null, null);
+        }
+
+        FIND_STATUS_MESSAGE_CONSECUTIVE_FAILURES.set(0);
+        String statusMessageId = statusMessage.getId();
+        return overviewChannel.editMessageById(statusMessageId, updatedStatusMessage);
     }
 
     private enum ChannelType {


### PR DESCRIPTION
## Overview

We have an ongoing issue with the question overview in `#active_questions` being posted twice (a moderator is then usually pinged and deletes the duplicate). This happens roughly once or twice a week.

The cause of this are likely Discord hicups where the codes history-lookup can not locate the message, even though it is actually there.

This mitigates the issue, while still preserving the intended feature of having a fresh message post if the message is truly not the recent message in the channel, by allowing it to fail up to 3 times before it decides to send a fresh message.