### PR TITLE
Disallow 'help' in title of help threads

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
@@ -107,9 +107,12 @@ public final class AskCommand extends SlashCommandAdapter {
             return true;
         }
 
-        event.reply(
-                "Sorry, but the title length (after removal of special characters) has to be between %d and %d."
-                    .formatted(TITLE_COMPACT_LENGTH_MIN, TITLE_COMPACT_LENGTH_MAX))
+        event.reply("""
+                Sorry, but your title is invalid. Please pick a title where:
+                • length is between %d and %d
+                • must not contain the word 'help'
+                Thanks, and sorry for the inconvenience 👍
+                """.formatted(TITLE_COMPACT_LENGTH_MIN, TITLE_COMPACT_LENGTH_MAX))
             .setEphemeral(true)
             .queue();
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -18,6 +18,7 @@ import org.togetherjava.tjbot.db.generated.tables.records.HelpThreadsRecord;
 import java.awt.Color;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -207,7 +208,8 @@ public final class HelpSystemHelper {
         String titleCompact = TITLE_COMPACT_REMOVAL_PATTERN.matcher(title).replaceAll("");
 
         return titleCompact.length() >= TITLE_COMPACT_LENGTH_MIN
-                && titleCompact.length() <= TITLE_COMPACT_LENGTH_MAX;
+                && titleCompact.length() <= TITLE_COMPACT_LENGTH_MAX
+                && !titleCompact.toLowerCase(Locale.US).contains("help");
     }
 
     @NotNull


### PR DESCRIPTION
Closes #488 .

Having threads with 'help' in their title frequently leads to confusion for beginners, who think that this is a general purpose help channel and hijack it for their own questions.

It happens about twice per week and its cumbersome, confusing and unfair to all parties.

This fixes the issue by simply checking thread names for `help` (case insensitive) and, if present:
* for `/ask`, the user has to pick a new title
* for _implicit ask_, the title goes to `Untitled`

![example](https://i.imgur.com/4fr0l9k.png)

While at it, made the message a bit more readable and friendly.