### PR TITLE
Adding help thread auto archiver

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
@@ -83,6 +83,7 @@ public class Features {
         features.add(new HelpThreadActivityUpdater(helpSystemHelper));
         features
             .add(new AutoPruneHelperRoutine(config, helpSystemHelper, modAuditLogWriter, database));
+        features.add(new HelpThreadAutoArchiver(helpSystemHelper));
 
         // Message receivers
         features.add(new TopHelpersMessageListener(database, config));

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadAutoArchiver.java
@@ -1,0 +1,100 @@
+package org.togetherjava.tjbot.commands.help;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.utils.TimeUtil;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.togetherjava.tjbot.commands.Routine;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Routine, which periodically checks all help threads and archives them if there has not been any
+ * recent activity.
+ */
+public final class HelpThreadAutoArchiver implements Routine {
+    private static final Logger logger = LoggerFactory.getLogger(HelpThreadAutoArchiver.class);
+    private static final int SCHEDULE_MINUTES = 60;
+    private static final Duration ARCHIVE_AFTER_INACTIVITY_OF = Duration.ofHours(24);
+
+    private final HelpSystemHelper helper;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param helper the helper to use
+     */
+    public HelpThreadAutoArchiver(@NotNull HelpSystemHelper helper) {
+        this.helper = helper;
+    }
+
+    @Override
+    public @NotNull Schedule createSchedule() {
+        return new Schedule(ScheduleMode.FIXED_RATE, 0, SCHEDULE_MINUTES, TimeUnit.MINUTES);
+    }
+
+    @Override
+    public void runRoutine(@NotNull JDA jda) {
+        jda.getGuildCache().forEach(this::autoArchiveForGuild);
+    }
+
+    private void autoArchiveForGuild(@NotNull Guild guild) {
+        Optional<TextChannel> maybeOverviewChannel = helper
+            .handleRequireOverviewChannel(guild, channelPattern -> logger.warn(
+                    "Unable to auto archive help threads, did not find an overview channel matching the configured pattern '{}' for guild '{}'",
+                    channelPattern, guild.getName()));
+
+        if (maybeOverviewChannel.isEmpty()) {
+            return;
+        }
+
+        logger.debug("Auto archiving of help threads");
+
+        List<ThreadChannel> activeThreads =
+                helper.getActiveThreadsIn(maybeOverviewChannel.orElseThrow());
+        logger.debug("Found {} active questions", activeThreads.size());
+
+        Instant archiveAfterMoment = computeArchiveAfterMoment();
+        activeThreads
+            .forEach(activeThread -> autoArchiveForThread(activeThread, archiveAfterMoment));
+    }
+
+    private @NotNull Instant computeArchiveAfterMoment() {
+        return Instant.now().minus(ARCHIVE_AFTER_INACTIVITY_OF);
+    }
+
+    private void autoArchiveForThread(@NotNull ThreadChannel threadChannel,
+            @NotNull Instant archiveAfterMoment) {
+        if (shouldBeArchived(threadChannel, archiveAfterMoment)) {
+            logger.debug("Auto archiving help thread {}", threadChannel.getId());
+
+            MessageEmbed embed = new EmbedBuilder().setDescription(
+                    """
+                            Closed the thread due to inactivity.
+
+                            If your question was not resolved yet, feel free to create a new thread. \
+                            But try to improve the quality of your question to make it easier to help you 👍""")
+                .setColor(HelpSystemHelper.AMBIENT_COLOR)
+                .build();
+
+            threadChannel.sendMessageEmbeds(embed)
+                .flatMap(any -> threadChannel.getManager().setArchived(true))
+                .queue();
+        }
+    }
+
+    private static boolean shouldBeArchived(MessageChannel channel,
+            @NotNull Instant archiveAfterMoment) {
+        Instant lastActivity =
+                TimeUtil.getTimeCreated(channel.getLatestMessageIdLong()).toInstant();
+
+        return lastActivity.isBefore(archiveAfterMoment);
+    }
+}


### PR DESCRIPTION
## Motivation

Discord did some changes to the auto-archive system. They now only _hide_ a channel after the set period and archive it only later (a week). That is a problem for us, since we relied on automatic archival after 24h for our help threads. Without it, they pile up and UX goes down.

## Solution

Since Discord does not automatically close our channels properly anymore, we do it ourselves.

This PR adds a simple routine that periodically checks all help threads and archives them if there was no message sent since 24h.

![example](https://i.imgur.com/ZFXrOe9.png)

## Other

While at it, added a utility for the `handleRequireOverviewChannel` functionality that has been duplicated around 5 times.

Same with `getActiveThreadsIn` which also has been duplicated a couple of times.

## Tests

The solution is well tested. Here are some edge cases (the archive period has been set to 2 minutes for testing):

* Keep it alive by sending messages
![activity](https://i.imgur.com/OTmO9EZ.png)

* Reopen after close
![closes again](https://i.imgur.com/IYiEtcC.png)