### PR TITLE
Adding uncaught exception handling

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdStore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdStore.java
@@ -114,8 +114,16 @@ public final class ComponentIdStore implements AutoCloseable {
             .maximumSize(CACHE_SIZE)
             .expireAfterAccess(EVICT_CACHE_OLDER_THAN, TimeUnit.of(EVICT_CACHE_OLDER_THAN_UNIT))
             .build();
-        evictionTask = evictionService.scheduleWithFixedDelay(this::evictDatabase,
-                evictEveryInitialDelay, evictEveryDelay, TimeUnit.of(evictEveryUnit));
+
+        Runnable evictCommand = () -> {
+            try {
+                evictDatabase();
+            } catch (Exception e) {
+                logger.error("Unknown error while evicting the component ID store database.", e);
+            }
+        };
+        evictionTask = evictionService.scheduleWithFixedDelay(evictCommand, evictEveryInitialDelay,
+                evictEveryDelay, TimeUnit.of(evictEveryUnit));
 
         logDebugSizeStatistics();
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
@@ -81,10 +81,18 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
         message.delete().queue();
 
         // Thread creation can sometimes take a bit longer than the actual message, so that
-        // "getThreadChannels()"
-        // would not pick it up, hence we execute the update with some slight delay.
-        UPDATE_SERVICE.schedule(() -> updateOverviewForGuild(event.getGuild()), 2,
-                TimeUnit.SECONDS);
+        // "getThreadChannels()" would not pick it up, hence we execute the update with some slight
+        // delay.
+        Runnable updateOverviewCommand = () -> {
+            try {
+                updateOverviewForGuild(event.getGuild());
+            } catch (Exception e) {
+                logger.error(
+                        "Unknown error while attempting to update the help overview for guild {}.",
+                        event.getGuild().getId(), e);
+            }
+        };
+        UPDATE_SERVICE.schedule(updateOverviewCommand, 2, TimeUnit.SECONDS);
     }
 
     private void updateOverviewForGuild(@NotNull Guild guild) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
@@ -94,9 +94,13 @@ public final class BotCore extends ListenerAdapter implements SlashCommandProvid
             .forEach(routine -> {
                 Runnable command = () -> {
                     String routineName = routine.getClass().getSimpleName();
-                    logger.debug("Running routine %s...".formatted(routineName));
-                    routine.runRoutine(jda);
-                    logger.debug("Finished routine %s.".formatted(routineName));
+                    try {
+                        logger.debug("Running routine %s...".formatted(routineName));
+                        routine.runRoutine(jda);
+                        logger.debug("Finished routine %s.".formatted(routineName));
+                    } catch (Exception e) {
+                        logger.error("Unknown error in routine {}.", routineName, e);
+                    }
                 };
 
                 Routine.Schedule schedule = routine.createSchedule();


### PR DESCRIPTION
## Overview

Closes #490. Some exceptions slipped through the logging system. Most notable, anything happening inside `Routine`s. Even worse, the routine actually stopped forever (until the next bot restart).

This fixes the issue by:
* adding a global default uncaught handler
* additionally logging for scheduled executor services, which otherwise supress and wrap the exceptions into the future

An example of a quick test exception from a routine, which is now correctly logged:

![example exception](https://i.imgur.com/yHKCc65.png)