### PR TITLE
Auto-prune of full helper roles

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/Application.java
+++ b/application/src/main/java/org/togetherjava/tjbot/Application.java
@@ -82,8 +82,14 @@ public enum Application {
             JDA jda = JDABuilder.createDefault(config.getToken())
                 .enableIntents(GatewayIntent.GUILD_MEMBERS)
                 .build();
-            jda.addEventListener(new BotCore(jda, database, config));
+
+            BotCore core = new BotCore(jda, database, config);
+            jda.addEventListener(core);
             jda.awaitReady();
+
+            // We fire the event manually, since the core might be added too late to receive the
+            // actual event fired from JDA
+            core.onReady(jda);
             logger.info("Bot is ready");
         } catch (LoginException e) {
             logger.error("Failed to login", e);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
@@ -76,7 +76,8 @@ public enum Features {
         features.add(new ScamHistoryPurgeRoutine(scamHistoryStore));
         features.add(new BotMessageCleanup(config));
         features.add(new HelpThreadActivityUpdater(helpSystemHelper));
-        features.add(new AutoPruneHelperRoutine(config, helpSystemHelper, modAuditLogWriter, database));
+        features
+            .add(new AutoPruneHelperRoutine(config, helpSystemHelper, modAuditLogWriter, database));
 
         // Message receivers
         features.add(new TopHelpersMessageListener(database, config));

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
@@ -76,6 +76,7 @@ public enum Features {
         features.add(new ScamHistoryPurgeRoutine(scamHistoryStore));
         features.add(new BotMessageCleanup(config));
         features.add(new HelpThreadActivityUpdater(helpSystemHelper));
+        features.add(new AutoPruneHelperRoutine(config, helpSystemHelper, database));
 
         // Message receivers
         features.add(new TopHelpersMessageListener(database, config));

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
@@ -76,7 +76,7 @@ public enum Features {
         features.add(new ScamHistoryPurgeRoutine(scamHistoryStore));
         features.add(new BotMessageCleanup(config));
         features.add(new HelpThreadActivityUpdater(helpSystemHelper));
-        features.add(new AutoPruneHelperRoutine(config, helpSystemHelper, database));
+        features.add(new AutoPruneHelperRoutine(config, helpSystemHelper, modAuditLogWriter, database));
 
         // Message receivers
         features.add(new TopHelpersMessageListener(database, config));

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/AutoPruneHelperRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/AutoPruneHelperRoutine.java
@@ -145,8 +145,6 @@ public final class AutoPruneHelperRoutine implements Routine {
 
     private void pruneMemberFromRole(@NotNull Member member, @NotNull Role role,
             @NotNull TextChannel overviewChannel) {
-        if (Math.random() <= 0.999)
-            return;
         Guild guild = member.getGuild();
 
         String dmMessage =

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/AutoPruneHelperRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/AutoPruneHelperRoutine.java
@@ -1,0 +1,158 @@
+package org.togetherjava.tjbot.commands.help;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.TextChannel;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.togetherjava.tjbot.commands.Routine;
+import org.togetherjava.tjbot.config.Config;
+import org.togetherjava.tjbot.db.Database;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.Period;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static org.togetherjava.tjbot.db.generated.tables.HelpChannelMessages.HELP_CHANNEL_MESSAGES;
+
+/**
+ * Due to a technical limitation in Discord, roles with more than 100 users can not be ghost-pinged
+ * into helper threads.
+ * <p>
+ * This routine mitigates the problem by automatically pruning inactive users from helper roles
+ * approaching this limit.
+ */
+public final class AutoPruneHelperRoutine implements Routine {
+    private static final Logger logger = LoggerFactory.getLogger(AutoPruneHelperRoutine.class);
+
+    private static final int ROLE_FULL_LIMIT = 100;
+    private static final int ROLE_FULL_THRESHOLD = 95;
+    private static final int PRUNE_MEMBER_AMOUNT = 10;
+    private static final Period INACTIVE_AFTER = Period.ofDays(90);
+    private static final int RECENTLY_JOINED_DAYS = 7;
+
+    private final HelpSystemHelper helper;
+    private final Database database;
+    private final List<String> allCategories;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param config to determine all helper categories
+     * @param helper the helper to use
+     * @param database to determine whether an user is inactive
+     */
+    public AutoPruneHelperRoutine(@NotNull Config config, @NotNull HelpSystemHelper helper,
+            @NotNull Database database) {
+        allCategories = config.getHelpSystem().getCategories();
+        this.helper = helper;
+        this.database = database;
+    }
+
+    @Override
+    public @NotNull Schedule createSchedule() {
+        return new Schedule(ScheduleMode.FIXED_RATE, 0, 1, TimeUnit.HOURS);
+    }
+
+    @Override
+    public void runRoutine(@NotNull JDA jda) {
+        jda.getGuildCache().forEach(this::pruneForGuild);
+    }
+
+    private void pruneForGuild(@NotNull Guild guild) {
+        TextChannel overviewChannel = guild.getTextChannels()
+            .stream()
+            .filter(channel -> helper.isOverviewChannelName(channel.getName()))
+            .findAny()
+            .orElseThrow();
+        Instant when = Instant.now();
+
+        allCategories.stream()
+            .map(category -> helper.handleFindRoleForCategory(category, guild))
+            .filter(Optional::isPresent)
+            .map(Optional::orElseThrow)
+            .forEach(role -> pruneRoleIfFull(role, overviewChannel, when));
+    }
+
+    private void pruneRoleIfFull(@NotNull Role role, @NotNull TextChannel overviewChannel,
+            @NotNull Instant when) {
+        role.getGuild().findMembersWithRoles(role).onSuccess(members -> {
+            if (isRoleFull(members)) {
+                logger.debug("Helper role {} is full, starting to prune.", role.getName());
+                pruneRole(role, members, overviewChannel, when);
+            }
+        });
+    }
+
+    private boolean isRoleFull(@NotNull Collection<Member> members) {
+        return members.size() >= ROLE_FULL_THRESHOLD;
+    }
+
+    private void pruneRole(@NotNull Role role, @NotNull List<? extends Member> members,
+            @NotNull TextChannel overviewChannel, @NotNull Instant when) {
+        List<Member> membersShuffled = new ArrayList<>(members);
+        Collections.shuffle(membersShuffled);
+
+        List<Member> membersToPrune = membersShuffled.stream()
+            .filter(member -> isMemberInactive(member, when))
+            .limit(PRUNE_MEMBER_AMOUNT)
+            .toList();
+        if (membersToPrune.size() < PRUNE_MEMBER_AMOUNT) {
+            logger
+                .warn("Attempting to prune helpers from role {} ({} members), but only found {} inactive users."
+                        + " That is less than expected, the category might eventually grow beyond the limit.",
+                        role.getName(), members.size(), membersToPrune.size());
+        }
+        if (members.size() - membersToPrune.size() >= ROLE_FULL_LIMIT) {
+            logger
+                .warn("The helper role {} went beyond its member limit ({}), despite automatic pruning."
+                        + " It will not function correctly anymore. Please manually prune some users.",
+                        role.getName(), ROLE_FULL_LIMIT);
+        }
+
+        logger.info("Pruning {} users {} from role {}", membersToPrune.size(), membersToPrune,
+                role.getName());
+        membersToPrune.forEach(member -> pruneMemberFromRole(member, role, overviewChannel));
+    }
+
+    private boolean isMemberInactive(@NotNull Member member, @NotNull Instant when) {
+        if (member.hasTimeJoined()) {
+            Instant memberJoined = member.getTimeJoined().toInstant();
+            if (Duration.between(memberJoined, when).toDays() <= RECENTLY_JOINED_DAYS) {
+                // New users are protected from purging to not immediately kick them out of the role
+                // again
+                return false;
+            }
+        }
+
+        Instant latestActiveMoment = when.minus(INACTIVE_AFTER);
+
+        // Has no recent help message
+        return database.read(context -> context.fetchCount(HELP_CHANNEL_MESSAGES,
+                HELP_CHANNEL_MESSAGES.GUILD_ID.eq(member.getGuild().getIdLong())
+                    .and(HELP_CHANNEL_MESSAGES.AUTHOR_ID.eq(member.getIdLong()))
+                    .and(HELP_CHANNEL_MESSAGES.SENT_AT.greaterThan(latestActiveMoment)))) == 0;
+    }
+
+    private void pruneMemberFromRole(@NotNull Member member, @NotNull Role role,
+            @NotNull TextChannel overviewChannel) {
+        Guild guild = member.getGuild();
+
+        String dmMessage =
+                """
+                        You seem to have been inactive for some time in server **%s**, hence we removed you from the **%s** role.
+                        If that was a mistake, just head back to %s and select the role again.
+                        Sorry for any inconvenience caused by this 🙇"""
+                    .formatted(guild.getName(), role.getName(), overviewChannel.getAsMention());
+
+        guild.removeRoleFromMember(member, role)
+            .flatMap(any -> member.getUser().openPrivateChannel())
+            .flatMap(channel -> channel.sendMessage(dmMessage))
+            .queue();
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/AutoPruneHelperRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/AutoPruneHelperRoutine.java
@@ -74,13 +74,13 @@ public final class AutoPruneHelperRoutine implements Routine {
             .filter(channel -> helper.isOverviewChannelName(channel.getName()))
             .findAny()
             .orElseThrow();
-        Instant when = Instant.now();
+        Instant now = Instant.now();
 
         allCategories.stream()
             .map(category -> helper.handleFindRoleForCategory(category, guild))
             .filter(Optional::isPresent)
             .map(Optional::orElseThrow)
-            .forEach(role -> pruneRoleIfFull(role, overviewChannel, when));
+            .forEach(role -> pruneRoleIfFull(role, overviewChannel, now));
     }
 
     private void pruneRoleIfFull(@NotNull Role role, @NotNull TextChannel overviewChannel,
@@ -93,7 +93,7 @@ public final class AutoPruneHelperRoutine implements Routine {
         });
     }
 
-    private boolean isRoleFull(@NotNull Collection<Member> members) {
+    private boolean isRoleFull(@NotNull Collection<?> members) {
         return members.size() >= ROLE_FULL_THRESHOLD;
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
@@ -166,8 +166,8 @@ public final class BotCore extends ListenerAdapter implements SlashCommandProvid
     private void scheduleRoutines(@NotNull JDA jda) {
         routines.forEach(routine -> {
             Runnable command = () -> {
+                String routineName = routine.getClass().getSimpleName();
                 try {
-                    String routineName = routine.getClass().getSimpleName();
                     logger.debug("Running routine %s...".formatted(routineName));
                     routine.runRoutine(jda);
                     logger.debug("Finished routine %s.".formatted(routineName));

--- a/application/src/main/resources/log4j2.xml
+++ b/application/src/main/resources/log4j2.xml
@@ -22,6 +22,10 @@
         </Async>
     </Appenders>
     <Loggers>
+        <!-- Change this level to see more of our logs -->
+        <Logger name="org.togetherjava.tjbot" level="info"/>
+
+        <!-- Change this level to see more logs of everything (including JDA) -->
         <Root level="info">
             <AppenderRef ref="Console"/>
             <AppenderRef ref="File"/>


### PR DESCRIPTION
## Overview

Closes #483. This is a somewhat urgent mitigation due to a technical limitation. Our helper-role system breaks once a helper role has more than 100 users (usually the JAVA helper role).

This mitigates the problem by automatically removing some users from helper roles.

## Details

Roles are pruned once they go beyond `95` users (the hard limit is `100`). It will then attempt to prune `10` **random** users who fulfill:
* not recently joined (**7 days**)
* no recent message in a help thread (**90 days** - this is also the lookback limit of our DB as of today)

Users are send a DM to inform them about what happened:

![DM](https://i.imgur.com/3rA6jab.png)

The routine also logs on `INFO` level who got pruned, so we can always double check in the logs. It will also tell us on `WARN` level if a role is, despite auto-pruning, approaching or even going beyond the limit. So that we can start to prune manually.

Latter warnings are also forwarded to the `#mod_audit_log` channel, so that we really do not miss it:

![audit log](https://i.imgur.com/qo9VgEy.png)

## Other stuff

This PR also addresses two unrelated things:

* Added hints on how to change the logging level (also for bot only) in `log4j2.xml`
* Fixed a bug with routines starting too early (they must only be started once the system is ready, not directly during startup)
* Fixed a bug where `BotCore#onReady` is not always triggered because the core is added too late to JDA