### PR TITLE
Update stale action v3 -> v4

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label, comment or add the valid label or this will be closed in 5 days.'


### PR DESCRIPTION
The stale action just reported an issue that it does not know the setting `labels-to-add-when-unstale`.

Seems to be caused by the fact that we are using `v3` instead of `v4`.

Not a big deal though.