### PR TITLE
Fixed attachment error + close input stream correctly

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
@@ -185,8 +185,8 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
 
         if (statusCode < HttpURLConnection.HTTP_OK
                 || statusCode >= HttpURLConnection.HTTP_MULT_CHOICE) {
-            LOGGER.warn("Request JSON: {}", body);
-            throw new IllegalStateException("Gist API unexpected response: " + apiResponse.body());
+            throw new IllegalStateException("Gist API unexpected response: " + apiResponse.body()
+                    + ". Request JSON: " + body);
         }
 
         GistResponse gistResponse;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
@@ -185,8 +185,8 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
 
         if (statusCode < HttpURLConnection.HTTP_OK
                 || statusCode >= HttpURLConnection.HTTP_MULT_CHOICE) {
-            throw new IllegalStateException("Gist API unexpected response: " + apiResponse.body()
-                    + ". Request JSON: " + body);
+            throw new IllegalStateException("Gist API unexpected response: %s. Request JSON: %s"
+                .formatted(apiResponse.body(), body));
         }
 
         GistResponse gistResponse;


### PR DESCRIPTION
# About

Fixes #525 and closes input stream correctly now, cause it produced this before:

![image](https://user-images.githubusercontent.com/88111627/186451147-8b9d79f0-1942-41a4-8848-eebf7ed5dcea.png)
