### PR TITLE
Increase dependabot support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "daily"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
+        update-types: ["version-update:semver-patch"]
     open-pull-requests-limit: 10


### PR DESCRIPTION
We initially started with a dependabot config that posted every change, daily. That was too spammy for us and we tried out to only have major versions, monthly.

The bot is now running fine since many months and dependabot went almost silent since then.

We should bump it a bit, so that it starts giving us more updates again - we do not want to miss on any cool stuff or security updates.

This time, I am going for:
* daily
* major, minor (but no patch)