### PR TITLE
Added missing javadocs

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
@@ -51,6 +51,7 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
 
     /**
      * Creates a new instance.
+     * 
      * @param config used to get api key and channel names.
      * @see org.togetherjava.tjbot.commands.Features
      */

--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
@@ -49,7 +49,11 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
     private final Predicate<String> isStagingChannelName;
     private final Predicate<String> isOverviewChannelName;
 
-
+    /**
+     * Creates a new instance.
+     * @param config used to get api key and channel names.
+     * @see org.togetherjava.tjbot.commands.Features
+     */
     public FileSharingMessageListener(@NotNull Config config) {
         super(Pattern.compile(".*"));
 


### PR DESCRIPTION
# About

SonarLint failed because of missing javadocs in FileSharingMessageListener's constructor.