### PR TITLE
Introduce @ParametersAreNonnullByDefault

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -39,6 +39,7 @@ shadowJar {
 }
 
 dependencies {
+    implementation 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'org.jetbrains:annotations:23.0.0'
 
     implementation project(':database')

--- a/application/src/main/java/org/togetherjava/tjbot/Application.java
+++ b/application/src/main/java/org/togetherjava/tjbot/Application.java
@@ -2,20 +2,17 @@ package org.togetherjava.tjbot;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
-import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import org.jetbrains.annotations.NotNull;
+import net.dv8tion.jda.api.requests.GatewayIntent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.togetherjava.tjbot.commands.Features;
+import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.system.BotCore;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.db.Database;
-import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 
 import javax.security.auth.login.LoginException;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -114,8 +111,7 @@ public class Application {
         logger.info("Bot has been stopped");
     }
 
-    private static void onUncaughtException(@NotNull Thread failingThread,
-            @NotNull Throwable failure) {
+    private static void onUncaughtException(Thread failingThread, Throwable failure) {
         logger.error("Unknown error in thread {}.", failingThread.getName(), failure);
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
@@ -31,6 +31,7 @@ import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.moderation.ModAuditLogWriter;
 import org.togetherjava.tjbot.routines.ModAuditLogRoutine;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
@@ -1,7 +1,6 @@
 package org.togetherjava.tjbot.commands;
 
 import net.dv8tion.jda.api.JDA;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.basic.PingCommand;
 import org.togetherjava.tjbot.commands.basic.RoleSelectCommand;
 import org.togetherjava.tjbot.commands.basic.SuggestionsUpDownVoter;
@@ -59,8 +58,8 @@ public class Features {
      * @param config the configuration features should use
      * @return a collection of all features
      */
-    public static @NotNull Collection<Feature> createFeatures(@NotNull JDA jda,
-            @NotNull Database database, @NotNull Config config) {
+    @Nonnull
+    public static Collection<Feature> createFeatures(JDA jda, Database database, Config config) {
         TagSystem tagSystem = new TagSystem(database);
         ModerationActionsStore actionsStore = new ModerationActionsStore(database);
         ModAuditLogWriter modAuditLogWriter = new ModAuditLogWriter(config);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/MessageReceiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/MessageReceiver.java
@@ -2,8 +2,8 @@ package org.togetherjava.tjbot.commands;
 
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.MessageUpdateEvent;
-import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
 import java.util.regex.Pattern;
 
 /**
@@ -28,7 +28,7 @@ public interface MessageReceiver extends Feature {
      *
      * @return the pattern matching the names of relevant channels
      */
-    @NotNull
+    @Nonnull
     Pattern getChannelNamePattern();
 
     /**
@@ -38,7 +38,7 @@ public interface MessageReceiver extends Feature {
      * @param event the event that triggered this, containing information about the corresponding
      *        message that was sent and received
      */
-    void onMessageReceived(@NotNull MessageReceivedEvent event);
+    void onMessageReceived(MessageReceivedEvent event);
 
     /**
      * Triggered by the core system whenever an existing message was edited in a text channel of a
@@ -47,5 +47,5 @@ public interface MessageReceiver extends Feature {
      * @param event the event that triggered this, containing information about the corresponding
      *        message that was edited
      */
-    void onMessageUpdated(@NotNull MessageUpdateEvent event);
+    void onMessageUpdated(MessageUpdateEvent event);
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/MessageReceiverAdapter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/MessageReceiverAdapter.java
@@ -2,8 +2,8 @@ package org.togetherjava.tjbot.commands;
 
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.MessageUpdateEvent;
-import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
 import java.util.regex.Pattern;
 
 /**
@@ -24,24 +24,25 @@ public abstract class MessageReceiverAdapter implements MessageReceiver {
      * @param channelNamePattern the pattern matching names of channels interested in, only messages
      *        from matching channels will be received
      */
-    protected MessageReceiverAdapter(@NotNull Pattern channelNamePattern) {
+    protected MessageReceiverAdapter(Pattern channelNamePattern) {
         this.channelNamePattern = channelNamePattern;
     }
 
     @Override
-    public final @NotNull Pattern getChannelNamePattern() {
+    @Nonnull
+    public final Pattern getChannelNamePattern() {
         return channelNamePattern;
     }
 
     @SuppressWarnings("NoopMethodInAbstractClass")
     @Override
-    public void onMessageReceived(@NotNull MessageReceivedEvent event) {
+    public void onMessageReceived(MessageReceivedEvent event) {
         // Adapter does not react by default, subclasses may change this behavior
     }
 
     @SuppressWarnings("NoopMethodInAbstractClass")
     @Override
-    public void onMessageUpdated(@NotNull MessageUpdateEvent event) {
+    public void onMessageUpdated(MessageUpdateEvent event) {
         // Adapter does not react by default, subclasses may change this behavior
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Routine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Routine.java
@@ -1,8 +1,8 @@
 package org.togetherjava.tjbot.commands;
 
 import net.dv8tion.jda.api.JDA;
-import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -24,7 +24,7 @@ public interface Routine extends Feature {
      *
      * @return the schedule of this routine
      */
-    @NotNull
+    @Nonnull
     Schedule createSchedule();
 
     /**
@@ -32,7 +32,7 @@ public interface Routine extends Feature {
      *
      * @param jda the JDA instance the bot is operating with
      */
-    void runRoutine(@NotNull JDA jda);
+    void runRoutine(JDA jda);
 
     /**
      * The schedule of routines.
@@ -46,8 +46,7 @@ public interface Routine extends Feature {
      * @param unit the time unit for both, {@link #initialDuration} and {@link #duration}, e.g.
      *        seconds
      */
-    record Schedule(@NotNull ScheduleMode mode, long initialDuration, long duration,
-            @NotNull TimeUnit unit) {
+    record Schedule(ScheduleMode mode, long initialDuration, long duration, TimeUnit unit) {
     }
 
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/SlashCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/SlashCommand.java
@@ -9,11 +9,11 @@ import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 import net.dv8tion.jda.api.interactions.components.ComponentInteraction;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.componentids.ComponentId;
 import org.togetherjava.tjbot.commands.componentids.ComponentIdGenerator;
 import org.togetherjava.tjbot.commands.componentids.Lifespan;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -49,7 +49,7 @@ public interface SlashCommand extends UserInteractor {
      *
      * @return the description of the command
      */
-    @NotNull
+    @Nonnull
     String getDescription();
 
     /**
@@ -59,7 +59,7 @@ public interface SlashCommand extends UserInteractor {
      *
      * @return the visibility of the command
      */
-    @NotNull
+    @Nonnull
     SlashCommandVisibility getVisibility();
 
     /**
@@ -77,7 +77,7 @@ public interface SlashCommand extends UserInteractor {
      *
      * @return the command data of this command
      */
-    @NotNull
+    @Nonnull
     SlashCommandData getData();
 
     /**
@@ -118,5 +118,5 @@ public interface SlashCommand extends UserInteractor {
      *
      * @param event the event that triggered this
      */
-    void onSlashCommand(@NotNull SlashCommandInteractionEvent event);
+    void onSlashCommand(SlashCommandInteractionEvent event);
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/SlashCommandAdapter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/SlashCommandAdapter.java
@@ -9,13 +9,13 @@ import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Range;
 import org.jetbrains.annotations.Unmodifiable;
 import org.togetherjava.tjbot.commands.componentids.ComponentId;
 import org.togetherjava.tjbot.commands.componentids.ComponentIdGenerator;
 import org.togetherjava.tjbot.commands.componentids.Lifespan;
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -55,7 +55,7 @@ import java.util.stream.IntStream;
  *         }
  *
  *         &#64;Override
- *         public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+ *         public void onSlashCommand(SlashCommandInteractionEvent event) {
  *             event.reply("Pong!").queue();
  *         }
  *     }
@@ -80,7 +80,7 @@ public abstract class SlashCommandAdapter implements SlashCommand {
      *        {@link SlashCommandData#setDescription(String)}
      * @param visibility the visibility of the command
      */
-    protected SlashCommandAdapter(@NotNull String name, @NotNull String description,
+    protected SlashCommandAdapter(String name, String description,
             SlashCommandVisibility visibility) {
         this.name = name;
         this.description = description;
@@ -90,40 +90,43 @@ public abstract class SlashCommandAdapter implements SlashCommand {
     }
 
     @Override
-    public final @NotNull String getName() {
+    @Nonnull
+    public final String getName() {
         return name;
     }
 
     @Override
-    public final @NotNull String getDescription() {
+    @Nonnull
+    public final String getDescription() {
         return description;
     }
 
     @Override
-    public final @NotNull SlashCommandVisibility getVisibility() {
+    @Nonnull
+    public final SlashCommandVisibility getVisibility() {
         return visibility;
     }
 
     @Override
-    public final @NotNull SlashCommandData getData() {
+    @Nonnull
+    public final SlashCommandData getData() {
         return data;
     }
 
     @Override
-    public final void acceptComponentIdGenerator(@NotNull ComponentIdGenerator generator) {
+    public final void acceptComponentIdGenerator(ComponentIdGenerator generator) {
         componentIdGenerator = generator;
     }
 
     @SuppressWarnings("NoopMethodInAbstractClass")
     @Override
-    public void onButtonClick(@NotNull ButtonInteractionEvent event, @NotNull List<String> args) {
+    public void onButtonClick(ButtonInteractionEvent event, List<String> args) {
         // Adapter does not react by default, subclasses may change this behavior
     }
 
     @SuppressWarnings("NoopMethodInAbstractClass")
     @Override
-    public void onSelectionMenu(@NotNull SelectMenuInteractionEvent event,
-            @NotNull List<String> args) {
+    public void onSelectionMenu(SelectMenuInteractionEvent event, List<String> args) {
         // Adapter does not react by default, subclasses may change this behavior
     }
 
@@ -142,7 +145,8 @@ public abstract class SlashCommandAdapter implements SlashCommand {
      * @return the generated component ID
      */
     @SuppressWarnings("OverloadedVarargsMethod")
-    protected final @NotNull String generateComponentId(@NotNull String... args) {
+    @Nonnull
+    protected final String generateComponentId(String... args) {
         return generateComponentId(Lifespan.REGULAR, args);
     }
 
@@ -159,8 +163,8 @@ public abstract class SlashCommandAdapter implements SlashCommand {
      * @return the generated component ID
      */
     @SuppressWarnings({"OverloadedVarargsMethod", "WeakerAccess"})
-    protected final @NotNull String generateComponentId(@NotNull Lifespan lifespan,
-            @NotNull String... args) {
+    @Nonnull
+    protected final String generateComponentId(Lifespan lifespan, String... args) {
         return Objects.requireNonNull(componentIdGenerator)
             .generate(new ComponentId(getName(), Arrays.asList(args)), lifespan);
     }
@@ -190,8 +194,9 @@ public abstract class SlashCommandAdapter implements SlashCommand {
      * @return the generated list of options
      */
     @Unmodifiable
-    protected static @NotNull List<OptionData> generateMultipleOptions(
-            @NotNull OptionData optionData, @Range(from = 1, to = 25) int amount) {
+    @Nonnull
+    protected static List<OptionData> generateMultipleOptions(OptionData optionData,
+            @Range(from = 1, to = 25) int amount) {
         String baseName = optionData.getName();
 
         Function<String, OptionData> nameToOption =
@@ -211,8 +216,9 @@ public abstract class SlashCommandAdapter implements SlashCommand {
      * @return all options with the given prefix
      */
     @Unmodifiable
-    protected static @NotNull List<OptionMapping> getMultipleOptionsByNamePrefix(
-            @NotNull CommandInteractionPayload event, @NotNull String namePrefix) {
+    @Nonnull
+    protected static List<OptionMapping> getMultipleOptionsByNamePrefix(
+            CommandInteractionPayload event, String namePrefix) {
         return event.getOptions()
             .stream()
             .filter(option -> option.getName().startsWith(namePrefix))

--- a/application/src/main/java/org/togetherjava/tjbot/commands/UserInteractor.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/UserInteractor.java
@@ -3,9 +3,9 @@ package org.togetherjava.tjbot.commands;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.SelectMenuInteractionEvent;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.componentids.ComponentIdGenerator;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -27,7 +27,7 @@ public interface UserInteractor extends Feature {
      *
      * @return the name of the interactor
      */
-    @NotNull
+    @Nonnull
     String getName();
 
     /**
@@ -49,7 +49,7 @@ public interface UserInteractor extends Feature {
      *        {@link SlashCommand#onSlashCommand(SlashCommandInteractionEvent)} for details on how
      *        these are created
      */
-    void onButtonClick(@NotNull ButtonInteractionEvent event, @NotNull List<String> args);
+    void onButtonClick(ButtonInteractionEvent event, List<String> args);
 
     /**
      * Triggered by the core system when a selection menu corresponding to this implementation
@@ -70,7 +70,7 @@ public interface UserInteractor extends Feature {
      *        {@link SlashCommand#onSlashCommand(SlashCommandInteractionEvent)} for details on how
      *        these are created
      */
-    void onSelectionMenu(@NotNull SelectMenuInteractionEvent event, @NotNull List<String> args);
+    void onSelectionMenu(SelectMenuInteractionEvent event, List<String> args);
 
     /**
      * Triggered by the core system during its setup phase. It will provide the interactor a
@@ -81,5 +81,5 @@ public interface UserInteractor extends Feature {
      *
      * @param generator the provided component id generator
      */
-    void acceptComponentIdGenerator(@NotNull ComponentIdGenerator generator);
+    void acceptComponentIdGenerator(ComponentIdGenerator generator);
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/PingCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/PingCommand.java
@@ -1,7 +1,6 @@
 package org.togetherjava.tjbot.commands.basic;
 
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
@@ -24,7 +23,7 @@ public final class PingCommand extends SlashCommandAdapter {
      * @param event the corresponding event
      */
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         event.reply("Pong!").queue();
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/RoleSelectCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/RoleSelectCommand.java
@@ -13,13 +13,13 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.components.selections.SelectMenu;
 import net.dv8tion.jda.api.interactions.components.selections.SelectOption;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.commands.componentids.Lifespan;
 
+import javax.annotation.Nonnull;
 import java.awt.Color;
 import java.util.*;
 import java.util.function.Function;
@@ -80,7 +80,7 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         if (!handleHasPermissions(event)) {
             return;
         }
@@ -101,7 +101,7 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
         sendRoleSelectionMenu(event, selectedRoles);
     }
 
-    private boolean handleHasPermissions(@NotNull SlashCommandInteractionEvent event) {
+    private boolean handleHasPermissions(SlashCommandInteractionEvent event) {
         if (!event.getMember().hasPermission(Permission.MANAGE_ROLES)) {
             event.reply("You do not have the required manage role permission to use this command")
                 .setEphemeral(true)
@@ -123,7 +123,7 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
     }
 
     @Contract(pure = true)
-    private static boolean handleIsBotAccessibleRole(@NotNull Role role) {
+    private static boolean handleIsBotAccessibleRole(Role role) {
         boolean isSystemRole = role.isPublicRole() || role.getTags().isBot()
                 || role.getTags().isBoost() || role.getTags().isIntegration();
 
@@ -135,8 +135,8 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
         return !isSystemRole;
     }
 
-    private static boolean handleAccessibleRolesSelected(@NotNull IReplyCallback event,
-            @NotNull Collection<Role> selectedRoles) {
+    private static boolean handleAccessibleRolesSelected(IReplyCallback event,
+            Collection<Role> selectedRoles) {
         if (!selectedRoles.isEmpty()) {
             return true;
         }
@@ -151,8 +151,8 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
         return false;
     }
 
-    private static boolean handleInteractableRolesSelected(@NotNull IReplyCallback event,
-            @NotNull Collection<Role> selectedRoles) {
+    private static boolean handleInteractableRolesSelected(IReplyCallback event,
+            Collection<Role> selectedRoles) {
         List<Role> nonInteractableRoles = selectedRoles.stream()
             .filter(role -> !event.getGuild().getSelfMember().canInteract(role))
             .toList();
@@ -173,8 +173,8 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
         return false;
     }
 
-    private void sendRoleSelectionMenu(@NotNull final CommandInteraction event,
-            @NotNull final Collection<? extends Role> selectableRoles) {
+    private void sendRoleSelectionMenu(final CommandInteraction event,
+            final Collection<? extends Role> selectableRoles) {
         SelectMenu.Builder menu =
                 SelectMenu.create(generateComponentId(Lifespan.PERMANENT, event.getUser().getId()))
                     .setPlaceholder("Select your roles")
@@ -193,8 +193,8 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
         event.replyEmbeds(embed).addActionRow(menu.build()).queue();
     }
 
-    @NotNull
-    private static SelectOption mapToSelectOption(@NotNull Role role) {
+    @Nonnull
+    private static SelectOption mapToSelectOption(Role role) {
         RoleIcon roleIcon = role.getIcon();
 
         SelectOption option = SelectOption.of(role.getName(), role.getId());
@@ -206,8 +206,7 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSelectionMenu(@NotNull SelectMenuInteractionEvent event,
-            @NotNull List<String> args) {
+    public void onSelectionMenu(SelectMenuInteractionEvent event, List<String> args) {
         Guild guild = event.getGuild();
         List<Role> selectedRoles = event.getSelectedOptions()
             .stream()
@@ -223,8 +222,8 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
         handleRoleSelection(event, guild, selectedRoles);
     }
 
-    private static void handleRoleSelection(@NotNull SelectMenuInteractionEvent event,
-            @NotNull Guild guild, @NotNull Collection<Role> selectedRoles) {
+    private static void handleRoleSelection(SelectMenuInteractionEvent event, Guild guild,
+            Collection<Role> selectedRoles) {
         Collection<Role> rolesToAdd = new ArrayList<>(selectedRoles.size());
         Collection<Role> rolesToRemove = new ArrayList<>(selectedRoles.size());
 
@@ -244,8 +243,8 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
         modifyRoles(event, event.getMember(), guild, rolesToAdd, rolesToRemove);
     }
 
-    @NotNull
-    private static Function<SelectOption, Optional<Role>> optionToRole(@NotNull Guild guild) {
+    @Nonnull
+    private static Function<SelectOption, Optional<Role>> optionToRole(Guild guild) {
         return option -> {
             Role role = guild.getRoleById(option.getValue());
 
@@ -259,16 +258,15 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
         };
     }
 
-    private static void modifyRoles(@NotNull IReplyCallback event, @NotNull Member target,
-            @NotNull Guild guild, @NotNull Collection<Role> rolesToAdd,
-            @NotNull Collection<Role> rolesToRemove) {
+    private static void modifyRoles(IReplyCallback event, Member target, Guild guild,
+            Collection<Role> rolesToAdd, Collection<Role> rolesToRemove) {
         guild.modifyMemberRoles(target, rolesToAdd, rolesToRemove)
             .flatMap(empty -> event.reply("Your roles have been updated.").setEphemeral(true))
             .queue();
     }
 
-    private static @NotNull MessageEmbed createEmbed(@NotNull String title,
-            @NotNull CharSequence description) {
+    @Nonnull
+    private static MessageEmbed createEmbed(String title, CharSequence description) {
         return new EmbedBuilder().setTitle(title)
             .setDescription(description)
             .setColor(AMBIENT_COLOR)

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/SuggestionsUpDownVoter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/SuggestionsUpDownVoter.java
@@ -6,13 +6,13 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.requests.ErrorResponse;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.MessageReceiverAdapter;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.config.SuggestionsConfig;
 
+import javax.annotation.Nonnull;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -33,14 +33,14 @@ public final class SuggestionsUpDownVoter extends MessageReceiverAdapter {
      *
      * @param config the config to use for this
      */
-    public SuggestionsUpDownVoter(@NotNull Config config) {
+    public SuggestionsUpDownVoter(Config config) {
         super(Pattern.compile(config.getSuggestions().getChannelPattern()));
 
         this.config = config.getSuggestions();
     }
 
     @Override
-    public void onMessageReceived(@NotNull MessageReceivedEvent event) {
+    public void onMessageReceived(MessageReceivedEvent event) {
         if (event.getAuthor().isBot() || event.isWebhookMessage() || !event.isFromGuild()) {
             return;
         }
@@ -53,7 +53,7 @@ public final class SuggestionsUpDownVoter extends MessageReceiverAdapter {
         reactWith(config.getDownVoteEmoteName(), FALLBACK_DOWN_VOTE, guild, message);
     }
 
-    private static void createThread(@NotNull Message message) {
+    private static void createThread(Message message) {
         String title = message.getContentRaw();
 
         if (title.length() >= TITLE_MAX_LENGTH) {
@@ -69,8 +69,8 @@ public final class SuggestionsUpDownVoter extends MessageReceiverAdapter {
         message.createThreadChannel(title).queue();
     }
 
-    private static void reactWith(@NotNull String emoteName, @NotNull String fallbackUnicodeEmote,
-            @NotNull Guild guild, @NotNull Message message) {
+    private static void reactWith(String emoteName, String fallbackUnicodeEmote, Guild guild,
+            Message message) {
         getEmoteByName(emoteName, guild).map(message::addReaction).orElseGet(() -> {
             logger.warn(
                     "Unable to vote on a suggestion with the configured emote ('{}'), using fallback instead.",
@@ -89,8 +89,8 @@ public final class SuggestionsUpDownVoter extends MessageReceiverAdapter {
         });
     }
 
-    private static @NotNull Optional<Emote> getEmoteByName(@NotNull String name,
-            @NotNull Guild guild) {
+    @Nonnull
+    private static Optional<Emote> getEmoteByName(String name, Guild guild) {
         return guild.getEmotesByName(name, false).stream().findAny();
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
@@ -13,13 +13,13 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -144,7 +144,7 @@ public final class VcActivityCommand extends SlashCommandAdapter {
 
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         Member member = Objects.requireNonNull(event.getMember(), "member is null");
         GuildVoiceState voiceState = Objects.requireNonNull(member.getVoiceState(),
                 "Voicestates aren't being cached, check the JDABuilder");
@@ -191,9 +191,8 @@ public final class VcActivityCommand extends SlashCommandAdapter {
         handleSubcommand(event, voiceChannel, applicationId, maxUses, maxAgeDays, applicationName);
     }
 
-
-    private static <K, V> @NotNull Optional<K> getKeyByValue(@NotNull Map<K, V> map,
-            @NotNull V value) {
+    @Nonnull
+    private static <K, V> Optional<K> getKeyByValue(Map<K, V> map, V value) {
         for (Map.Entry<K, V> entry : map.entrySet()) {
             if (value.equals(entry.getKey())) {
                 return Optional.of(entry.getKey());
@@ -203,10 +202,9 @@ public final class VcActivityCommand extends SlashCommandAdapter {
         return Optional.empty();
     }
 
-    private static void handleSubcommand(@NotNull SlashCommandInteractionEvent event,
-            @NotNull VoiceChannel voiceChannel, @NotNull String applicationId,
-            @Nullable Integer maxUses, @Nullable Integer maxAgeDays,
-            @NotNull String applicationName) {
+    private static void handleSubcommand(SlashCommandInteractionEvent event,
+            VoiceChannel voiceChannel, String applicationId, @Nullable Integer maxUses,
+            @Nullable Integer maxAgeDays, String applicationName) {
 
 
         voiceChannel.createInvite()
@@ -219,9 +217,9 @@ public final class VcActivityCommand extends SlashCommandAdapter {
 
     }
 
-    private static @NotNull ReplyCallbackAction replyInvite(
-            @NotNull SlashCommandInteractionEvent event, @NotNull Invite invite,
-            @NotNull String applicationName) {
+    @Nonnull
+    private static ReplyCallbackAction replyInvite(SlashCommandInteractionEvent event,
+            Invite invite, String applicationName) {
         return event.reply("""
                 %s wants to start %s.
                 Feel free to join by clicking %s , enjoy!
@@ -229,7 +227,7 @@ public final class VcActivityCommand extends SlashCommandAdapter {
                  """.formatted(event.getUser().getAsTag(), applicationName, invite.getUrl()));
     }
 
-    private static void handleErrors(@NotNull SlashCommandInteractionEvent event,
+    private static void handleErrors(SlashCommandInteractionEvent event,
             @Nullable Throwable throwable) {
         event.reply("Something went wrong :/").queue();
         logger.warn("Something went wrong in the VcActivityCommand", throwable);
@@ -242,7 +240,8 @@ public final class VcActivityCommand extends SlashCommandAdapter {
      * @return the extracted integer if present, null otherwise
      **/
     @Contract("null -> null")
-    private static @Nullable Integer requireIntOptionIfPresent(@Nullable OptionMapping option) {
+    @Nullable
+    private static Integer requireIntOptionIfPresent(@Nullable OptionMapping option) {
 
         return option == null ? null : Math.toIntExact(option.getAsLong());
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/package-info.java
@@ -2,4 +2,7 @@
  * This package offers some basic commands that act as example for how to use the command system of
  * the application.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.basic;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentId.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentId.java
@@ -1,6 +1,5 @@
 package org.togetherjava.tjbot.commands.componentids;
 
-import org.jetbrains.annotations.NotNull;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 
 import java.util.List;
@@ -14,5 +13,5 @@ import java.util.List;
  *        this component ID, when triggered
  * @param elements the additional elements to carry along this component ID, empty if not desired
  */
-public record ComponentId(@NotNull String userInteractorName, @NotNull List<String> elements) {
+public record ComponentId(String userInteractorName, List<String> elements) {
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdGenerator.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdGenerator.java
@@ -3,12 +3,11 @@ package org.togetherjava.tjbot.commands.componentids;
 import net.dv8tion.jda.api.entities.Emoji;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.components.ComponentInteraction;
-import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
-
+import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 import org.togetherjava.tjbot.commands.SlashCommand;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 /**
  * Provides component ID generation.
@@ -38,6 +37,6 @@ public interface ComponentIdGenerator {
      * @throws InvalidComponentIdFormatException if the given component ID was in an unexpected
      *         format and could not be serialized
      */
-    @NotNull
-    String generate(@NotNull ComponentId componentId, @NotNull Lifespan lifespan);
+    @Nonnull
+    String generate(ComponentId componentId, Lifespan lifespan);
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdParser.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdParser.java
@@ -1,13 +1,12 @@
 package org.togetherjava.tjbot.commands.componentids;
 
 import net.dv8tion.jda.api.entities.Emoji;
-import net.dv8tion.jda.api.interactions.components.ComponentInteraction;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
+import net.dv8tion.jda.api.interactions.components.ComponentInteraction;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 
-import org.jetbrains.annotations.NotNull;
-
+import javax.annotation.Nonnull;
 import java.util.Optional;
 
 /**
@@ -39,6 +38,6 @@ public interface ComponentIdParser {
      * @throws InvalidComponentIdFormatException if the component ID associated to the given UUID
      *         was in an unexpected format and could not be deserialized
      */
-    @NotNull
-    Optional<ComponentId> parse(@NotNull String uuid);
+    @Nonnull
+    Optional<ComponentId> parse(String uuid);
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdStore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdStore.java
@@ -5,15 +5,15 @@ import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import org.togetherjava.tjbot.commands.SlashCommand;
-import org.jetbrains.annotations.NotNull;
 import org.jooq.Result;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.togetherjava.tjbot.commands.SlashCommand;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.ComponentIds;
 import org.togetherjava.tjbot.db.generated.tables.records.ComponentIdsRecord;
 
+import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
@@ -84,7 +84,7 @@ public final class ComponentIdStore implements AutoCloseable {
      *
      * @param database the database to use to persist component IDs in
      */
-    public ComponentIdStore(@NotNull Database database) {
+    public ComponentIdStore(Database database) {
         this(database, EVICT_DATABASE_EVERY_INITIAL_DELAY, EVICT_DATABASE_EVERY_DELAY,
                 EVICT_DATABASE_EVERY_UNIT, EVICT_DATABASE_OLDER_THAN,
                 EVICT_DATABASE_OLDER_THAN_UNIT);
@@ -103,9 +103,8 @@ public final class ComponentIdStore implements AutoCloseable {
      * @param evictOlderThanUnit the unit of the 'evictOlderThan' value
      */
     @SuppressWarnings({"WeakerAccess", "ConstructorWithTooManyParameters"})
-    public ComponentIdStore(@NotNull Database database, long evictEveryInitialDelay,
-            long evictEveryDelay, ChronoUnit evictEveryUnit, long evictOlderThan,
-            @SuppressWarnings("TypeMayBeWeakened") ChronoUnit evictOlderThanUnit) {
+    public ComponentIdStore(Database database, long evictEveryInitialDelay, long evictEveryDelay,
+            ChronoUnit evictEveryUnit, long evictOlderThan, ChronoUnit evictOlderThanUnit) {
         this.database = database;
         evictDatabaseOlderThan = evictOlderThan;
         evictDatabaseOlderThanUnit = evictOlderThanUnit;
@@ -137,7 +136,7 @@ public final class ComponentIdStore implements AutoCloseable {
      *
      * @param listener the listener to add
      */
-    public void addComponentIdRemovedListener(@NotNull Consumer<ComponentId> listener) {
+    public void addComponentIdRemovedListener(Consumer<ComponentId> listener) {
         componentIdRemovedListeners.add(listener);
     }
 
@@ -156,7 +155,8 @@ public final class ComponentIdStore implements AutoCloseable {
      *         format and could not be serialized
      */
     @SuppressWarnings("WeakerAccess")
-    public @NotNull Optional<ComponentId> get(@NotNull UUID uuid) {
+    @Nonnull
+    public Optional<ComponentId> get(UUID uuid) {
         synchronized (storeLock) {
             // Get it from the cache or, if not found, the database
             return Optional.ofNullable(storeCache.getIfPresent(uuid)).or(() -> {
@@ -188,8 +188,7 @@ public final class ComponentIdStore implements AutoCloseable {
      *         was in an unexpected format and could not be deserialized
      */
     @SuppressWarnings("WeakerAccess")
-    public void putOrThrow(@NotNull UUID uuid, @NotNull ComponentId componentId,
-            @NotNull Lifespan lifespan) {
+    public void putOrThrow(UUID uuid, ComponentId componentId, Lifespan lifespan) {
         Supplier<String> alreadyExistsMessageSupplier =
                 () -> "The UUID '%s' already exists and is associated to a component id."
                     .formatted(uuid);
@@ -218,7 +217,8 @@ public final class ComponentIdStore implements AutoCloseable {
         }
     }
 
-    private @NotNull Optional<ComponentId> getFromDatabase(@NotNull UUID uuid) {
+    @Nonnull
+    private Optional<ComponentId> getFromDatabase(UUID uuid) {
         return database.read(context -> Optional
             .ofNullable(context.selectFrom(ComponentIds.COMPONENT_IDS)
                 .where(ComponentIds.COMPONENT_IDS.UUID.eq(uuid.toString()))
@@ -235,7 +235,7 @@ public final class ComponentIdStore implements AutoCloseable {
      * @param uuid the uuid to heat
      * @throws IllegalArgumentException if there is no, or multiple, records associated to that UUID
      */
-    private void heatRecord(@NotNull UUID uuid) {
+    private void heatRecord(UUID uuid) {
         int updatedRecords;
         synchronized (storeLock) {
             updatedRecords =
@@ -294,7 +294,8 @@ public final class ComponentIdStore implements AutoCloseable {
         }
     }
 
-    private static @NotNull String serializeComponentId(@NotNull ComponentId componentId) {
+    @Nonnull
+    private static String serializeComponentId(ComponentId componentId) {
         try {
             return CSV.writerFor(ComponentId.class)
                 .with(CSV.schemaFor(ComponentId.class))
@@ -304,7 +305,8 @@ public final class ComponentIdStore implements AutoCloseable {
         }
     }
 
-    private static @NotNull ComponentId deserializeComponentId(@NotNull String componentId) {
+    @Nonnull
+    private static ComponentId deserializeComponentId(String componentId) {
         try {
             return CSV.readerFor(ComponentId.class)
                 .with(CSV.schemaFor(ComponentId.class))

--- a/application/src/main/java/org/togetherjava/tjbot/commands/componentids/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/componentids/package-info.java
@@ -2,7 +2,7 @@
  * This package provides utilities to generate, persist and parse component IDs.
  * <p>
  * See
- * {@link org.togetherjava.tjbot.commands.SlashCommand#onSlashCommand(net.dv8tion.jda.api.events.interaction.SlashCommandInteractionEvent)}
+ * {@link org.togetherjava.tjbot.commands.SlashCommand#onSlashCommand(net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent)}
  * for details on component IDs.
  * <p>
  * The class {@link org.togetherjava.tjbot.commands.componentids.ComponentIdStore} is the central
@@ -10,4 +10,7 @@
  * {@link org.togetherjava.tjbot.commands.componentids.ComponentIdGenerator} and
  * {@link org.togetherjava.tjbot.commands.componentids.ComponentIdParser}.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.componentids;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
@@ -8,12 +8,12 @@ import net.dv8tion.jda.api.entities.ThreadChannel;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.MessageReceiverAdapter;
 import org.togetherjava.tjbot.config.Config;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -23,7 +23,10 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
@@ -55,7 +58,7 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
      * @param config used to get api key and channel names.
      * @see org.togetherjava.tjbot.commands.Features
      */
-    public FileSharingMessageListener(@NotNull Config config) {
+    public FileSharingMessageListener(Config config) {
         super(Pattern.compile(".*"));
 
         gistApiKey = config.getGistApiKey();
@@ -66,7 +69,7 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
     }
 
     @Override
-    public void onMessageReceived(@NotNull MessageReceivedEvent event) {
+    public void onMessageReceived(MessageReceivedEvent event) {
         User author = event.getAuthor();
         if (author.isBot() || event.isWebhookMessage()) {
             return;
@@ -98,7 +101,7 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
         });
     }
 
-    private boolean isAttachmentRelevant(@NotNull Message.Attachment attachment) {
+    private boolean isAttachmentRelevant(Message.Attachment attachment) {
         String extension = attachment.getFileExtension();
         if (extension == null) {
             return false;
@@ -107,8 +110,8 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
     }
 
 
-    private void processAttachments(@NotNull MessageReceivedEvent event,
-            @NotNull List<Message.Attachment> attachments) {
+    private void processAttachments(MessageReceivedEvent event,
+            List<Message.Attachment> attachments) {
 
         Map<String, GistFile> nameToFile = new ConcurrentHashMap<>();
 
@@ -130,7 +133,8 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
         sendResponse(event, url);
     }
 
-    private @NotNull String readAttachment(@NotNull InputStream stream) {
+    @Nonnull
+    private String readAttachment(InputStream stream) {
         try (stream) {
             return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
         } catch (IOException e) {
@@ -138,7 +142,8 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
         }
     }
 
-    private @NotNull String getNameOf(@NotNull Message.Attachment attachment) {
+    @Nonnull
+    private String getNameOf(Message.Attachment attachment) {
         String fileName = attachment.getFileName();
         String fileExtension = attachment.getFileExtension();
 
@@ -158,7 +163,8 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
         return fileName;
     }
 
-    private @NotNull String uploadToGist(@NotNull GistRequest jsonRequest) {
+    @Nonnull
+    private String uploadToGist(GistRequest jsonRequest) {
         String body;
         try {
             body = JSON.writeValueAsString(jsonRequest);
@@ -204,7 +210,7 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
         return gistResponse.getHtmlUrl();
     }
 
-    private void sendResponse(@NotNull MessageReceivedEvent event, @NotNull String url) {
+    private void sendResponse(MessageReceivedEvent event, String url) {
         Message message = event.getMessage();
         String messageContent =
                 "I uploaded your attachments as **gist**. That way, they are easier to read for everyone, especially mobile users 👍";
@@ -212,7 +218,7 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
         message.reply(messageContent).setActionRow(Button.link(url, "gist")).queue();
     }
 
-    private boolean isHelpThread(@NotNull MessageReceivedEvent event) {
+    private boolean isHelpThread(MessageReceivedEvent event) {
         if (event.getChannelType() != ChannelType.GUILD_PUBLIC_THREAD) {
             return false;
         }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/GistFile.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/GistFile.java
@@ -1,10 +1,8 @@
 package org.togetherjava.tjbot.commands.filesharing;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * @see <a href="https://docs.github.com/en/rest/gists/gists#create-a-gist">Create a Gist via
  *      API</a>
  */
-record GistFile(@NotNull String content) {
+record GistFile(String content) {
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/GistFiles.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/GistFiles.java
@@ -1,7 +1,6 @@
 package org.togetherjava.tjbot.commands.filesharing;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 
@@ -9,5 +8,5 @@ import java.util.Map;
  * @see <a href="https://docs.github.com/en/rest/gists/gists#create-a-gist">Create a Gist via
  *      API</a>
  */
-record GistFiles(@NotNull @JsonAnyGetter Map<String, GistFile> nameToContent) {
+record GistFiles(@JsonAnyGetter Map<String, GistFile> nameToContent) {
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/GistRequest.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/GistRequest.java
@@ -1,12 +1,10 @@
 package org.togetherjava.tjbot.commands.filesharing;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * @see <a href="https://docs.github.com/en/rest/gists/gists#create-a-gist">Create a Gist via
  *      API</a>
  */
-record GistRequest(@NotNull String description, @JsonProperty("public") boolean isPublic,
-        @NotNull GistFiles files) {
+record GistRequest(String description, @JsonProperty("public") boolean isPublic, GistFiles files) {
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/GistResponse.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/GistResponse.java
@@ -2,7 +2,8 @@ package org.togetherjava.tjbot.commands.filesharing;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nonnull;
 
 /**
  * @see <a href="https://docs.github.com/en/rest/gists/gists#create-a-gist">Create a Gist via
@@ -13,11 +14,12 @@ final class GistResponse {
     @JsonProperty("html_url")
     private String htmlUrl;
 
-    public @NotNull String getHtmlUrl() {
-        return this.htmlUrl;
+    @Nonnull
+    public String getHtmlUrl() {
+        return htmlUrl;
     }
 
-    public void setHtmlUrl(@NotNull String htmlUrl) {
+    public void setHtmlUrl(String htmlUrl) {
         this.htmlUrl = htmlUrl;
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/package-info.java
@@ -2,4 +2,7 @@
  * This package offers all the functionality for automatically uploading files to sharing services.
  * The core class is {@link org.togetherjava.tjbot.commands.filesharing.FileSharingMessageListener}.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.filesharing;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
@@ -9,13 +9,13 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.requests.RestAction;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
+import javax.annotation.Nonnull;
 import java.util.Optional;
 
 import static org.togetherjava.tjbot.commands.help.HelpSystemHelper.TITLE_COMPACT_LENGTH_MAX;
@@ -54,7 +54,7 @@ public final class AskCommand extends SlashCommandAdapter {
      * @param config the config to use
      * @param helper the helper to use
      */
-    public AskCommand(@NotNull Config config, @NotNull HelpSystemHelper helper) {
+    public AskCommand(Config config, HelpSystemHelper helper) {
         super("ask", "Ask a question - use this in the staging channel",
                 SlashCommandVisibility.GUILD);
 
@@ -72,7 +72,7 @@ public final class AskCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         String title = event.getOption(TITLE_OPTION).getAsString();
         String category = event.getOption(CATEGORY_OPTION).getAsString();
 
@@ -102,7 +102,7 @@ public final class AskCommand extends SlashCommandAdapter {
             }, e -> handleFailure(e, eventHook));
     }
 
-    private boolean handleIsValidTitle(@NotNull CharSequence title, @NotNull IReplyCallback event) {
+    private boolean handleIsValidTitle(CharSequence title, IReplyCallback event) {
         if (HelpSystemHelper.isTitleValid(title)) {
             return true;
         }
@@ -119,18 +119,18 @@ public final class AskCommand extends SlashCommandAdapter {
         return false;
     }
 
-    private @NotNull RestAction<Message> handleEvent(@NotNull InteractionHook eventHook,
-            @NotNull ThreadChannel threadChannel, @NotNull Member author, @NotNull String title,
-            @NotNull String category, @NotNull Guild guild) {
+    @Nonnull
+    private RestAction<Message> handleEvent(InteractionHook eventHook, ThreadChannel threadChannel,
+            Member author, String title, String category, Guild guild) {
         helper.writeHelpThreadToDatabase(author, threadChannel);
         return sendInitialMessage(guild, threadChannel, author, title, category)
             .flatMap(any -> notifyUser(eventHook, threadChannel))
             .flatMap(any -> helper.sendExplanationMessage(threadChannel));
     }
 
-    private RestAction<Message> sendInitialMessage(@NotNull Guild guild,
-            @NotNull ThreadChannel threadChannel, @NotNull Member author, @NotNull String title,
-            @NotNull String category) {
+    @Nonnull
+    private RestAction<Message> sendInitialMessage(Guild guild, ThreadChannel threadChannel,
+            Member author, String title, String category) {
         String roleMentionDescription = helper.handleFindRoleForCategory(category, guild)
             .map(role -> " (%s)".formatted(role.getAsMention()))
             .orElse("");
@@ -148,15 +148,15 @@ public final class AskCommand extends SlashCommandAdapter {
             .flatMap(message -> message.editMessage(contentWithRole));
     }
 
-    private static @NotNull RestAction<Message> notifyUser(@NotNull InteractionHook eventHook,
-            @NotNull IMentionable threadChannel) {
+    @Nonnull
+    private static RestAction<Message> notifyUser(InteractionHook eventHook,
+            IMentionable threadChannel) {
         return eventHook.editOriginal("""
                 Created a thread for you: %s
                 Please ask your question there, thanks.""".formatted(threadChannel.getAsMention()));
     }
 
-    private static void handleFailure(@NotNull Throwable exception,
-            @NotNull InteractionHook eventHook) {
+    private static void handleFailure(Throwable exception, InteractionHook eventHook) {
         if (exception instanceof ErrorResponseException responseException) {
             ErrorResponse response = responseException.getErrorResponse();
             if (response == ErrorResponse.MAX_CHANNELS

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/BotMessageCleanup.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/BotMessageCleanup.java
@@ -7,13 +7,13 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.internal.requests.CompletedRestAction;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.Routine;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.config.HelpSystemConfig;
 
+import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -46,7 +46,7 @@ public final class BotMessageCleanup implements Routine {
      *
      * @param config the config to use
      */
-    public BotMessageCleanup(@NotNull Config config) {
+    public BotMessageCleanup(Config config) {
         this.config = config.getHelpSystem();
 
         isStagingChannelName = Pattern.compile(config.getHelpSystem().getStagingChannelPattern())
@@ -54,16 +54,17 @@ public final class BotMessageCleanup implements Routine {
     }
 
     @Override
-    public @NotNull Schedule createSchedule() {
+    @Nonnull
+    public Schedule createSchedule() {
         return new Schedule(ScheduleMode.FIXED_RATE, 1, 1, TimeUnit.MINUTES);
     }
 
     @Override
-    public void runRoutine(@NotNull JDA jda) {
+    public void runRoutine(JDA jda) {
         jda.getGuildCache().forEach(this::cleanupBotMessagesForGuild);
     }
 
-    private void cleanupBotMessagesForGuild(@NotNull Guild guild) {
+    private void cleanupBotMessagesForGuild(Guild guild) {
         Optional<TextChannel> maybeStagingChannel = handleRequireStagingChannel(guild);
 
         if (maybeStagingChannel.isEmpty()) {
@@ -78,7 +79,8 @@ public final class BotMessageCleanup implements Routine {
             .queue();
     }
 
-    private @NotNull Optional<TextChannel> handleRequireStagingChannel(@NotNull Guild guild) {
+    @Nonnull
+    private Optional<TextChannel> handleRequireStagingChannel(Guild guild) {
         Optional<TextChannel> maybeChannel = guild.getTextChannelCache()
             .stream()
             .filter(channel -> isStagingChannelName.test(channel.getName()))
@@ -94,7 +96,7 @@ public final class BotMessageCleanup implements Routine {
         return maybeChannel;
     }
 
-    private static boolean shouldMessageBeCleanedUp(@NotNull Message message) {
+    private static boolean shouldMessageBeCleanedUp(Message message) {
         if (!message.getAuthor().isBot()) {
             return false;
         }
@@ -106,8 +108,9 @@ public final class BotMessageCleanup implements Routine {
         return deleteWhen.isBefore(Instant.now());
     }
 
-    private static @NotNull RestAction<Void> cleanupBotMessages(
-            @NotNull GuildMessageChannel channel, @NotNull Collection<? extends Message> messages) {
+    @Nonnull
+    private static RestAction<Void> cleanupBotMessages(GuildMessageChannel channel,
+            Collection<? extends Message> messages) {
         logger.debug("Cleaning up old bot messages in the staging channel");
         List<String> messageIdsToDelete = messages.stream()
             .filter(BotMessageCleanup::shouldMessageBeCleanedUp)

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpCategoryCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpCategoryCommand.java
@@ -11,11 +11,11 @@ import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.requests.RestAction;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
+import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Locale;
@@ -47,7 +47,7 @@ public final class ChangeHelpCategoryCommand extends SlashCommandAdapter {
      * @param config the config to use
      * @param helper the helper to use
      */
-    public ChangeHelpCategoryCommand(@NotNull Config config, @NotNull HelpSystemHelper helper) {
+    public ChangeHelpCategoryCommand(Config config, HelpSystemHelper helper) {
         super("change-help-category", "changes the category of a help thread",
                 SlashCommandVisibility.GUILD);
 
@@ -68,7 +68,7 @@ public final class ChangeHelpCategoryCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         String category = event.getOption(CATEGORY_OPTION).getAsString();
 
         ThreadChannel helpThread = event.getThreadChannel();
@@ -96,9 +96,9 @@ public final class ChangeHelpCategoryCommand extends SlashCommandAdapter {
             .queue();
     }
 
-    private @NotNull RestAction<Message> sendCategoryChangedMessage(@NotNull Guild guild,
-            @NotNull InteractionHook hook, @NotNull ThreadChannel helpThread,
-            @NotNull String category) {
+    @Nonnull
+    private RestAction<Message> sendCategoryChangedMessage(Guild guild, InteractionHook hook,
+            ThreadChannel helpThread, String category) {
         String changedContent = "Changed the category to **%s**.".formatted(category);
         var action = hook.editOriginal(changedContent);
 
@@ -119,7 +119,7 @@ public final class ChangeHelpCategoryCommand extends SlashCommandAdapter {
             .flatMap(message -> message.editMessage(headsUpWithRole)));
     }
 
-    private boolean isHelpThreadOnCooldown(@NotNull ThreadChannel helpThread) {
+    private boolean isHelpThreadOnCooldown(ThreadChannel helpThread) {
         return Optional
             .ofNullable(helpThreadIdToLastCategoryChange.getIfPresent(helpThread.getIdLong()))
             .map(lastCategoryChange -> lastCategoryChange.plus(COOLDOWN_DURATION_VALUE,

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpTitleCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpTitleCommand.java
@@ -6,7 +6,6 @@ import net.dv8tion.jda.api.entities.ThreadChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
@@ -40,7 +39,7 @@ public final class ChangeHelpTitleCommand extends SlashCommandAdapter {
      *
      * @param helper the helper to use
      */
-    public ChangeHelpTitleCommand(@NotNull HelpSystemHelper helper) {
+    public ChangeHelpTitleCommand(HelpSystemHelper helper) {
         super("change-help-title", "changes the title of a help thread",
                 SlashCommandVisibility.GUILD);
 
@@ -55,7 +54,7 @@ public final class ChangeHelpTitleCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         String title = event.getOption(TITLE_OPTION).getAsString();
 
         if (!handleIsValidTitle(title, event)) {
@@ -84,7 +83,7 @@ public final class ChangeHelpTitleCommand extends SlashCommandAdapter {
             .queue();
     }
 
-    private boolean isHelpThreadOnCooldown(@NotNull ThreadChannel helpThread) {
+    private boolean isHelpThreadOnCooldown(ThreadChannel helpThread) {
         return Optional
             .ofNullable(helpThreadIdToLastTitleChange.getIfPresent(helpThread.getIdLong()))
             .map(lastCategoryChange -> lastCategoryChange.plus(COOLDOWN_DURATION_VALUE,
@@ -93,7 +92,7 @@ public final class ChangeHelpTitleCommand extends SlashCommandAdapter {
             .isPresent();
     }
 
-    private boolean handleIsValidTitle(@NotNull CharSequence title, @NotNull IReplyCallback event) {
+    private boolean handleIsValidTitle(CharSequence title, IReplyCallback event) {
         if (HelpSystemHelper.isTitleValid(title)) {
             return true;
         }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/CloseCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/CloseCommand.java
@@ -6,7 +6,6 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.ThreadChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
@@ -41,7 +40,7 @@ public final class CloseCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         ThreadChannel helpThread = event.getThreadChannel();
         if (helpThread.isArchived()) {
             event.reply("This thread is already closed.").setEphemeral(true).queue();
@@ -66,7 +65,7 @@ public final class CloseCommand extends SlashCommandAdapter {
         event.replyEmbeds(embed).flatMap(any -> helpThread.getManager().setArchived(true)).queue();
     }
 
-    private boolean isHelpThreadOnCooldown(@NotNull ThreadChannel helpThread) {
+    private boolean isHelpThreadOnCooldown(ThreadChannel helpThread) {
         return Optional.ofNullable(helpThreadIdToLastClose.getIfPresent(helpThread.getIdLong()))
             .map(lastCategoryChange -> lastCategoryChange.plus(COOLDOWN_DURATION_VALUE,
                     COOLDOWN_DURATION_UNIT))

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -5,8 +5,6 @@ import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
 import net.dv8tion.jda.internal.requests.CompletedRestAction;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.config.Config;
@@ -15,6 +13,8 @@ import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.HelpThreads;
 import org.togetherjava.tjbot.db.generated.tables.records.HelpThreadsRecord;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.awt.Color;
 import java.io.InputStream;
 import java.util.List;
@@ -60,7 +60,7 @@ public final class HelpSystemHelper {
      * @param config the config to use
      * @param database the database to store help thread metadata in
      */
-    public HelpSystemHelper(@NotNull Config config, @NotNull Database database) {
+    public HelpSystemHelper(Config config, Database database) {
         HelpSystemConfig helpConfig = config.getHelpSystem();
         this.database = database;
 
@@ -73,7 +73,8 @@ public final class HelpSystemHelper {
         categoryRoleSuffix = helpConfig.getCategoryRoleSuffix();
     }
 
-    RestAction<Message> sendExplanationMessage(@NotNull MessageChannel threadChannel) {
+    @Nonnull
+    RestAction<Message> sendExplanationMessage(MessageChannel threadChannel) {
         boolean useCodeSyntaxExampleImage = true;
         InputStream codeSyntaxExampleData =
                 AskCommand.class.getResourceAsStream("/" + CODE_SYNTAX_EXAMPLE_PATH);
@@ -119,20 +120,21 @@ public final class HelpSystemHelper {
         });
     }
 
-    private static @NotNull MessageEmbed embedWith(@NotNull CharSequence message) {
+    @Nonnull
+    private static MessageEmbed embedWith(CharSequence message) {
         return embedWith(message, null);
     }
 
-    private static @NotNull MessageEmbed embedWith(@NotNull CharSequence message,
-            @Nullable String imageUrl) {
+    @Nonnull
+    private static MessageEmbed embedWith(CharSequence message, @Nullable String imageUrl) {
         return new EmbedBuilder().setColor(AMBIENT_COLOR)
             .setDescription(message)
             .setImage(imageUrl)
             .build();
     }
 
-    @NotNull
-    Optional<Role> handleFindRoleForCategory(@NotNull String category, @NotNull Guild guild) {
+    @Nonnull
+    Optional<Role> handleFindRoleForCategory(String category, Guild guild) {
         String roleName = category + categoryRoleSuffix;
         Optional<Role> maybeHelperRole = guild.getRolesByName(roleName, true).stream().findAny();
 
@@ -143,14 +145,13 @@ public final class HelpSystemHelper {
         return maybeHelperRole;
     }
 
-    @NotNull
-    Optional<String> getCategoryOfChannel(@NotNull Channel channel) {
+    @Nonnull
+    Optional<String> getCategoryOfChannel(Channel channel) {
         return Optional.ofNullable(HelpThreadName.ofChannelName(channel.getName()).category);
     }
 
-    @NotNull
-    RestAction<Void> renameChannelToCategory(@NotNull GuildChannel channel,
-            @NotNull String category) {
+    @Nonnull
+    RestAction<Void> renameChannelToCategory(GuildChannel channel, String category) {
         HelpThreadName currentName = HelpThreadName.ofChannelName(channel.getName());
         HelpThreadName nextName =
                 new HelpThreadName(currentName.activity, category, currentName.title);
@@ -158,8 +159,8 @@ public final class HelpSystemHelper {
         return renameChannel(channel, currentName, nextName);
     }
 
-    @NotNull
-    RestAction<Void> renameChannelToTitle(@NotNull GuildChannel channel, @NotNull String title) {
+    @Nonnull
+    RestAction<Void> renameChannelToTitle(GuildChannel channel, String title) {
         HelpThreadName currentName = HelpThreadName.ofChannelName(channel.getName());
         HelpThreadName nextName =
                 new HelpThreadName(currentName.activity, currentName.category, title);
@@ -167,9 +168,8 @@ public final class HelpSystemHelper {
         return renameChannel(channel, currentName, nextName);
     }
 
-    @NotNull
-    RestAction<Void> renameChannelToActivity(@NotNull GuildChannel channel,
-            @NotNull ThreadActivity activity) {
+    @Nonnull
+    RestAction<Void> renameChannelToActivity(GuildChannel channel, ThreadActivity activity) {
         HelpThreadName currentName = HelpThreadName.ofChannelName(channel.getName());
         HelpThreadName nextName =
                 new HelpThreadName(activity, currentName.category, currentName.title);
@@ -177,9 +177,9 @@ public final class HelpSystemHelper {
         return renameChannel(channel, currentName, nextName);
     }
 
-    @NotNull
-    private RestAction<Void> renameChannel(@NotNull GuildChannel channel,
-            @NotNull HelpThreadName currentName, @NotNull HelpThreadName nextName) {
+    @Nonnull
+    private RestAction<Void> renameChannel(GuildChannel channel, HelpThreadName currentName,
+            HelpThreadName nextName) {
         if (currentName.equals(nextName)) {
             // Do not stress rate limits if no actual change is done
             return new CompletedRestAction<>(channel.getJDA(), null);
@@ -188,25 +188,25 @@ public final class HelpSystemHelper {
         return channel.getManager().setName(nextName.toChannelName());
     }
 
-    boolean isOverviewChannelName(@NotNull String channelName) {
+    boolean isOverviewChannelName(String channelName) {
         return isOverviewChannelName.test(channelName);
     }
 
-    @NotNull
+    @Nonnull
     String getOverviewChannelPattern() {
         return overviewChannelPattern;
     }
 
-    boolean isStagingChannelName(@NotNull String channelName) {
+    boolean isStagingChannelName(String channelName) {
         return isStagingChannelName.test(channelName);
     }
 
-    @NotNull
+    @Nonnull
     String getStagingChannelPattern() {
         return stagingChannelPattern;
     }
 
-    static boolean isTitleValid(@NotNull CharSequence title) {
+    static boolean isTitleValid(CharSequence title) {
         String titleCompact = TITLE_COMPACT_REMOVAL_PATTERN.matcher(title).replaceAll("");
 
         return titleCompact.length() >= TITLE_COMPACT_LENGTH_MIN
@@ -214,9 +214,9 @@ public final class HelpSystemHelper {
                 && !titleCompact.toLowerCase(Locale.US).contains("help");
     }
 
-    @NotNull
-    Optional<TextChannel> handleRequireOverviewChannel(@NotNull Guild guild,
-            @NotNull Consumer<? super String> consumeChannelPatternIfNotFound) {
+    @Nonnull
+    Optional<TextChannel> handleRequireOverviewChannel(Guild guild,
+            Consumer<? super String> consumeChannelPatternIfNotFound) {
         Predicate<String> isChannelName = this::isOverviewChannelName;
         String channelPattern = getOverviewChannelPattern();
 
@@ -232,9 +232,9 @@ public final class HelpSystemHelper {
         return maybeChannel;
     }
 
-    @NotNull
-    Optional<TextChannel> handleRequireOverviewChannelForAsk(@NotNull Guild guild,
-            @NotNull MessageChannel respondTo) {
+    @Nonnull
+    Optional<TextChannel> handleRequireOverviewChannelForAsk(Guild guild,
+            MessageChannel respondTo) {
         return handleRequireOverviewChannel(guild, channelPattern -> {
             logger.warn(
                     "Attempted to create a help thread, did not find the overview channel matching the configured pattern '{}' for guild '{}'",
@@ -246,8 +246,8 @@ public final class HelpSystemHelper {
         });
     }
 
-    @NotNull
-    List<ThreadChannel> getActiveThreadsIn(@NotNull TextChannel channel) {
+    @Nonnull
+    List<ThreadChannel> getActiveThreadsIn(TextChannel channel) {
         return channel.getThreadChannels()
             .stream()
             .filter(Predicate.not(ThreadChannel::isArchived))
@@ -255,8 +255,9 @@ public final class HelpSystemHelper {
     }
 
     record HelpThreadName(@Nullable ThreadActivity activity, @Nullable String category,
-            @NotNull String title) {
-        static @NotNull HelpThreadName ofChannelName(@NotNull CharSequence channelName) {
+            String title) {
+        @Nonnull
+        static HelpThreadName ofChannelName(CharSequence channelName) {
             Matcher matcher = EXTRACT_HELP_NAME_PATTERN.matcher(channelName);
 
             if (!matcher.matches()) {
@@ -273,7 +274,7 @@ public final class HelpSystemHelper {
             return new HelpThreadName(activity, category, title);
         }
 
-        @NotNull
+        @Nonnull
         String toChannelName() {
             String activityText = activity == null ? "" : activity.getSymbol() + " ";
             String categoryText = category == null ? "" : "[%s] ".formatted(category);
@@ -289,15 +290,17 @@ public final class HelpSystemHelper {
 
         private final String symbol;
 
-        ThreadActivity(@NotNull String symbol) {
+        ThreadActivity(String symbol) {
             this.symbol = symbol;
         }
 
-        public @NotNull String getSymbol() {
+        @Nonnull
+        public String getSymbol() {
             return symbol;
         }
 
-        static @NotNull ThreadActivity ofSymbol(@NotNull String symbol) {
+        @Nonnull
+        static ThreadActivity ofSymbol(String symbol) {
             return Stream.of(values())
                 .filter(activity -> activity.getSymbol().equals(symbol))
                 .findAny()

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadActivityUpdater.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadActivityUpdater.java
@@ -3,11 +3,11 @@ package org.togetherjava.tjbot.commands.help;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.requests.RestAction;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.Routine;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -33,21 +33,22 @@ public final class HelpThreadActivityUpdater implements Routine {
      *
      * @param helper the helper to use
      */
-    public HelpThreadActivityUpdater(@NotNull HelpSystemHelper helper) {
+    public HelpThreadActivityUpdater(HelpSystemHelper helper) {
         this.helper = helper;
     }
 
     @Override
-    public @NotNull Schedule createSchedule() {
+    @Nonnull
+    public Schedule createSchedule() {
         return new Schedule(ScheduleMode.FIXED_RATE, 1, SCHEDULE_MINUTES, TimeUnit.MINUTES);
     }
 
     @Override
-    public void runRoutine(@NotNull JDA jda) {
+    public void runRoutine(JDA jda) {
         jda.getGuildCache().forEach(this::updateActivityForGuild);
     }
 
-    private void updateActivityForGuild(@NotNull Guild guild) {
+    private void updateActivityForGuild(Guild guild) {
         Optional<TextChannel> maybeOverviewChannel = helper
             .handleRequireOverviewChannel(guild, channelPattern -> logger.warn(
                     "Unable to update help thread overview, did not find an overview channel matching the configured pattern '{}' for guild '{}'",
@@ -66,14 +67,15 @@ public final class HelpThreadActivityUpdater implements Routine {
         activeThreads.forEach(this::updateActivityForThread);
     }
 
-    private void updateActivityForThread(@NotNull ThreadChannel threadChannel) {
+    private void updateActivityForThread(ThreadChannel threadChannel) {
         determineActivity(threadChannel)
             .flatMap(
                     threadActivity -> helper.renameChannelToActivity(threadChannel, threadActivity))
             .queue();
     }
 
-    private static @NotNull RestAction<HelpSystemHelper.ThreadActivity> determineActivity(
+    @Nonnull
+    private static RestAction<HelpSystemHelper.ThreadActivity> determineActivity(
             MessageChannel channel) {
         return channel.getHistory().retrievePast(ACTIVITY_DETERMINE_MESSAGE_LIMIT).map(messages -> {
             if (messages.size() >= ACTIVITY_DETERMINE_MESSAGE_LIMIT) {
@@ -94,7 +96,7 @@ public final class HelpThreadActivityUpdater implements Routine {
         });
     }
 
-    private static boolean isBotMessage(@NotNull Message message) {
+    private static boolean isBotMessage(Message message) {
         return message.getAuthor().equals(message.getJDA().getSelfUser());
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadAutoArchiver.java
@@ -4,11 +4,11 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.utils.TimeUtil;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.Routine;
 
+import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -31,21 +31,22 @@ public final class HelpThreadAutoArchiver implements Routine {
      *
      * @param helper the helper to use
      */
-    public HelpThreadAutoArchiver(@NotNull HelpSystemHelper helper) {
+    public HelpThreadAutoArchiver(HelpSystemHelper helper) {
         this.helper = helper;
     }
 
     @Override
-    public @NotNull Schedule createSchedule() {
+    @Nonnull
+    public Schedule createSchedule() {
         return new Schedule(ScheduleMode.FIXED_RATE, 0, SCHEDULE_MINUTES, TimeUnit.MINUTES);
     }
 
     @Override
-    public void runRoutine(@NotNull JDA jda) {
+    public void runRoutine(JDA jda) {
         jda.getGuildCache().forEach(this::autoArchiveForGuild);
     }
 
-    private void autoArchiveForGuild(@NotNull Guild guild) {
+    private void autoArchiveForGuild(Guild guild) {
         Optional<TextChannel> maybeOverviewChannel = helper
             .handleRequireOverviewChannel(guild, channelPattern -> logger.warn(
                     "Unable to auto archive help threads, did not find an overview channel matching the configured pattern '{}' for guild '{}'",
@@ -66,12 +67,12 @@ public final class HelpThreadAutoArchiver implements Routine {
             .forEach(activeThread -> autoArchiveForThread(activeThread, archiveAfterMoment));
     }
 
-    private @NotNull Instant computeArchiveAfterMoment() {
+    @Nonnull
+    private Instant computeArchiveAfterMoment() {
         return Instant.now().minus(ARCHIVE_AFTER_INACTIVITY_OF);
     }
 
-    private void autoArchiveForThread(@NotNull ThreadChannel threadChannel,
-            @NotNull Instant archiveAfterMoment) {
+    private void autoArchiveForThread(ThreadChannel threadChannel, Instant archiveAfterMoment) {
         if (shouldBeArchived(threadChannel, archiveAfterMoment)) {
             logger.debug("Auto archiving help thread {}", threadChannel.getId());
 
@@ -90,8 +91,7 @@ public final class HelpThreadAutoArchiver implements Routine {
         }
     }
 
-    private static boolean shouldBeArchived(MessageChannel channel,
-            @NotNull Instant archiveAfterMoment) {
+    private static boolean shouldBeArchived(MessageChannel channel, Instant archiveAfterMoment) {
         Instant lastActivity =
                 TimeUtil.getTimeCreated(channel.getLatestMessageIdLong()).toInstant();
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadMetadataPurger.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadMetadataPurger.java
@@ -1,12 +1,13 @@
 package org.togetherjava.tjbot.commands.help;
 
 import net.dv8tion.jda.api.JDA;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.Routine;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.HelpThreads;
+
+import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.time.Period;
 import java.util.concurrent.TimeUnit;
@@ -24,17 +25,18 @@ public class HelpThreadMetadataPurger implements Routine {
      *
      * @param database the database used to purge help thread metadata
      */
-    public HelpThreadMetadataPurger(@NotNull Database database) {
+    public HelpThreadMetadataPurger(Database database) {
         this.database = database;
     }
 
     @Override
-    public @NotNull Schedule createSchedule() {
+    @Nonnull
+    public Schedule createSchedule() {
         return new Schedule(ScheduleMode.FIXED_RATE, 0, 4, TimeUnit.HOURS);
     }
 
     @Override
-    public void runRoutine(@NotNull JDA jda) {
+    public void runRoutine(JDA jda) {
         int recordsDeleted =
                 database.writeAndProvide(content -> content.deleteFrom(HelpThreads.HELP_THREADS))
                     .where(HelpThreads.HELP_THREADS.CREATED_AT

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
@@ -6,14 +6,14 @@ import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.internal.requests.CompletedRestAction;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.MessageReceiverAdapter;
 import org.togetherjava.tjbot.commands.Routine;
 import org.togetherjava.tjbot.config.Config;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -51,7 +51,7 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
      * @param config the config to use
      * @param helper the helper to use
      */
-    public HelpThreadOverviewUpdater(@NotNull Config config, @NotNull HelpSystemHelper helper) {
+    public HelpThreadOverviewUpdater(Config config, HelpSystemHelper helper) {
         super(Pattern.compile(config.getHelpSystem().getOverviewChannelPattern()));
 
         allCategories = config.getHelpSystem().getCategories();
@@ -59,17 +59,18 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
     }
 
     @Override
-    public @NotNull Schedule createSchedule() {
+    @Nonnull
+    public Schedule createSchedule() {
         return new Schedule(ScheduleMode.FIXED_RATE, 1, 1, TimeUnit.MINUTES);
     }
 
     @Override
-    public void runRoutine(@NotNull JDA jda) {
+    public void runRoutine(JDA jda) {
         jda.getGuildCache().forEach(this::updateOverviewForGuild);
     }
 
     @Override
-    public void onMessageReceived(@NotNull MessageReceivedEvent event) {
+    public void onMessageReceived(MessageReceivedEvent event) {
         // Update whenever a thread was created
         Message message = event.getMessage();
         if (message.getType() != MessageType.THREAD_CREATED) {
@@ -94,7 +95,7 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
         UPDATE_SERVICE.schedule(updateOverviewCommand, 2, TimeUnit.SECONDS);
     }
 
-    private void updateOverviewForGuild(@NotNull Guild guild) {
+    private void updateOverviewForGuild(Guild guild) {
         Optional<TextChannel> maybeOverviewChannel = helper
             .handleRequireOverviewChannel(guild, channelPattern -> logger.warn(
                     "Unable to update help thread overview, did not find an overview channel matching the configured pattern '{}' for guild '{}'",
@@ -107,7 +108,7 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
         updateOverview(maybeOverviewChannel.orElseThrow());
     }
 
-    private void updateOverview(@NotNull TextChannel overviewChannel) {
+    private void updateOverview(TextChannel overviewChannel) {
         logger.debug("Updating overview of active questions");
 
         List<ThreadChannel> activeThreads = helper.getActiveThreadsIn(overviewChannel);
@@ -123,7 +124,8 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
             .queue();
     }
 
-    private @NotNull String createDescription(@NotNull Collection<ThreadChannel> activeThreads) {
+    @Nonnull
+    private String createDescription(Collection<ThreadChannel> activeThreads) {
         if (activeThreads.isEmpty()) {
             return "Currently none.";
         }
@@ -148,8 +150,8 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
             .collect(Collectors.joining("\n\n"));
     }
 
-    private static @NotNull RestAction<Optional<Message>> getStatusMessage(
-            @NotNull MessageChannel channel) {
+    @Nonnull
+    private static RestAction<Optional<Message>> getStatusMessage(MessageChannel channel) {
         return channel.getHistory()
             .retrievePast(1)
             .map(messages -> messages.stream()
@@ -157,7 +159,7 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
                 .filter(HelpThreadOverviewUpdater::isStatusMessage));
     }
 
-    private static boolean isStatusMessage(@NotNull Message message) {
+    private static boolean isStatusMessage(Message message) {
         if (!message.getAuthor().equals(message.getJDA().getSelfUser())) {
             return false;
         }
@@ -166,8 +168,9 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
         return content.startsWith(STATUS_TITLE);
     }
 
-    private @NotNull RestAction<Message> sendUpdatedOverview(@Nullable Message statusMessage,
-            @NotNull Message updatedStatusMessage, @NotNull MessageChannel overviewChannel) {
+    @Nonnull
+    private RestAction<Message> sendUpdatedOverview(@Nullable Message statusMessage,
+            Message updatedStatusMessage, MessageChannel overviewChannel) {
         logger.debug("Sending the updated question overview");
         if (statusMessage == null) {
             int currentFailures = FIND_STATUS_MESSAGE_CONSECUTIVE_FAILURES.incrementAndGet();
@@ -190,8 +193,7 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
         return overviewChannel.editMessageById(statusMessageId, updatedStatusMessage);
     }
 
-    private record CategoryWithThreads(@NotNull String category,
-            @NotNull List<ThreadChannel> threads) {
+    private record CategoryWithThreads(String category, List<ThreadChannel> threads) {
 
         String toDiscordString() {
             String threadListText = threads.stream()
@@ -201,8 +203,9 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
             return "**%s**:%n%s".formatted(category, threadListText);
         }
 
-        static @NotNull CategoryWithThreads ofEntry(
-                Map.@NotNull Entry<String, ? extends List<ThreadChannel>> categoryAndThreads) {
+        @Nonnull
+        static CategoryWithThreads ofEntry(
+                Map.Entry<String, ? extends List<ThreadChannel>> categoryAndThreads) {
             return new CategoryWithThreads(categoryAndThreads.getKey(),
                     categoryAndThreads.getValue());
         }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/OnGuildLeaveCloseThreadListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/OnGuildLeaveCloseThreadListener.java
@@ -5,15 +5,14 @@ import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.ThreadChannel;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.EventReceiver;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.HelpThreads;
 
-import javax.annotation.Nonnull;
-import java.util.*;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Remove all thread channels associated to a user when they leave the guild.
@@ -28,12 +27,12 @@ public class OnGuildLeaveCloseThreadListener extends ListenerAdapter implements 
      *
      * @param database database to use
      */
-    public OnGuildLeaveCloseThreadListener(@NotNull Database database) {
+    public OnGuildLeaveCloseThreadListener(Database database) {
         this.database = database;
     }
 
     @Override
-    public void onGuildMemberRemove(@Nonnull GuildMemberRemoveEvent leaveEvent) {
+    public void onGuildMemberRemove(GuildMemberRemoveEvent leaveEvent) {
         Set<Long> channelIds = getThreadsCreatedByLeaver(leaveEvent.getUser().getIdLong());
         for (long channelId : channelIds) {
             closeThread(channelId, leaveEvent);
@@ -48,7 +47,7 @@ public class OnGuildLeaveCloseThreadListener extends ListenerAdapter implements 
             .fetch(databaseMapper -> databaseMapper.getValue(HelpThreads.HELP_THREADS.CHANNEL_ID)));
     }
 
-    private void closeThread(long channelId, @NotNull GuildMemberRemoveEvent leaveEvent) {
+    private void closeThread(long channelId, GuildMemberRemoveEvent leaveEvent) {
         ThreadChannel threadChannel = leaveEvent.getGuild().getThreadChannelById(channelId);
         if (threadChannel == null) {
             logger.warn(

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/package-info.java
@@ -2,4 +2,7 @@
  * This package offers all functionality for the help system. For example commands that let users
  * ask questions, such as {@link org.togetherjava.tjbot.commands.help.AskCommand}.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.help;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/TeXCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/TeXCommand.java
@@ -6,7 +6,6 @@ import net.dv8tion.jda.api.interactions.callbacks.IDeferrableCallback;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
-import org.jetbrains.annotations.NotNull;
 import org.scilab.forge.jlatexmath.ParseException;
 import org.scilab.forge.jlatexmath.TeXConstants;
 import org.scilab.forge.jlatexmath.TeXFormula;
@@ -15,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
+import javax.annotation.Nonnull;
 import javax.imageio.ImageIO;
 import java.awt.Color;
 import java.awt.Image;
@@ -62,7 +62,7 @@ public final class TeXCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull final SlashCommandInteractionEvent event) {
+    public void onSlashCommand(final SlashCommandInteractionEvent event) {
         String latex = Objects.requireNonNull(event.getOption(LATEX_OPTION)).getAsString();
         String userID = (Objects.requireNonNull(event.getMember()).getId());
         TeXFormula formula;
@@ -97,7 +97,8 @@ public final class TeXCommand extends SlashCommandAdapter {
         }
     }
 
-    private @NotNull Image renderImage(@NotNull TeXFormula formula) {
+    @Nonnull
+    private Image renderImage(TeXFormula formula) {
         Image image = formula.createBufferedImage(TeXConstants.STYLE_DISPLAY, DEFAULT_IMAGE_SIZE,
                 FOREGROUND_COLOR, BACKGROUND_COLOR);
 
@@ -107,8 +108,8 @@ public final class TeXCommand extends SlashCommandAdapter {
         return image;
     }
 
-    private void sendImage(@NotNull IDeferrableCallback event, @NotNull String userID,
-            @NotNull Image image) throws IOException {
+    private void sendImage(IDeferrableCallback event, String userID, Image image)
+            throws IOException {
         ByteArrayOutputStream renderedTextImageStream = getRenderedTextImageStream(image);
         event.getHook()
             .editOriginal(renderedTextImageStream.toByteArray(), "tex.png")
@@ -116,9 +117,8 @@ public final class TeXCommand extends SlashCommandAdapter {
             .queue();
     }
 
-    @NotNull
-    private ByteArrayOutputStream getRenderedTextImageStream(@NotNull Image image)
-            throws IOException {
+    @Nonnull
+    private ByteArrayOutputStream getRenderedTextImageStream(Image image) throws IOException {
         BufferedImage renderedTextImage = new BufferedImage(image.getWidth(null),
                 image.getHeight(null), BufferedImage.TYPE_4BYTE_ABGR);
 
@@ -137,8 +137,8 @@ public final class TeXCommand extends SlashCommandAdapter {
      * @param latex the latex to convert
      * @return the converted latex
      */
-    @NotNull
-    private String convertInlineLatexToFull(@NotNull String latex) {
+    @Nonnull
+    private String convertInlineLatexToFull(String latex) {
         if (isInvalidInlineFormat(latex)) {
             throw new ParseException(INVALID_INLINE_FORMAT_ERROR_MESSAGE);
         }
@@ -158,13 +158,12 @@ public final class TeXCommand extends SlashCommandAdapter {
         return sb.toString();
     }
 
-    private boolean isInvalidInlineFormat(@NotNull String latex) {
+    private boolean isInvalidInlineFormat(String latex) {
         return latex.chars().filter(charAsInt -> charAsInt == '$').count() % 2 == 1;
     }
 
     @Override
-    public void onButtonClick(@NotNull final ButtonInteractionEvent event,
-            @NotNull final List<String> args) {
+    public void onButtonClick(final ButtonInteractionEvent event, final List<String> args) {
         if (!args.get(0).equals(Objects.requireNonNull(event.getMember()).getId())) {
             event.reply("You are not the person who executed the command, you cannot do that")
                 .setEphemeral(true)

--- a/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/WolframAlphaCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/WolframAlphaCommand.java
@@ -6,7 +6,6 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.callbacks.IDeferrableCallback;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageUpdateAction;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
@@ -39,7 +38,7 @@ public final class WolframAlphaCommand extends SlashCommandAdapter {
      *
      * @param config the config to use
      */
-    public WolframAlphaCommand(@NotNull Config config) {
+    public WolframAlphaCommand(Config config) {
         super("wolfram-alpha", "Renders mathematical queries using WolframAlpha",
                 SlashCommandVisibility.GUILD);
         getData().addOption(OptionType.STRING, QUERY_OPTION, "the query to send to WolframAlpha",
@@ -48,7 +47,7 @@ public final class WolframAlphaCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         String query = event.getOption(QUERY_OPTION).getAsString();
         WolframAlphaHandler handler = new WolframAlphaHandler(query);
 
@@ -73,8 +72,8 @@ public final class WolframAlphaCommand extends SlashCommandAdapter {
             .thenAccept(response -> sendResponse(response, event));
     }
 
-    private static void sendResponse(@NotNull WolframAlphaHandler.HandlerResponse response,
-            @NotNull IDeferrableCallback event) {
+    private static void sendResponse(WolframAlphaHandler.HandlerResponse response,
+            IDeferrableCallback event) {
         WebhookMessageUpdateAction<Message> action =
                 event.getHook().editOriginalEmbeds(response.embeds());
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/WolframAlphaHandler.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/WolframAlphaHandler.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import io.mikael.urlbuilder.UrlBuilder;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.mathcommands.wolframalpha.api.Error;
 import org.togetherjava.tjbot.commands.mathcommands.wolframalpha.api.*;
 
+import javax.annotation.Nonnull;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -58,7 +58,7 @@ final class WolframAlphaHandler {
      *
      * @param query the original query send to the API
      */
-    WolframAlphaHandler(@NotNull String query) {
+    WolframAlphaHandler(String query) {
         this.query = query;
 
         userApiQuery = UrlBuilder.fromString(USER_API_ENDPOINT)
@@ -73,8 +73,8 @@ final class WolframAlphaHandler {
      * @param apiResponse response of the Wolfram Alpha API query
      * @return user-friendly message for display, as list of embeds
      */
-    @NotNull
-    HandlerResponse handleApiResponse(@NotNull HttpResponse<String> apiResponse) {
+    @Nonnull
+    HandlerResponse handleApiResponse(HttpResponse<String> apiResponse) {
         // Check status code
         int statusCode = apiResponse.statusCode();
         if (statusCode != HttpURLConnection.HTTP_OK) {
@@ -111,7 +111,8 @@ final class WolframAlphaHandler {
         return handleSuccessfulResponse(queryResult);
     }
 
-    private @NotNull HandlerResponse handleMisunderstoodQuery(@NotNull QueryResult result) {
+    @Nonnull
+    private HandlerResponse handleMisunderstoodQuery(QueryResult result) {
         StringJoiner output = new StringJoiner("\n");
         output.add("Sorry, I did not understand your query.");
 
@@ -151,7 +152,8 @@ final class WolframAlphaHandler {
         return responseOf(output.toString());
     }
 
-    private static <E> @NotNull String createBulletPointList(Collection<? extends E> elements,
+    @Nonnull
+    private static <E> String createBulletPointList(Collection<? extends E> elements,
             Function<E, String> elementToText) {
         return elements.stream()
             .map(elementToText)
@@ -159,7 +161,8 @@ final class WolframAlphaHandler {
             .collect(Collectors.joining("\n"));
     }
 
-    private @NotNull HandlerResponse handleSuccessfulResponse(@NotNull QueryResult queryResult) {
+    @Nonnull
+    private HandlerResponse handleSuccessfulResponse(QueryResult queryResult) {
         StringJoiner messages = new StringJoiner("\n\n");
         messages.add("Click the link to see full results.");
 
@@ -198,7 +201,8 @@ final class WolframAlphaHandler {
         return responseOf(messages.toString(), tilesToDisplay);
     }
 
-    private @NotNull HandlerResponse responseOf(@NotNull CharSequence text) {
+    @Nonnull
+    private HandlerResponse responseOf(CharSequence text) {
         MessageEmbed embed = new EmbedBuilder().setTitle(buildTitle(), userApiQuery)
             .setDescription(text)
             .setColor(AMBIENT_COLOR)
@@ -207,8 +211,9 @@ final class WolframAlphaHandler {
         return new HandlerResponse(List.of(embed), List.of());
     }
 
-    private @NotNull HandlerResponse responseOf(@NotNull CharSequence text,
-            @NotNull Collection<? extends BufferedImage> tiles) {
+    @Nonnull
+    private HandlerResponse responseOf(CharSequence text,
+            Collection<? extends BufferedImage> tiles) {
         List<MessageEmbed> embeds = new ArrayList<>();
         embeds.add(new EmbedBuilder().setTitle(buildTitle(), userApiQuery)
             .setDescription(text)
@@ -232,16 +237,16 @@ final class WolframAlphaHandler {
         return new HandlerResponse(embeds, attachments);
     }
 
-    private @NotNull String buildTitle() {
+    @Nonnull
+    private String buildTitle() {
         return query + " - " + SERVICE_NAME;
     }
 
-    record HandlerResponse(@NotNull List<MessageEmbed> embeds,
-            @NotNull List<Attachment> attachments) {
+    record HandlerResponse(List<MessageEmbed> embeds, List<Attachment> attachments) {
     }
 
 
-    record Attachment(@NotNull String name, byte @NotNull [] data) {
+    record Attachment(String name, byte[] data) {
         @Override
         public boolean equals(Object o) {
             if (this == o) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/WolframAlphaImages.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/WolframAlphaImages.java
@@ -1,9 +1,9 @@
 package org.togetherjava.tjbot.commands.mathcommands.wolframalpha;
 
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.mathcommands.wolframalpha.api.SubPod;
 import org.togetherjava.tjbot.commands.mathcommands.wolframalpha.api.WolframAlphaImage;
 
+import javax.annotation.Nonnull;
 import javax.imageio.ImageIO;
 import java.awt.Color;
 import java.awt.Font;
@@ -39,7 +39,8 @@ class WolframAlphaImages {
         throw new UnsupportedOperationException("Utility class, construction not supported");
     }
 
-    static @NotNull BufferedImage renderTitle(@NotNull String title) {
+    @Nonnull
+    static BufferedImage renderTitle(String title) {
         Rectangle2D titleBounds = TITLE_FONT.getStringBounds(title, TITLE_RENDER_CONTEXT);
         int widthPx = (int) Math.ceil(titleBounds.getWidth()) + 2 * IMAGE_MARGIN_PX;
         int heightPx = (int) Math.ceil(titleBounds.getHeight()) + IMAGE_MARGIN_PX;
@@ -55,7 +56,8 @@ class WolframAlphaImages {
         return image;
     }
 
-    static @NotNull BufferedImage renderSubPod(@NotNull SubPod subPod) {
+    @Nonnull
+    static BufferedImage renderSubPod(SubPod subPod) {
         WolframAlphaImage sourceImage = subPod.getImage();
 
         int widthPx = sourceImage.getWidth() + 2 * IMAGE_MARGIN_PX;
@@ -75,12 +77,14 @@ class WolframAlphaImages {
         return destinationImage;
     }
 
-    static @NotNull BufferedImage renderFooter() {
+    @Nonnull
+    static BufferedImage renderFooter() {
         return new BufferedImage(1, IMAGE_MARGIN_PX, BufferedImage.TYPE_4BYTE_ABGR);
     }
 
-    static @NotNull List<BufferedImage> combineImagesIntoTiles(
-            @NotNull Collection<? extends BufferedImage> images, int maxTileHeight) {
+    @Nonnull
+    static List<BufferedImage> combineImagesIntoTiles(Collection<? extends BufferedImage> images,
+            int maxTileHeight) {
         if (images.isEmpty()) {
             throw new IllegalArgumentException("Images must not be empty");
         }
@@ -120,8 +124,9 @@ class WolframAlphaImages {
         return tileHeight != 0 && tileHeight + heightOfImageToAdd > maxTileHeight;
     }
 
-    private static @NotNull BufferedImage combineImages(
-            @NotNull Collection<? extends BufferedImage> images, int widthPx) {
+    @Nonnull
+    private static BufferedImage combineImages(Collection<? extends BufferedImage> images,
+            int widthPx) {
         if (images.isEmpty()) {
             throw new IllegalArgumentException("Images must not be empty");
         }
@@ -146,7 +151,8 @@ class WolframAlphaImages {
         return destinationImage;
     }
 
-    static byte @NotNull [] imageToBytes(@NotNull RenderedImage img) {
+    @Nonnull
+    static byte[] imageToBytes(RenderedImage img) {
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             ImageIO.write(img, IMAGE_FORMAT, outputStream);
             return outputStream.toByteArray();

--- a/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/api/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/api/package-info.java
@@ -3,4 +3,7 @@
  * <a href="https://products.wolframalpha.com/docs/WolframAlpha-API-Reference.pdf">WolframAlpha
  * API</a>.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.mathcommands.wolframalpha.api;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/package-info.java
@@ -2,4 +2,7 @@
  * This packages offers all the functionality for the wolfram-alpha command. Sending queries to
  * their official API, rendering results and displaying them.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.mathcommands.wolframalpha;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ActionRecord.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ActionRecord.java
@@ -1,9 +1,9 @@
 package org.togetherjava.tjbot.commands.moderation;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.togetherjava.tjbot.db.generated.tables.records.ModerationActionsRecord;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.time.Instant;
 
 /**
@@ -20,9 +20,8 @@ import java.time.Instant;
  *        {@code null}
  * @param reason the reason why this action was executed
  */
-public record ActionRecord(int caseId, @NotNull Instant issuedAt, long guildId, long authorId,
-        long targetId, @NotNull ModerationAction actionType, @Nullable Instant actionExpiresAt,
-        @NotNull String reason) {
+public record ActionRecord(int caseId, Instant issuedAt, long guildId, long authorId, long targetId,
+        ModerationAction actionType, @Nullable Instant actionExpiresAt, String reason) {
 
     /**
      * Creates the action record that corresponds to the given action entry from the database table.
@@ -30,8 +29,8 @@ public record ActionRecord(int caseId, @NotNull Instant issuedAt, long guildId, 
      * @param action the action to convert
      * @return the corresponding action record
      */
-    @SuppressWarnings("StaticMethodOnlyUsedInOneClass")
-    static @NotNull ActionRecord of(@NotNull ModerationActionsRecord action) {
+    @Nonnull
+    static ActionRecord of(ModerationActionsRecord action) {
         return new ActionRecord(action.getCaseId(), action.getIssuedAt(), action.getGuildId(),
                 action.getAuthorId(), action.getTargetId(),
                 ModerationAction.valueOf(action.getActionType()), action.getActionExpiresAt(),

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/AuditCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/AuditCommand.java
@@ -73,8 +73,8 @@ public final class AuditCommand extends SlashCommandAdapter {
                 event.getJDA()).flatMap(event::reply).queue();
     }
 
-    private boolean handleChecks(Member bot, Member author,
-            @Nullable Member target, IReplyCallback event) {
+    private boolean handleChecks(Member bot, Member author, @Nullable Member target,
+            IReplyCallback event) {
         // Member doesn't exist if attempting to audit a user who is not part of the guild.
         if (target == null) {
             return true;
@@ -110,8 +110,7 @@ public final class AuditCommand extends SlashCommandAdapter {
     }
 
     @Nonnull
-    private List<List<ActionRecord>> groupActionsByPages(
-            List<ActionRecord> actions) {
+    private List<List<ActionRecord>> groupActionsByPages(List<ActionRecord> actions) {
         List<List<ActionRecord>> groupedActions = new ArrayList<>();
         for (int i = 0; i < actions.size(); i++) {
             if (i % AuditCommand.MAX_PAGE_LENGTH == 0) {
@@ -129,8 +128,7 @@ public final class AuditCommand extends SlashCommandAdapter {
     }
 
     @Nonnull
-    private static EmbedBuilder createSummaryEmbed(User user,
-            Collection<ActionRecord> actions) {
+    private static EmbedBuilder createSummaryEmbed(User user, Collection<ActionRecord> actions) {
         return new EmbedBuilder().setTitle("Audit log of **%s**".formatted(user.getAsTag()))
             .setAuthor(user.getName(), null, user.getAvatarUrl())
             .setDescription(createSummaryMessageDescription(actions))
@@ -165,8 +163,8 @@ public final class AuditCommand extends SlashCommandAdapter {
 
     @Nonnull
     private RestAction<EmbedBuilder> attachEmbedFields(EmbedBuilder auditEmbed,
-            List<? extends List<ActionRecord>> groupedActions, int pageNumber,
-            int totalPages, JDA jda) {
+            List<? extends List<ActionRecord>> groupedActions, int pageNumber, int totalPages,
+            JDA jda) {
         if (groupedActions.isEmpty()) {
             return new CompletedRestAction<>(jda, auditEmbed);
         }
@@ -184,8 +182,7 @@ public final class AuditCommand extends SlashCommandAdapter {
     }
 
     @Nonnull
-    private static RestAction<MessageEmbed.Field> actionToField(
-            ActionRecord action, JDA jda) {
+    private static RestAction<MessageEmbed.Field> actionToField(ActionRecord action, JDA jda) {
         return jda.retrieveUserById(action.authorId())
             .map(author -> author == null ? "(unknown user)" : author.getAsTag())
             .map(authorText -> {
@@ -209,8 +206,8 @@ public final class AuditCommand extends SlashCommandAdapter {
     }
 
     @Nonnull
-    private Message attachPageTurnButtons(EmbedBuilder auditEmbed, int pageNumber,
-            int totalPages, long guildId, long targetId, long callerId) {
+    private Message attachPageTurnButtons(EmbedBuilder auditEmbed, int pageNumber, int totalPages,
+            long guildId, long targetId, long callerId) {
         var messageBuilder = new MessageBuilder(auditEmbed.build());
 
         if (totalPages <= 1) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/AuditCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/AuditCommand.java
@@ -14,11 +14,11 @@ import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.TimeUtil;
 import net.dv8tion.jda.internal.requests.CompletedRestAction;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.*;
@@ -45,7 +45,7 @@ public final class AuditCommand extends SlashCommandAdapter {
      *
      * @param actionsStore used to store actions issued by this command
      */
-    public AuditCommand(@NotNull ModerationActionsStore actionsStore) {
+    public AuditCommand(ModerationActionsStore actionsStore) {
         super(COMMAND_NAME, "Lists all moderation actions that have been taken against a user",
                 SlashCommandVisibility.GUILD);
 
@@ -56,7 +56,7 @@ public final class AuditCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         OptionMapping targetOption =
                 Objects.requireNonNull(event.getOption(TARGET_OPTION), "The target is null");
         User target = targetOption.getAsUser();
@@ -73,9 +73,8 @@ public final class AuditCommand extends SlashCommandAdapter {
                 event.getJDA()).flatMap(event::reply).queue();
     }
 
-    @SuppressWarnings("BooleanMethodNameMustStartWithQuestion")
-    private boolean handleChecks(@NotNull Member bot, @NotNull Member author,
-            @Nullable Member target, @NotNull IReplyCallback event) {
+    private boolean handleChecks(Member bot, Member author,
+            @Nullable Member target, IReplyCallback event) {
         // Member doesn't exist if attempting to audit a user who is not part of the guild.
         if (target == null) {
             return true;
@@ -88,8 +87,9 @@ public final class AuditCommand extends SlashCommandAdapter {
      *        can contain {@link AuditCommand#MAX_PAGE_LENGTH} actions, {@code -1} encodes the last
      *        page
      */
-    private @NotNull RestAction<Message> auditUser(long guildId, long targetId, long callerId,
-            int pageNumber, @NotNull JDA jda) {
+    @Nonnull
+    private RestAction<Message> auditUser(long guildId, long targetId, long callerId,
+            int pageNumber, JDA jda) {
         List<ActionRecord> actions = actionsStore.getActionsByTargetAscending(guildId, targetId);
         List<List<ActionRecord>> groupedActions = groupActionsByPages(actions);
         int totalPages = groupedActions.size();
@@ -109,8 +109,9 @@ public final class AuditCommand extends SlashCommandAdapter {
                     guildId, targetId, callerId));
     }
 
-    private @NotNull List<List<ActionRecord>> groupActionsByPages(
-            @NotNull List<ActionRecord> actions) {
+    @Nonnull
+    private List<List<ActionRecord>> groupActionsByPages(
+            List<ActionRecord> actions) {
         List<List<ActionRecord>> groupedActions = new ArrayList<>();
         for (int i = 0; i < actions.size(); i++) {
             if (i % AuditCommand.MAX_PAGE_LENGTH == 0) {
@@ -127,16 +128,17 @@ public final class AuditCommand extends SlashCommandAdapter {
         return Math.min(Math.max(minInclusive, value), maxInclusive);
     }
 
-    private static @NotNull EmbedBuilder createSummaryEmbed(@NotNull User user,
-            @NotNull Collection<ActionRecord> actions) {
+    @Nonnull
+    private static EmbedBuilder createSummaryEmbed(User user,
+            Collection<ActionRecord> actions) {
         return new EmbedBuilder().setTitle("Audit log of **%s**".formatted(user.getAsTag()))
             .setAuthor(user.getName(), null, user.getAvatarUrl())
             .setDescription(createSummaryMessageDescription(actions))
             .setColor(ModerationUtils.AMBIENT_COLOR);
     }
 
-    private static @NotNull String createSummaryMessageDescription(
-            @NotNull Collection<ActionRecord> actions) {
+    @Nonnull
+    private static String createSummaryMessageDescription(Collection<ActionRecord> actions) {
         int actionAmount = actions.size();
 
         String shortSummary = "There are **%s actions** against the user."
@@ -161,9 +163,10 @@ public final class AuditCommand extends SlashCommandAdapter {
         return shortSummary + "\n" + typeCountSummary;
     }
 
-    private @NotNull RestAction<EmbedBuilder> attachEmbedFields(@NotNull EmbedBuilder auditEmbed,
-            @NotNull List<? extends List<ActionRecord>> groupedActions, int pageNumber,
-            int totalPages, @NotNull JDA jda) {
+    @Nonnull
+    private RestAction<EmbedBuilder> attachEmbedFields(EmbedBuilder auditEmbed,
+            List<? extends List<ActionRecord>> groupedActions, int pageNumber,
+            int totalPages, JDA jda) {
         if (groupedActions.isEmpty()) {
             return new CompletedRestAction<>(jda, auditEmbed);
         }
@@ -180,8 +183,9 @@ public final class AuditCommand extends SlashCommandAdapter {
         });
     }
 
-    private static @NotNull RestAction<MessageEmbed.Field> actionToField(
-            @NotNull ActionRecord action, @NotNull JDA jda) {
+    @Nonnull
+    private static RestAction<MessageEmbed.Field> actionToField(
+            ActionRecord action, JDA jda) {
         return jda.retrieveUserById(action.authorId())
             .map(author -> author == null ? "(unknown user)" : author.getAsTag())
             .map(authorText -> {
@@ -199,11 +203,13 @@ public final class AuditCommand extends SlashCommandAdapter {
             });
     }
 
-    private static @NotNull String formatTime(@NotNull Instant when) {
+    @Nonnull
+    private static String formatTime(Instant when) {
         return TimeUtil.getDateTimeString(when.atOffset(ZoneOffset.UTC));
     }
 
-    private @NotNull Message attachPageTurnButtons(@NotNull EmbedBuilder auditEmbed, int pageNumber,
+    @Nonnull
+    private Message attachPageTurnButtons(EmbedBuilder auditEmbed, int pageNumber,
             int totalPages, long guildId, long targetId, long callerId) {
         var messageBuilder = new MessageBuilder(auditEmbed.build());
 
@@ -216,7 +222,8 @@ public final class AuditCommand extends SlashCommandAdapter {
         return messageBuilder.setActionRows(pageTurnButtons).build();
     }
 
-    private @NotNull ActionRow createPageTurnButtons(long guildId, long targetId, long callerId,
+    @Nonnull
+    private ActionRow createPageTurnButtons(long guildId, long targetId, long callerId,
             int pageNumber, int totalPages) {
         int previousButtonTurnPageBy = -1;
         Button previousButton = createPageTurnButton(PREVIOUS_BUTTON_LABEL, guildId, targetId,
@@ -235,15 +242,16 @@ public final class AuditCommand extends SlashCommandAdapter {
         return ActionRow.of(previousButton, nextButton);
     }
 
-    private @NotNull Button createPageTurnButton(@NotNull String label, long guildId, long targetId,
-            long callerId, long pageNumber, int turnPageBy) {
+    @Nonnull
+    private Button createPageTurnButton(String label, long guildId, long targetId, long callerId,
+            long pageNumber, int turnPageBy) {
         return Button.primary(generateComponentId(String.valueOf(guildId), String.valueOf(targetId),
                 String.valueOf(callerId), String.valueOf(pageNumber), String.valueOf(turnPageBy)),
                 label);
     }
 
     @Override
-    public void onButtonClick(@NotNull ButtonInteractionEvent event, @NotNull List<String> args) {
+    public void onButtonClick(ButtonInteractionEvent event, List<String> args) {
         long commandUserId = Long.parseLong(args.get(2));
         long buttonUserId = event.getMember().getIdLong();
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/BanCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/BanCommand.java
@@ -14,13 +14,13 @@ import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.utils.Result;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
@@ -52,7 +52,7 @@ public final class BanCommand extends SlashCommandAdapter {
      *
      * @param actionsStore used to store actions issued by this command
      */
-    public BanCommand(@NotNull ModerationActionsStore actionsStore) {
+    public BanCommand(ModerationActionsStore actionsStore) {
         super(COMMAND_NAME, "Bans the given user from the server", SlashCommandVisibility.GUILD);
 
         OptionData durationData = new OptionData(OptionType.STRING, DURATION_OPTION,
@@ -69,8 +69,8 @@ public final class BanCommand extends SlashCommandAdapter {
         this.actionsStore = Objects.requireNonNull(actionsStore);
     }
 
-    private static RestAction<InteractionHook> handleAlreadyBanned(@NotNull Guild.Ban ban,
-            @NotNull IReplyCallback event) {
+    private static RestAction<InteractionHook> handleAlreadyBanned(Guild.Ban ban,
+            IReplyCallback event) {
         String reason = ban.getReason();
         String reasonText =
                 reason == null || reason.isBlank() ? "" : " (reason: %s)".formatted(reason);
@@ -80,9 +80,9 @@ public final class BanCommand extends SlashCommandAdapter {
         return event.reply(message).setEphemeral(true);
     }
 
-    private static RestAction<Boolean> sendDm(@NotNull ISnowflake target,
-            @Nullable ModerationUtils.TemporaryData temporaryData, @NotNull String reason,
-            @NotNull Guild guild, @NotNull GenericEvent event) {
+    private static RestAction<Boolean> sendDm(ISnowflake target,
+            @Nullable ModerationUtils.TemporaryData temporaryData, String reason, Guild guild,
+            GenericEvent event) {
         String durationMessage =
                 temporaryData == null ? "permanently" : "for " + temporaryData.duration();
         String dmMessage =
@@ -100,9 +100,9 @@ public final class BanCommand extends SlashCommandAdapter {
             .map(Result::isSuccess);
     }
 
-    private static @NotNull MessageEmbed sendFeedback(boolean hasSentDm, @NotNull User target,
-            @NotNull Member author, @Nullable ModerationUtils.TemporaryData temporaryData,
-            @NotNull String reason) {
+    @Nonnull
+    private static MessageEmbed sendFeedback(boolean hasSentDm, User target, Member author,
+            @Nullable ModerationUtils.TemporaryData temporaryData, String reason) {
         String durationText = "The ban duration is: "
                 + (temporaryData == null ? "permanent" : temporaryData.duration());
         String dmNoticeText = "";
@@ -113,9 +113,9 @@ public final class BanCommand extends SlashCommandAdapter {
                 durationText + dmNoticeText, reason);
     }
 
+    @Nonnull
     private static Optional<RestAction<InteractionHook>> handleNotAlreadyBannedResponse(
-            @NotNull Throwable alreadyBannedFailure, @NotNull IReplyCallback event,
-            @NotNull Guild guild, @NotNull User target) {
+            Throwable alreadyBannedFailure, IReplyCallback event, Guild guild, User target) {
         if (alreadyBannedFailure instanceof ErrorResponseException errorResponseException) {
             if (errorResponseException.getErrorResponse() == ErrorResponse.UNKNOWN_BAN) {
                 return Optional.empty();
@@ -136,11 +136,10 @@ public final class BanCommand extends SlashCommandAdapter {
             .setEphemeral(true));
     }
 
-    @SuppressWarnings("MethodWithTooManyParameters")
-    private RestAction<InteractionHook> banUserFlow(@NotNull User target, @NotNull Member author,
-            @Nullable ModerationUtils.TemporaryData temporaryData, @NotNull String reason,
-            int deleteHistoryDays, @NotNull Guild guild,
-            @NotNull SlashCommandInteractionEvent event) {
+    @Nonnull
+    private RestAction<InteractionHook> banUserFlow(User target, Member author,
+            @Nullable ModerationUtils.TemporaryData temporaryData, String reason,
+            int deleteHistoryDays, Guild guild, SlashCommandInteractionEvent event) {
         return sendDm(target, temporaryData, reason, guild, event)
             .flatMap(hasSentDm -> banUser(target, author, temporaryData, reason, deleteHistoryDays,
                     guild).map(banResult -> hasSentDm))
@@ -148,10 +147,10 @@ public final class BanCommand extends SlashCommandAdapter {
             .flatMap(event::replyEmbeds);
     }
 
-    @SuppressWarnings("MethodWithTooManyParameters")
-    private AuditableRestAction<Void> banUser(@NotNull User target, @NotNull Member author,
-            @Nullable ModerationUtils.TemporaryData temporaryData, @NotNull String reason,
-            int deleteHistoryDays, @NotNull Guild guild) {
+    @Nonnull
+    private AuditableRestAction<Void> banUser(User target, Member author,
+            @Nullable ModerationUtils.TemporaryData temporaryData, String reason,
+            int deleteHistoryDays, Guild guild) {
         String durationMessage =
                 temporaryData == null ? "permanently" : "for " + temporaryData.duration();
         logger.info(
@@ -167,9 +166,8 @@ public final class BanCommand extends SlashCommandAdapter {
     }
 
     @SuppressWarnings({"BooleanMethodNameMustStartWithQuestion", "MethodWithTooManyParameters"})
-    private boolean handleChecks(@NotNull Member bot, @NotNull Member author,
-            @Nullable Member target, @NotNull CharSequence reason, @NotNull Guild guild,
-            @NotNull IReplyCallback event) {
+    private boolean handleChecks(Member bot, Member author, @Nullable Member target,
+            CharSequence reason, Guild guild, IReplyCallback event) {
         // Member doesn't exist if attempting to ban a user who is not part of the guild.
         if (target != null && !ModerationUtils.handleCanInteractWithTarget(ACTION_VERB, bot, author,
                 target, event)) {
@@ -187,7 +185,7 @@ public final class BanCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         OptionMapping targetOption =
                 Objects.requireNonNull(event.getOption(TARGET_OPTION), "The target is null");
         User target = targetOption.getAsUser();

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/BanCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/BanCommand.java
@@ -178,7 +178,7 @@ public final class BanCommand extends SlashCommandAdapter {
             return false;
         }
         if (!ModerationUtils.handleHasAuthorPermissions(ACTION_VERB, Permission.BAN_MEMBERS, author,
-                guild, event)) {
+                event)) {
             return false;
         }
         return ModerationUtils.handleReason(reason, event);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/KickCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/KickCommand.java
@@ -12,13 +12,13 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.utils.Result;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
@@ -41,7 +41,7 @@ public final class KickCommand extends SlashCommandAdapter {
      *
      * @param actionsStore used to store actions issued by this command
      */
-    public KickCommand(@NotNull ModerationActionsStore actionsStore) {
+    public KickCommand(ModerationActionsStore actionsStore) {
         super(COMMAND_NAME, "Kicks the given user from the server", SlashCommandVisibility.GUILD);
 
         getData().addOption(OptionType.USER, TARGET_OPTION, "The user who you want to kick", true)
@@ -50,15 +50,14 @@ public final class KickCommand extends SlashCommandAdapter {
         this.actionsStore = Objects.requireNonNull(actionsStore);
     }
 
-    private static void handleAbsentTarget(@NotNull IReplyCallback event) {
+    private static void handleAbsentTarget(IReplyCallback event) {
         event.reply("I can not kick the given user since they are not part of the guild anymore.")
             .setEphemeral(true)
             .queue();
     }
 
-    private void kickUserFlow(@NotNull Member target, @NotNull Member author,
-            @NotNull String reason, @NotNull Guild guild,
-            @NotNull SlashCommandInteractionEvent event) {
+    private void kickUserFlow(Member target, Member author, String reason, Guild guild,
+            SlashCommandInteractionEvent event) {
         sendDm(target, reason, guild, event)
             .flatMap(hasSentDm -> kickUser(target, author, reason, guild)
                 .map(kickResult -> hasSentDm))
@@ -67,8 +66,9 @@ public final class KickCommand extends SlashCommandAdapter {
             .queue();
     }
 
-    private static RestAction<Boolean> sendDm(@NotNull ISnowflake target, @NotNull String reason,
-            @NotNull Guild guild, @NotNull GenericEvent event) {
+    @Nonnull
+    private static RestAction<Boolean> sendDm(ISnowflake target, String reason, Guild guild,
+            GenericEvent event) {
         return event.getJDA()
             .openPrivateChannelById(target.getId())
             .flatMap(channel -> channel.sendMessage(
@@ -82,8 +82,9 @@ public final class KickCommand extends SlashCommandAdapter {
             .map(Result::isSuccess);
     }
 
-    private AuditableRestAction<Void> kickUser(@NotNull Member target, @NotNull Member author,
-            @NotNull String reason, @NotNull Guild guild) {
+    @Nonnull
+    private AuditableRestAction<Void> kickUser(Member target, Member author, String reason,
+            Guild guild) {
         logger.info("'{}' ({}) kicked the user '{}' ({}) from guild '{}' for reason '{}'.",
                 author.getUser().getAsTag(), author.getId(), target.getUser().getAsTag(),
                 target.getId(), guild.getName(), reason);
@@ -94,8 +95,9 @@ public final class KickCommand extends SlashCommandAdapter {
         return guild.kick(target, reason).reason(reason);
     }
 
-    private static @NotNull MessageEmbed sendFeedback(boolean hasSentDm, @NotNull Member target,
-            @NotNull Member author, @NotNull String reason) {
+    @Nonnull
+    private static MessageEmbed sendFeedback(boolean hasSentDm, Member target, Member author,
+            String reason) {
         String dmNoticeText = "";
         if (!hasSentDm) {
             dmNoticeText = "(Unable to send them a DM.)";
@@ -104,10 +106,9 @@ public final class KickCommand extends SlashCommandAdapter {
                 target.getUser(), dmNoticeText, reason);
     }
 
-    @SuppressWarnings({"BooleanMethodNameMustStartWithQuestion", "MethodWithTooManyParameters"})
-    private boolean handleChecks(@NotNull Member bot, @NotNull Member author,
-            @Nullable Member target, @NotNull CharSequence reason, @NotNull Guild guild,
-            @NotNull IReplyCallback event) {
+    @Nonnull
+    private boolean handleChecks(Member bot, Member author, @Nullable Member target,
+            CharSequence reason, Guild guild, IReplyCallback event) {
         // Member doesn't exist if attempting to kick a user who is not part of the guild anymore.
         if (target == null) {
             handleAbsentTarget(event);
@@ -128,7 +129,7 @@ public final class KickCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         Member target = Objects.requireNonNull(event.getOption(TARGET_OPTION), "The target is null")
             .getAsMember();
         Member author = Objects.requireNonNull(event.getMember(), "The author is null");

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/KickCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/KickCommand.java
@@ -122,7 +122,7 @@ public final class KickCommand extends SlashCommandAdapter {
             return false;
         }
         if (!ModerationUtils.handleHasAuthorPermissions(ACTION_VERB, Permission.KICK_MEMBERS,
-                author, guild, event)) {
+                author, event)) {
             return false;
         }
         return ModerationUtils.handleReason(reason, event);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationAction.java
@@ -1,6 +1,6 @@
 package org.togetherjava.tjbot.commands.moderation;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 /**
  * All available moderation actions.
@@ -51,7 +51,7 @@ public enum ModerationAction {
      * @param verb the verb of the action, as it would be used in a sentence, such as "banned" or
      *        "kicked"
      */
-    ModerationAction(@NotNull String verb) {
+    ModerationAction(String verb) {
         this.verb = verb;
     }
 
@@ -62,7 +62,8 @@ public enum ModerationAction {
      *
      * @return the verb of this action
      */
-    public @NotNull String getVerb() {
+    @Nonnull
+    public String getVerb() {
         return verb;
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationActionsStore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationActionsStore.java
@@ -1,12 +1,12 @@
 package org.togetherjava.tjbot.commands.moderation;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jooq.Condition;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.ModerationActions;
 import org.togetherjava.tjbot.db.generated.tables.records.ModerationActionsRecord;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
@@ -35,7 +35,7 @@ public final class ModerationActionsStore {
      *
      * @param database the database to write and retrieve actions from
      */
-    public ModerationActionsStore(@NotNull Database database) {
+    public ModerationActionsStore(Database database) {
         this.database = Objects.requireNonNull(database);
     }
 
@@ -45,7 +45,8 @@ public final class ModerationActionsStore {
      * 
      * @return a list of all expired actions, chronologically ascending
      */
-    public @NotNull List<ActionRecord> getExpiredActionsAscending() {
+    @Nonnull
+    public List<ActionRecord> getExpiredActionsAscending() {
         return getActionsAscendingWhere(
                 ModerationActions.MODERATION_ACTIONS.ACTION_EXPIRES_AT.isNotNull()
                     .and(ModerationActions.MODERATION_ACTIONS.ACTION_EXPIRES_AT
@@ -61,8 +62,8 @@ public final class ModerationActionsStore {
      * @param actionType the type of action to filter for
      * @return a list of all actions with the given type, chronologically ascending
      */
-    public @NotNull List<ActionRecord> getActionsByTypeAscending(long guildId,
-            @NotNull ModerationAction actionType) {
+    @Nonnull
+    public List<ActionRecord> getActionsByTypeAscending(long guildId, ModerationAction actionType) {
         Objects.requireNonNull(actionType);
 
         return getActionsFromGuildAscending(guildId,
@@ -78,7 +79,8 @@ public final class ModerationActionsStore {
      * @param targetId the id of the target user to filter for
      * @return a list of all actions executed against the target, chronologically ascending
      */
-    public @NotNull List<ActionRecord> getActionsByTargetAscending(long guildId, long targetId) {
+    @Nonnull
+    public List<ActionRecord> getActionsByTargetAscending(long guildId, long targetId) {
         return getActionsFromGuildAscending(guildId,
                 ModerationActions.MODERATION_ACTIONS.TARGET_ID.eq(targetId));
     }
@@ -92,7 +94,8 @@ public final class ModerationActionsStore {
      * @param authorId the id of the author user to filter for
      * @return a list of all actions executed by the author, chronologically ascending
      */
-    public @NotNull List<ActionRecord> getActionsByAuthorAscending(long guildId, long authorId) {
+    @Nonnull
+    public List<ActionRecord> getActionsByAuthorAscending(long guildId, long authorId) {
         return getActionsFromGuildAscending(guildId,
                 ModerationActions.MODERATION_ACTIONS.AUTHOR_ID.eq(authorId));
     }
@@ -107,8 +110,9 @@ public final class ModerationActionsStore {
      * @param actionType the type of the action
      * @return the last action issued against the given user of the given type, if present
      */
-    public @NotNull Optional<ActionRecord> findLastActionAgainstTargetByType(long guildId,
-            long targetId, @NotNull ModerationAction actionType) {
+    @Nonnull
+    public Optional<ActionRecord> findLastActionAgainstTargetByType(long guildId, long targetId,
+            ModerationAction actionType) {
         return database
             .read(context -> context.selectFrom(ModerationActions.MODERATION_ACTIONS)
                 .where(ModerationActions.MODERATION_ACTIONS.GUILD_ID.eq(guildId)
@@ -126,7 +130,8 @@ public final class ModerationActionsStore {
      * @param caseId the actions' case id to search for
      * @return the action with the given case id, if present
      */
-    public @NotNull Optional<ActionRecord> findActionByCaseId(int caseId) {
+    @Nonnull
+    public Optional<ActionRecord> findActionByCaseId(int caseId) {
         return database
             .read(context -> context.selectFrom(ModerationActions.MODERATION_ACTIONS)
                 .where(ModerationActions.MODERATION_ACTIONS.CASE_ID.eq(caseId))
@@ -152,10 +157,8 @@ public final class ModerationActionsStore {
      * @param reason the reason why this action was executed
      * @return the unique case id associated with the action
      */
-    @SuppressWarnings("MethodWithTooManyParameters")
-    public int addAction(long guildId, long authorId, long targetId,
-            @NotNull ModerationAction actionType, @Nullable Instant actionExpiresAt,
-            @NotNull String reason) {
+    public int addAction(long guildId, long authorId, long targetId, ModerationAction actionType,
+            @Nullable Instant actionExpiresAt, String reason) {
         Objects.requireNonNull(actionType);
         Objects.requireNonNull(reason);
 
@@ -174,15 +177,16 @@ public final class ModerationActionsStore {
         });
     }
 
-    private @NotNull List<ActionRecord> getActionsFromGuildAscending(long guildId,
-            @NotNull Condition condition) {
+    @Nonnull
+    private List<ActionRecord> getActionsFromGuildAscending(long guildId, Condition condition) {
         Objects.requireNonNull(condition);
 
         return getActionsAscendingWhere(
                 ModerationActions.MODERATION_ACTIONS.GUILD_ID.eq(guildId).and(condition));
     }
 
-    private @NotNull List<ActionRecord> getActionsAscendingWhere(@NotNull Condition condition) {
+    @Nonnull
+    private List<ActionRecord> getActionsAscendingWhere(Condition condition) {
         Objects.requireNonNull(condition);
 
         return database.read(context -> context.selectFrom(ModerationActions.MODERATION_ACTIONS)

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
@@ -4,13 +4,13 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.config.Config;
 
-import java.awt.*;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.awt.Color;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
@@ -51,8 +51,7 @@ public class ModerationUtils {
      * @param event the event used to respond to the user
      * @return whether the reason is valid
      */
-    @SuppressWarnings("BooleanMethodNameMustStartWithQuestion")
-    static boolean handleReason(@NotNull CharSequence reason, @NotNull IReplyCallback event) {
+    static boolean handleReason(CharSequence reason, IReplyCallback event) {
         if (reason.length() <= REASON_MAX_LENGTH) {
             return true;
         }
@@ -78,9 +77,8 @@ public class ModerationUtils {
      * @param event the event used to respond to the user
      * @return Whether the author and bot can interact with the target user
      */
-    @SuppressWarnings("BooleanMethodNameMustStartWithQuestion")
-    static boolean handleCanInteractWithTarget(@NotNull String actionVerb, @NotNull Member bot,
-            @NotNull Member author, @NotNull Member target, @NotNull IReplyCallback event) {
+    static boolean handleCanInteractWithTarget(String actionVerb, Member bot, Member author,
+            Member target, IReplyCallback event) {
         String targetTag = target.getUser().getAsTag();
         if (!author.canInteract(target)) {
             event
@@ -113,9 +111,8 @@ public class ModerationUtils {
      * @param event the event used to respond to the user
      * @return Whether the author and bot can interact with the role
      */
-    @SuppressWarnings("BooleanMethodNameMustStartWithQuestion")
-    static boolean handleCanInteractWithRole(@NotNull Member bot, @NotNull Member author,
-            @NotNull Role role, @NotNull IReplyCallback event) {
+    static boolean handleCanInteractWithRole(Member bot, Member author, Role role,
+            IReplyCallback event) {
         if (!author.canInteract(role)) {
             event
                 .reply("The role %s is too powerful for you to interact with."
@@ -148,10 +145,8 @@ public class ModerationUtils {
      * @param event the event used to respond to the user
      * @return Whether the bot has the required permission
      */
-    @SuppressWarnings("BooleanMethodNameMustStartWithQuestion")
-    static boolean handleHasBotPermissions(@NotNull String actionVerb,
-            @NotNull Permission permission, @NotNull IPermissionHolder bot, @NotNull Guild guild,
-            @NotNull IReplyCallback event) {
+    static boolean handleHasBotPermissions(String actionVerb, Permission permission,
+            IPermissionHolder bot, Guild guild, IReplyCallback event) {
         if (!bot.hasPermission(permission)) {
             event
                 .reply("I can not %s users in this guild since I do not have the %s permission."
@@ -166,8 +161,7 @@ public class ModerationUtils {
         return true;
     }
 
-    private static void handleAbsentTarget(@NotNull String actionVerb,
-            @NotNull IReplyCallback event) {
+    private static void handleAbsentTarget(String actionVerb, IReplyCallback event) {
         event
             .reply("I can not %s the given user since they are not part of the guild anymore."
                 .formatted(actionVerb))
@@ -202,11 +196,9 @@ public class ModerationUtils {
      * @param event the event used to respond to the user
      * @return Whether the bot and the author have enough permission
      */
-    @SuppressWarnings({"MethodWithTooManyParameters", "BooleanMethodNameMustStartWithQuestion",
-            "squid:S107"})
-    static boolean handleRoleChangeChecks(@Nullable Role role, @NotNull String actionVerb,
-            @Nullable Member target, @NotNull Member bot, @NotNull Member author,
-            @NotNull Guild guild, @NotNull CharSequence reason, @NotNull IReplyCallback event) {
+    static boolean handleRoleChangeChecks(@Nullable Role role, String actionVerb,
+            @Nullable Member target, Member bot, Member author, Guild guild, CharSequence reason,
+            IReplyCallback event) {
         if (role == null) {
             event
                 .reply("Can not %s the user, unable to find the corresponding role on this server"
@@ -248,10 +240,8 @@ public class ModerationUtils {
      * @param event the event used to respond to the user
      * @return Whether the author has the required permission
      */
-    @SuppressWarnings("BooleanMethodNameMustStartWithQuestion")
-    static boolean handleHasAuthorPermissions(@NotNull String actionVerb,
-            @NotNull Permission permission, @NotNull IPermissionHolder author, @NotNull Guild guild,
-            @NotNull IReplyCallback event) {
+    static boolean handleHasAuthorPermissions(String actionVerb, Permission permission,
+            IPermissionHolder author, Guild guild, IReplyCallback event) {
         if (!author.hasPermission(permission)) {
             event
                 .reply("You can not %s users in this guild since you do not have the %s permission."
@@ -277,9 +267,9 @@ public class ModerationUtils {
      * @param reason an optional reason for why the action is executed, {@code null} if not desired
      * @return the created response
      */
-    static @NotNull MessageEmbed createActionResponse(@NotNull User author,
-            @NotNull ModerationAction action, @NotNull User target, @Nullable String extraMessage,
-            @Nullable String reason) {
+    @Nonnull
+    static MessageEmbed createActionResponse(User author, ModerationAction action, User target,
+            @Nullable String extraMessage, @Nullable String reason) {
         String description = "%s **%s** (id: %s).".formatted(action.getVerb(), target.getAsTag(),
                 target.getId());
         if (extraMessage != null && !extraMessage.isBlank()) {
@@ -301,7 +291,7 @@ public class ModerationUtils {
      * @param config the config used to identify the muted role
      * @return predicate that matches the name of the muted role
      */
-    public static Predicate<String> getIsMutedRolePredicate(@NotNull Config config) {
+    public static Predicate<String> getIsMutedRolePredicate(Config config) {
         return Pattern.compile(config.getMutedRolePattern()).asMatchPredicate();
     }
 
@@ -312,8 +302,8 @@ public class ModerationUtils {
      * @param config the config used to identify the muted role
      * @return the muted role, if found
      */
-    public static @NotNull Optional<Role> getMutedRole(@NotNull Guild guild,
-            @NotNull Config config) {
+    @Nonnull
+    public static Optional<Role> getMutedRole(Guild guild, Config config) {
         Predicate<String> isMutedRole = getIsMutedRolePredicate(config);
         return guild.getRoles().stream().filter(role -> isMutedRole.test(role.getName())).findAny();
     }
@@ -324,7 +314,7 @@ public class ModerationUtils {
      * @param config the config used to identify the quarantined role
      * @return predicate that matches the name of the quarantined role
      */
-    public static Predicate<String> getIsQuarantinedRolePredicate(@NotNull Config config) {
+    public static Predicate<String> getIsQuarantinedRolePredicate(Config config) {
         return Pattern.compile(config.getQuarantinedRolePattern()).asMatchPredicate();
     }
 
@@ -335,8 +325,8 @@ public class ModerationUtils {
      * @param config the config used to identify the quarantined role
      * @return the quarantined role, if found
      */
-    public static @NotNull Optional<Role> getQuarantinedRole(@NotNull Guild guild,
-            @NotNull Config config) {
+    @Nonnull
+    public static Optional<Role> getQuarantinedRole(Guild guild, Config config) {
         Predicate<String> isQuarantinedRole = getIsQuarantinedRolePredicate(config);
         return guild.getRoles()
             .stream()
@@ -353,7 +343,8 @@ public class ModerationUtils {
      * @return the temporary data represented by the given duration or empty if the duration is
      *         {@code "permanent"}
      */
-    static @NotNull Optional<TemporaryData> computeTemporaryData(@NotNull String durationText) {
+    @Nonnull
+    static Optional<TemporaryData> computeTemporaryData(String durationText) {
         if (PERMANENT_DURATION.equals(durationText)) {
             return Optional.empty();
         }
@@ -378,6 +369,6 @@ public class ModerationUtils {
      * @param duration a human-readable text representing the duration of the temporary action, such
      *        as {@code "1 day"}.
      */
-    record TemporaryData(@NotNull Instant expiresAt, @NotNull String duration) {
+    record TemporaryData(Instant expiresAt, String duration) {
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
@@ -196,6 +196,9 @@ public class ModerationUtils {
      * @param event the event used to respond to the user
      * @return Whether the bot and the author have enough permission
      */
+    // Sonar complains about having too many parameters. Not incorrect, but not easy to work around
+    // for now
+    @SuppressWarnings({"MethodWithTooManyParameters", "squid:S107"})
     static boolean handleRoleChangeChecks(@Nullable Role role, String actionVerb,
             @Nullable Member target, Member bot, Member author, Guild guild, CharSequence reason,
             IReplyCallback event) {
@@ -241,7 +244,7 @@ public class ModerationUtils {
      * @return Whether the author has the required permission
      */
     static boolean handleHasAuthorPermissions(String actionVerb, Permission permission,
-            IPermissionHolder author, Guild guild, IReplyCallback event) {
+            IPermissionHolder author, IReplyCallback event) {
         if (!author.hasPermission(permission)) {
             event
                 .reply("You can not %s users in this guild since you do not have the %s permission."

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
@@ -9,14 +9,14 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.utils.Result;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
@@ -48,7 +48,7 @@ public final class MuteCommand extends SlashCommandAdapter {
      * @param actionsStore used to store actions issued by this command
      * @param config the config to use for this
      */
-    public MuteCommand(@NotNull ModerationActionsStore actionsStore, @NotNull Config config) {
+    public MuteCommand(ModerationActionsStore actionsStore, Config config) {
         super(COMMAND_NAME, "Mutes the given user so that they can not send messages anymore",
                 SlashCommandVisibility.GUILD);
 
@@ -64,13 +64,14 @@ public final class MuteCommand extends SlashCommandAdapter {
         this.actionsStore = Objects.requireNonNull(actionsStore);
     }
 
-    private static void handleAlreadyMutedTarget(@NotNull IReplyCallback event) {
+    private static void handleAlreadyMutedTarget(IReplyCallback event) {
         event.reply("The user is already muted.").setEphemeral(true).queue();
     }
 
-    private static RestAction<Boolean> sendDm(@NotNull ISnowflake target,
-            @Nullable ModerationUtils.TemporaryData temporaryData, @NotNull String reason,
-            @NotNull Guild guild, @NotNull GenericEvent event) {
+    @Nonnull
+    private static RestAction<Boolean> sendDm(ISnowflake target,
+            @Nullable ModerationUtils.TemporaryData temporaryData, String reason, Guild guild,
+            GenericEvent event) {
         String durationMessage =
                 temporaryData == null ? "permanently" : "for " + temporaryData.duration();
         String dmMessage =
@@ -88,9 +89,9 @@ public final class MuteCommand extends SlashCommandAdapter {
             .map(Result::isSuccess);
     }
 
-    private static @NotNull MessageEmbed sendFeedback(boolean hasSentDm, @NotNull Member target,
-            @NotNull Member author, @Nullable ModerationUtils.TemporaryData temporaryData,
-            @NotNull String reason) {
+    @Nonnull
+    private static MessageEmbed sendFeedback(boolean hasSentDm, Member target, Member author,
+            @Nullable ModerationUtils.TemporaryData temporaryData, String reason) {
         String durationText = "The mute duration is: "
                 + (temporaryData == null ? "permanent" : temporaryData.duration());
         String dmNoticeText = "";
@@ -101,9 +102,9 @@ public final class MuteCommand extends SlashCommandAdapter {
                 target.getUser(), durationText + dmNoticeText, reason);
     }
 
-    private AuditableRestAction<Void> muteUser(@NotNull Member target, @NotNull Member author,
-            @Nullable ModerationUtils.TemporaryData temporaryData, @NotNull String reason,
-            @NotNull Guild guild) {
+    @Nonnull
+    private AuditableRestAction<Void> muteUser(Member target, Member author,
+            @Nullable ModerationUtils.TemporaryData temporaryData, String reason, Guild guild) {
         String durationMessage =
                 temporaryData == null ? "permanently" : "for " + temporaryData.duration();
         logger.info("'{}' ({}) muted the user '{}' ({}) {} in guild '{}' for reason '{}'.",
@@ -119,10 +120,9 @@ public final class MuteCommand extends SlashCommandAdapter {
             .reason(reason);
     }
 
-    @SuppressWarnings("MethodWithTooManyParameters")
-    private void muteUserFlow(@NotNull Member target, @NotNull Member author,
-            @Nullable ModerationUtils.TemporaryData temporaryData, @NotNull String reason,
-            @NotNull Guild guild, @NotNull SlashCommandInteractionEvent event) {
+    private void muteUserFlow(Member target, Member author,
+            @Nullable ModerationUtils.TemporaryData temporaryData, String reason, Guild guild,
+            SlashCommandInteractionEvent event) {
         sendDm(target, temporaryData, reason, guild, event)
             .flatMap(hasSentDm -> muteUser(target, author, temporaryData, reason, guild)
                 .map(result -> hasSentDm))
@@ -131,10 +131,8 @@ public final class MuteCommand extends SlashCommandAdapter {
             .queue();
     }
 
-    @SuppressWarnings({"BooleanMethodNameMustStartWithQuestion", "MethodWithTooManyParameters"})
-    private boolean handleChecks(@NotNull Member bot, @NotNull Member author,
-            @Nullable Member target, @NotNull CharSequence reason, @NotNull Guild guild,
-            @NotNull IReplyCallback event) {
+    private boolean handleChecks(Member bot, Member author, @Nullable Member target,
+            CharSequence reason, Guild guild, IReplyCallback event) {
         if (!ModerationUtils.handleRoleChangeChecks(
                 ModerationUtils.getMutedRole(guild, config).orElse(null), ACTION_VERB, target, bot,
                 author, guild, reason, event)) {
@@ -152,7 +150,7 @@ public final class MuteCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         Member target = Objects.requireNonNull(event.getOption(TARGET_OPTION), "The target is null")
             .getAsMember();
         Member author = Objects.requireNonNull(event.getMember(), "The author is null");

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/NoteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/NoteCommand.java
@@ -5,13 +5,12 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
@@ -34,7 +33,7 @@ public final class NoteCommand extends SlashCommandAdapter {
      *
      * @param actionsStore used to store actions issued by this command
      */
-    public NoteCommand(@NotNull ModerationActionsStore actionsStore) {
+    public NoteCommand(ModerationActionsStore actionsStore) {
         super("note", "Writes a note about the given user", SlashCommandVisibility.GUILD);
 
         getData()
@@ -47,7 +46,7 @@ public final class NoteCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         OptionMapping targetOption = event.getOption(USER_OPTION);
         Member author = event.getMember();
         Guild guild = event.getGuild();
@@ -61,9 +60,8 @@ public final class NoteCommand extends SlashCommandAdapter {
         sendNote(targetOption.getAsUser(), author, content, guild, event);
     }
 
-    @SuppressWarnings("BooleanMethodNameMustStartWithQuestion")
-    private boolean handleChecks(@NotNull Member bot, @NotNull Member author,
-            @Nullable Member target, CharSequence content, @NotNull IReplyCallback event) {
+    private boolean handleChecks(Member bot, Member author, @Nullable Member target,
+            CharSequence content, IReplyCallback event) {
         if (target != null && !ModerationUtils.handleCanInteractWithTarget(ACTION_VERB, bot, author,
                 target, event)) {
             return false;
@@ -72,14 +70,13 @@ public final class NoteCommand extends SlashCommandAdapter {
         return ModerationUtils.handleReason(content, event);
     }
 
-    private void sendNote(@NotNull User target, @NotNull Member author, @NotNull String content,
-            @NotNull ISnowflake guild, @NotNull IReplyCallback event) {
+    private void sendNote(User target, Member author, String content, ISnowflake guild,
+            IReplyCallback event) {
         storeNote(target, author, content, guild);
         sendFeedback(target, author, content, event);
     }
 
-    private void storeNote(@NotNull User target, @NotNull Member author, @NotNull String content,
-            @NotNull ISnowflake guild) {
+    private void storeNote(User target, Member author, String content, ISnowflake guild) {
         logger.info("'{}' ({}) wrote a note about the user '{}' ({}) with content '{}'.",
                 author.getUser().getAsTag(), author.getId(), target.getAsTag(), target.getId(),
                 content);
@@ -88,8 +85,8 @@ public final class NoteCommand extends SlashCommandAdapter {
                 ModerationAction.NOTE, null, content);
     }
 
-    private static void sendFeedback(@NotNull User target, @NotNull Member author,
-            @NotNull String noteContent, @NotNull IReplyCallback event) {
+    private static void sendFeedback(User target, Member author, String noteContent,
+            IReplyCallback event) {
         MessageEmbed feedback = ModerationUtils.createActionResponse(author.getUser(),
                 ModerationAction.NOTE, target, null, noteContent);
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/QuarantineCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/QuarantineCommand.java
@@ -8,14 +8,14 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.utils.Result;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
@@ -41,7 +41,7 @@ public final class QuarantineCommand extends SlashCommandAdapter {
      * @param actionsStore used to store actions issued by this command
      * @param config the config to use for this
      */
-    public QuarantineCommand(@NotNull ModerationActionsStore actionsStore, @NotNull Config config) {
+    public QuarantineCommand(ModerationActionsStore actionsStore, Config config) {
         super(COMMAND_NAME,
                 "Puts the given user under quarantine. They can not interact with anyone anymore then.",
                 SlashCommandVisibility.GUILD);
@@ -55,12 +55,13 @@ public final class QuarantineCommand extends SlashCommandAdapter {
         this.actionsStore = Objects.requireNonNull(actionsStore);
     }
 
-    private static void handleAlreadyQuarantinedTarget(@NotNull IReplyCallback event) {
+    private static void handleAlreadyQuarantinedTarget(IReplyCallback event) {
         event.reply("The user is already quarantined.").setEphemeral(true).queue();
     }
 
-    private static RestAction<Boolean> sendDm(@NotNull ISnowflake target, @NotNull String reason,
-            @NotNull Guild guild, @NotNull GenericEvent event) {
+    @Nonnull
+    private static RestAction<Boolean> sendDm(ISnowflake target, String reason, Guild guild,
+            GenericEvent event) {
         String dmMessage =
                 """
                         Hey there, sorry to tell you but unfortunately you have been put under quarantine in the server %s.
@@ -77,8 +78,9 @@ public final class QuarantineCommand extends SlashCommandAdapter {
             .map(Result::isSuccess);
     }
 
-    private static @NotNull MessageEmbed sendFeedback(boolean hasSentDm, @NotNull Member target,
-            @NotNull Member author, @NotNull String reason) {
+    @Nonnull
+    private static MessageEmbed sendFeedback(boolean hasSentDm, Member target, Member author,
+            String reason) {
         String dmNoticeText = "";
         if (!hasSentDm) {
             dmNoticeText = "\n(Unable to send them a DM.)";
@@ -87,8 +89,9 @@ public final class QuarantineCommand extends SlashCommandAdapter {
                 target.getUser(), dmNoticeText, reason);
     }
 
-    private AuditableRestAction<Void> quarantineUser(@NotNull Member target, @NotNull Member author,
-            @NotNull String reason, @NotNull Guild guild) {
+    @Nonnull
+    private AuditableRestAction<Void> quarantineUser(Member target, Member author, String reason,
+            Guild guild) {
         logger.info("'{}' ({}) quarantined the user '{}' ({}) in guild '{}' for reason '{}'.",
                 author.getUser().getAsTag(), author.getId(), target.getUser().getAsTag(),
                 target.getId(), guild.getName(), reason);
@@ -102,9 +105,8 @@ public final class QuarantineCommand extends SlashCommandAdapter {
             .reason(reason);
     }
 
-    private void quarantineUserFlow(@NotNull Member target, @NotNull Member author,
-            @NotNull String reason, @NotNull Guild guild,
-            @NotNull SlashCommandInteractionEvent event) {
+    private void quarantineUserFlow(Member target, Member author, String reason, Guild guild,
+            SlashCommandInteractionEvent event) {
         sendDm(target, reason, guild, event)
             .flatMap(hasSentDm -> quarantineUser(target, author, reason, guild)
                 .map(result -> hasSentDm))
@@ -113,10 +115,8 @@ public final class QuarantineCommand extends SlashCommandAdapter {
             .queue();
     }
 
-    @SuppressWarnings({"BooleanMethodNameMustStartWithQuestion", "MethodWithTooManyParameters"})
-    private boolean handleChecks(@NotNull Member bot, @NotNull Member author,
-            @Nullable Member target, @NotNull CharSequence reason, @NotNull Guild guild,
-            @NotNull IReplyCallback event) {
+    private boolean handleChecks(Member bot, Member author, @Nullable Member target,
+            CharSequence reason, Guild guild, IReplyCallback event) {
         if (!ModerationUtils.handleRoleChangeChecks(
                 ModerationUtils.getQuarantinedRole(guild, config).orElse(null), ACTION_VERB, target,
                 bot, author, guild, reason, event)) {
@@ -136,7 +136,7 @@ public final class QuarantineCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         Member target = event.getOption(TARGET_OPTION).getAsMember();
         Member author = event.getMember();
         String reason = event.getOption(REASON_OPTION).getAsString();

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/RejoinModerationRoleListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/RejoinModerationRoleListener.java
@@ -6,7 +6,6 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.GenericEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.EventReceiver;
@@ -39,8 +38,7 @@ public final class RejoinModerationRoleListener implements EventReceiver {
      *        user should be e.g. muted
      * @param config the config to use for this
      */
-    public RejoinModerationRoleListener(@NotNull ModerationActionsStore actionsStore,
-            @NotNull Config config) {
+    public RejoinModerationRoleListener(ModerationActionsStore actionsStore, Config config) {
         this.actionsStore = actionsStore;
 
         moderationRoles = List.of(
@@ -52,13 +50,13 @@ public final class RejoinModerationRoleListener implements EventReceiver {
     }
 
     @Override
-    public void onEvent(@NotNull GenericEvent event) {
+    public void onEvent(GenericEvent event) {
         if (event instanceof GuildMemberJoinEvent joinEvent) {
             onGuildMemberJoin(joinEvent);
         }
     }
 
-    private void onGuildMemberJoin(@NotNull GuildMemberJoinEvent event) {
+    private void onGuildMemberJoin(GuildMemberJoinEvent event) {
         Member member = event.getMember();
 
         for (ModerationRole moderationRole : moderationRoles) {
@@ -68,8 +66,8 @@ public final class RejoinModerationRoleListener implements EventReceiver {
         }
     }
 
-    private boolean shouldApplyModerationRole(@NotNull ModerationRole moderationRole,
-            @NotNull IPermissionHolder member) {
+    private boolean shouldApplyModerationRole(ModerationRole moderationRole,
+            IPermissionHolder member) {
         Optional<ActionRecord> lastApplyAction = actionsStore.findLastActionAgainstTargetByType(
                 member.getGuild().getIdLong(), member.getIdLong(), moderationRole.applyAction);
         if (lastApplyAction.isEmpty()) {
@@ -93,8 +91,7 @@ public final class RejoinModerationRoleListener implements EventReceiver {
         return false;
     }
 
-    private static void applyModerationRole(@NotNull ModerationRole moderationRole,
-            @NotNull Member member) {
+    private static void applyModerationRole(ModerationRole moderationRole, Member member) {
         Guild guild = member.getGuild();
         logger.info("Reapplied existing {} to user '{}' ({}) in guild '{}' after rejoining.",
                 moderationRole.actionName, member.getUser().getAsTag(), member.getId(),
@@ -106,7 +103,7 @@ public final class RejoinModerationRoleListener implements EventReceiver {
             .queue();
     }
 
-    private record ModerationRole(@NotNull String actionName, @NotNull ModerationAction applyAction,
-            @NotNull ModerationAction revokeAction, @NotNull Function<Guild, Role> guildToRole) {
+    private record ModerationRole(String actionName, ModerationAction applyAction,
+            ModerationAction revokeAction, Function<Guild, Role> guildToRole) {
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnbanCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnbanCommand.java
@@ -87,7 +87,7 @@ public final class UnbanCommand extends SlashCommandAdapter {
             return false;
         }
         if (!ModerationUtils.handleHasAuthorPermissions(ACTION_VERB, Permission.BAN_MEMBERS, author,
-                guild, event)) {
+                event)) {
             return false;
         }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnbanCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnbanCommand.java
@@ -7,7 +7,6 @@ import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.requests.ErrorResponse;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
@@ -32,7 +31,7 @@ public final class UnbanCommand extends SlashCommandAdapter {
      *
      * @param actionsStore used to store actions issued by this command
      */
-    public UnbanCommand(@NotNull ModerationActionsStore actionsStore) {
+    public UnbanCommand(ModerationActionsStore actionsStore) {
         super(COMMAND_NAME, "Unbans the given user from the server", SlashCommandVisibility.GUILD);
 
         getData()
@@ -43,8 +42,8 @@ public final class UnbanCommand extends SlashCommandAdapter {
         this.actionsStore = Objects.requireNonNull(actionsStore);
     }
 
-    private void unban(@NotNull User target, @NotNull Member author, @NotNull String reason,
-            @NotNull Guild guild, @NotNull IReplyCallback event) {
+    private void unban(User target, Member author, String reason, Guild guild,
+            IReplyCallback event) {
         guild.unban(target).reason(reason).queue(result -> {
             MessageEmbed message = ModerationUtils.createActionResponse(author.getUser(),
                     ModerationAction.UNBAN, target, null, reason);
@@ -59,8 +58,7 @@ public final class UnbanCommand extends SlashCommandAdapter {
         }, unbanFailure -> handleFailure(unbanFailure, target, event));
     }
 
-    private static void handleFailure(@NotNull Throwable unbanFailure, @NotNull User target,
-            @NotNull IReplyCallback event) {
+    private static void handleFailure(Throwable unbanFailure, User target, IReplyCallback event) {
         String targetTag = target.getAsTag();
         if (unbanFailure instanceof ErrorResponseException errorResponseException) {
             if (errorResponseException.getErrorResponse() == ErrorResponse.UNKNOWN_USER) {
@@ -82,9 +80,8 @@ public final class UnbanCommand extends SlashCommandAdapter {
                 targetTag, unbanFailure);
     }
 
-    @SuppressWarnings({"BooleanMethodNameMustStartWithQuestion"})
-    private boolean handleChecks(@NotNull IPermissionHolder bot, @NotNull Member author,
-            @NotNull CharSequence reason, @NotNull Guild guild, @NotNull IReplyCallback event) {
+    private boolean handleChecks(IPermissionHolder bot, Member author, CharSequence reason,
+            Guild guild, IReplyCallback event) {
         if (!ModerationUtils.handleHasBotPermissions(ACTION_VERB, Permission.BAN_MEMBERS, bot,
                 guild, event)) {
             return false;
@@ -98,7 +95,7 @@ public final class UnbanCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         User target = Objects.requireNonNull(event.getOption(TARGET_OPTION), "The target is null")
             .getAsUser();
         Member author = Objects.requireNonNull(event.getMember(), "The author is null");

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnmuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnmuteCommand.java
@@ -8,14 +8,14 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.utils.Result;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
@@ -40,7 +40,7 @@ public final class UnmuteCommand extends SlashCommandAdapter {
      * @param actionsStore used to store actions issued by this command
      * @param config the config to use for this
      */
-    public UnmuteCommand(@NotNull ModerationActionsStore actionsStore, @NotNull Config config) {
+    public UnmuteCommand(ModerationActionsStore actionsStore, Config config) {
         super(COMMAND_NAME,
                 "Unmutes the given already muted user so that they can send messages again",
                 SlashCommandVisibility.GUILD);
@@ -52,12 +52,13 @@ public final class UnmuteCommand extends SlashCommandAdapter {
         this.actionsStore = Objects.requireNonNull(actionsStore);
     }
 
-    private static void handleNotMutedTarget(@NotNull IReplyCallback event) {
+    private static void handleNotMutedTarget(IReplyCallback event) {
         event.reply("The user is not muted.").setEphemeral(true).queue();
     }
 
-    private static RestAction<Boolean> sendDm(@NotNull ISnowflake target, @NotNull String reason,
-            @NotNull Guild guild, @NotNull GenericEvent event) {
+    @Nonnull
+    private static RestAction<Boolean> sendDm(ISnowflake target, String reason, Guild guild,
+            GenericEvent event) {
         String dmMessage = """
                 Hey there, you have been unmuted in the server %s.
                 This means you can now send messages in the server again.
@@ -70,8 +71,9 @@ public final class UnmuteCommand extends SlashCommandAdapter {
             .map(Result::isSuccess);
     }
 
-    private static @NotNull MessageEmbed sendFeedback(boolean hasSentDm, @NotNull Member target,
-            @NotNull Member author, @NotNull String reason) {
+    @Nonnull
+    private static MessageEmbed sendFeedback(boolean hasSentDm, Member target, Member author,
+            String reason) {
         String dmNoticeText = "";
         if (!hasSentDm) {
             dmNoticeText = "(Unable to send them a DM.)";
@@ -80,8 +82,9 @@ public final class UnmuteCommand extends SlashCommandAdapter {
                 target.getUser(), dmNoticeText, reason);
     }
 
-    private AuditableRestAction<Void> unmuteUser(@NotNull Member target, @NotNull Member author,
-            @NotNull String reason, @NotNull Guild guild) {
+    @Nonnull
+    private AuditableRestAction<Void> unmuteUser(Member target, Member author, String reason,
+            Guild guild) {
         logger.info("'{}' ({}) unmuted the user '{}' ({}) in guild '{}' for reason '{}'.",
                 author.getUser().getAsTag(), author.getId(), target.getUser().getAsTag(),
                 target.getId(), guild.getName(), reason);
@@ -94,9 +97,8 @@ public final class UnmuteCommand extends SlashCommandAdapter {
             .reason(reason);
     }
 
-    private void unmuteUserFlow(@NotNull Member target, @NotNull Member author,
-            @NotNull String reason, @NotNull Guild guild,
-            @NotNull SlashCommandInteractionEvent event) {
+    private void unmuteUserFlow(Member target, Member author, String reason, Guild guild,
+            SlashCommandInteractionEvent event) {
         sendDm(target, reason, guild, event)
             .flatMap(
                     hasSentDm -> unmuteUser(target, author, reason, guild).map(result -> hasSentDm))
@@ -105,10 +107,8 @@ public final class UnmuteCommand extends SlashCommandAdapter {
             .queue();
     }
 
-    @SuppressWarnings({"BooleanMethodNameMustStartWithQuestion", "MethodWithTooManyParameters"})
-    private boolean handleChecks(@NotNull Member bot, @NotNull Member author,
-            @Nullable Member target, @NotNull CharSequence reason, @NotNull Guild guild,
-            @NotNull IReplyCallback event) {
+    private boolean handleChecks(Member bot, Member author, @Nullable Member target,
+            CharSequence reason, Guild guild, IReplyCallback event) {
         if (!ModerationUtils.handleRoleChangeChecks(
                 ModerationUtils.getMutedRole(guild, config).orElse(null), ACTION_VERB, target, bot,
                 author, guild, reason, event)) {
@@ -126,7 +126,7 @@ public final class UnmuteCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         Member target = Objects.requireNonNull(event.getOption(TARGET_OPTION), "The target is null")
             .getAsMember();
         Member author = Objects.requireNonNull(event.getMember(), "The author is null");

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnquarantineCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnquarantineCommand.java
@@ -8,14 +8,14 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.utils.Result;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
@@ -41,8 +41,7 @@ public final class UnquarantineCommand extends SlashCommandAdapter {
      * @param actionsStore used to store actions issued by this command
      * @param config the config to use for this
      */
-    public UnquarantineCommand(@NotNull ModerationActionsStore actionsStore,
-            @NotNull Config config) {
+    public UnquarantineCommand(ModerationActionsStore actionsStore, Config config) {
         super(COMMAND_NAME,
                 "Unquarantines the given already quarantined user so that they can interact again",
                 SlashCommandVisibility.GUILD);
@@ -57,12 +56,13 @@ public final class UnquarantineCommand extends SlashCommandAdapter {
         this.actionsStore = Objects.requireNonNull(actionsStore);
     }
 
-    private static void handleNotQuarantinedTarget(@NotNull IReplyCallback event) {
+    private static void handleNotQuarantinedTarget(IReplyCallback event) {
         event.reply("The user is not quarantined.").setEphemeral(true).queue();
     }
 
-    private static RestAction<Boolean> sendDm(@NotNull ISnowflake target, @NotNull String reason,
-            @NotNull Guild guild, @NotNull GenericEvent event) {
+    @Nonnull
+    private static RestAction<Boolean> sendDm(ISnowflake target, String reason, Guild guild,
+            GenericEvent event) {
         String dmMessage = """
                 Hey there, you have been put out of quarantine in the server %s.
                 This means you can now interact with others in the server again.
@@ -76,8 +76,9 @@ public final class UnquarantineCommand extends SlashCommandAdapter {
             .map(Result::isSuccess);
     }
 
-    private static @NotNull MessageEmbed sendFeedback(boolean hasSentDm, @NotNull Member target,
-            @NotNull Member author, @NotNull String reason) {
+    @Nonnull
+    private static MessageEmbed sendFeedback(boolean hasSentDm, Member target, Member author,
+            String reason) {
         String dmNoticeText = "";
         if (!hasSentDm) {
             dmNoticeText = "(Unable to send them a DM.)";
@@ -86,8 +87,9 @@ public final class UnquarantineCommand extends SlashCommandAdapter {
                 target.getUser(), dmNoticeText, reason);
     }
 
-    private AuditableRestAction<Void> unquarantineUser(@NotNull Member target,
-            @NotNull Member author, @NotNull String reason, @NotNull Guild guild) {
+    @Nonnull
+    private AuditableRestAction<Void> unquarantineUser(Member target, Member author, String reason,
+            Guild guild) {
         logger.info("'{}' ({}) unquarantined the user '{}' ({}) in guild '{}' for reason '{}'.",
                 author.getUser().getAsTag(), author.getId(), target.getUser().getAsTag(),
                 target.getId(), guild.getName(), reason);
@@ -101,9 +103,8 @@ public final class UnquarantineCommand extends SlashCommandAdapter {
             .reason(reason);
     }
 
-    private void unquarantineUserFlow(@NotNull Member target, @NotNull Member author,
-            @NotNull String reason, @NotNull Guild guild,
-            @NotNull SlashCommandInteractionEvent event) {
+    private void unquarantineUserFlow(Member target, Member author, String reason, Guild guild,
+            SlashCommandInteractionEvent event) {
         sendDm(target, reason, guild, event)
             .flatMap(hasSentDm -> unquarantineUser(target, author, reason, guild)
                 .map(result -> hasSentDm))
@@ -112,10 +113,8 @@ public final class UnquarantineCommand extends SlashCommandAdapter {
             .queue();
     }
 
-    @SuppressWarnings({"BooleanMethodNameMustStartWithQuestion", "MethodWithTooManyParameters"})
-    private boolean handleChecks(@NotNull Member bot, @NotNull Member author,
-            @Nullable Member target, @NotNull CharSequence reason, @NotNull Guild guild,
-            @NotNull IReplyCallback event) {
+    private boolean handleChecks(Member bot, Member author, @Nullable Member target,
+            CharSequence reason, Guild guild, IReplyCallback event) {
         if (!ModerationUtils.handleRoleChangeChecks(
                 ModerationUtils.getQuarantinedRole(guild, config).orElse(null), ACTION_VERB, target,
                 bot, author, guild, reason, event)) {
@@ -135,7 +134,7 @@ public final class UnquarantineCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         Member target = event.getOption(TARGET_OPTION).getAsMember();
         Member author = event.getMember();
         String reason = event.getOption(REASON_OPTION).getAsString();

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/WarnCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/WarnCommand.java
@@ -7,13 +7,13 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.Result;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
@@ -35,7 +35,7 @@ public final class WarnCommand extends SlashCommandAdapter {
      *
      * @param actionsStore used to store actions issued by this command
      */
-    public WarnCommand(@NotNull ModerationActionsStore actionsStore) {
+    public WarnCommand(ModerationActionsStore actionsStore) {
         super("warn", "Warns the given user", SlashCommandVisibility.GUILD);
 
         getData().addOption(OptionType.USER, USER_OPTION, "The user who you want to warn", true)
@@ -44,9 +44,9 @@ public final class WarnCommand extends SlashCommandAdapter {
         this.actionsStore = Objects.requireNonNull(actionsStore);
     }
 
-    private @NotNull RestAction<InteractionHook> warnUserFlow(@NotNull User target,
-            @NotNull Member author, @NotNull String reason, @NotNull Guild guild,
-            @NotNull SlashCommandInteractionEvent event) {
+    @Nonnull
+    private RestAction<InteractionHook> warnUserFlow(User target, Member author, String reason,
+            Guild guild, SlashCommandInteractionEvent event) {
         return dmUser(target, reason, guild, event).map(hasSentDm -> {
             warnUser(target, author, reason, guild);
             return hasSentDm;
@@ -55,9 +55,9 @@ public final class WarnCommand extends SlashCommandAdapter {
             .flatMap(event::replyEmbeds);
     }
 
-    private static @NotNull RestAction<Boolean> dmUser(@NotNull ISnowflake target,
-            @NotNull String reason, @NotNull Guild guild,
-            @NotNull SlashCommandInteractionEvent event) {
+    @Nonnull
+    private static RestAction<Boolean> dmUser(ISnowflake target, String reason, Guild guild,
+            SlashCommandInteractionEvent event) {
         return event.getJDA()
             .openPrivateChannelById(target.getId())
             .flatMap(channel -> channel.sendMessage(
@@ -71,8 +71,7 @@ public final class WarnCommand extends SlashCommandAdapter {
             .map(Result::isSuccess);
     }
 
-    private void warnUser(@NotNull User target, @NotNull Member author, @NotNull String reason,
-            @NotNull Guild guild) {
+    private void warnUser(User target, Member author, String reason, Guild guild) {
         logger.info("'{}' ({}) warned the user '{}' ({}) for reason '{}'.",
                 author.getUser().getAsTag(), author.getId(), target.getAsTag(), target.getId(),
                 reason);
@@ -81,8 +80,9 @@ public final class WarnCommand extends SlashCommandAdapter {
                 ModerationAction.WARN, null, reason);
     }
 
-    private static @NotNull MessageEmbed sendFeedback(boolean hasSentDm, @NotNull User target,
-            @NotNull Member author, @NotNull String reason) {
+    @Nonnull
+    private static MessageEmbed sendFeedback(boolean hasSentDm, User target, Member author,
+            String reason) {
         String dmNoticeText = "";
         if (!hasSentDm) {
             dmNoticeText = "(Unable to send them a DM.)";
@@ -92,7 +92,7 @@ public final class WarnCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         OptionMapping targetOption =
                 Objects.requireNonNull(event.getOption(USER_OPTION), "The target is null");
         Member author = Objects.requireNonNull(event.getMember(), "The author is null");
@@ -108,9 +108,8 @@ public final class WarnCommand extends SlashCommandAdapter {
         warnUserFlow(targetOption.getAsUser(), author, reason, guild, event).queue();
     }
 
-    @SuppressWarnings("BooleanMethodNameMustStartWithQuestion")
-    private boolean handleChecks(@NotNull Member bot, @NotNull Member author,
-            @Nullable Member target, String reason, @NotNull SlashCommandInteractionEvent event) {
+    private boolean handleChecks(Member bot, Member author, @Nullable Member target, String reason,
+            SlashCommandInteractionEvent event) {
         if (target != null && !ModerationUtils.handleCanInteractWithTarget(ACTION_VERB, bot, author,
                 target, event)) {
             return false;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/WhoIsCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/WhoIsCommand.java
@@ -8,12 +8,12 @@ import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.commands.utils.DiscordClientAction;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 import java.awt.Color;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -49,7 +49,7 @@ public final class WhoIsCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull final SlashCommandInteractionEvent event) {
+    public void onSlashCommand(final SlashCommandInteractionEvent event) {
         OptionMapping userOption = Objects.requireNonNull(event.getOption(USER_OPTION),
                 "The given user option cannot be null");
         OptionMapping showServerSpecificInfoOption = event.getOption(SHOW_SERVER_INFO_OPTION);
@@ -70,8 +70,9 @@ public final class WhoIsCommand extends SlashCommandAdapter {
     }
 
     @CheckReturnValue
-    private static @NotNull ReplyCallbackAction handleWhoIsUser(final @NotNull IReplyCallback event,
-            final @NotNull User user, final @NotNull User.Profile profile) {
+    @Nonnull
+    private static ReplyCallbackAction handleWhoIsUser(final IReplyCallback event, final User user,
+            final User.Profile profile) {
         String description = userIdentificationToStringItem(user) + "\n**Is bot:** " + user.isBot()
                 + userFlagsToStringItem(user.getFlags()) + "\n**Registration date:** "
                 + DATE_TIME_FORMAT.format(user.getTimeCreated());
@@ -85,9 +86,9 @@ public final class WhoIsCommand extends SlashCommandAdapter {
     }
 
     @CheckReturnValue
-    private static @NotNull ReplyCallbackAction handleWhoIsMember(
-            final @NotNull IReplyCallback event, final @NotNull Member member,
-            final @NotNull User.Profile profile) {
+    @Nonnull
+    private static ReplyCallbackAction handleWhoIsMember(final IReplyCallback event,
+            final Member member, final User.Profile profile) {
         User user = member.getUser();
 
         Color memberColor = member.getColor();
@@ -108,15 +109,16 @@ public final class WhoIsCommand extends SlashCommandAdapter {
         return sendEmbedWithProfileAction(event, embedBuilder.build(), user.getId());
     }
 
-    private static @NotNull ReplyCallbackAction sendEmbedWithProfileAction(
-            final @NotNull IReplyCallback event, @NotNull MessageEmbed embed,
-            @NotNull String userId) {
+    @Nonnull
+    private static ReplyCallbackAction sendEmbedWithProfileAction(final IReplyCallback event,
+            MessageEmbed embed, String userId) {
         return event.replyEmbeds(embed)
             .addActionRow(
                     DiscordClientAction.General.USER.asLinkButton("Click to see profile!", userId));
     }
 
-    private static @NotNull String voiceStateToStringItem(@NotNull final Member member) {
+    @Nonnull
+    private static String voiceStateToStringItem(final Member member) {
         GuildVoiceState voiceState = Objects.requireNonNull(member.getVoiceState(),
                 "The given voiceState cannot be null");
 
@@ -137,9 +139,9 @@ public final class WhoIsCommand extends SlashCommandAdapter {
      * @param effectiveColor the {@link Color} that the embed will become
      * @return the generated {@link EmbedBuilder}
      */
-    private static @NotNull EmbedBuilder generateEmbedBuilder(@NotNull final Interaction event,
-            @NotNull final User user, final @NotNull User.Profile profile,
-            final Color effectiveColor) {
+    @Nonnull
+    private static EmbedBuilder generateEmbedBuilder(final Interaction event, final User user,
+            final User.Profile profile, final Color effectiveColor) {
 
         EmbedBuilder embedBuilder = new EmbedBuilder().setThumbnail(user.getEffectiveAvatarUrl())
             .setColor(effectiveColor)
@@ -160,7 +162,8 @@ public final class WhoIsCommand extends SlashCommandAdapter {
      * @param member the {@link Member} to take the booster properties from
      * @return user readable {@link String}
      */
-    private static @NotNull String possibleBoosterToStringItem(final @NotNull Member member) {
+    @Nonnull
+    private static String possibleBoosterToStringItem(final Member member) {
         OffsetDateTime timeBoosted = member.getTimeBoosted();
 
         if (null == timeBoosted) {
@@ -177,7 +180,8 @@ public final class WhoIsCommand extends SlashCommandAdapter {
      * @param user the {@link User} to take the identifiers from
      * @return user readable {@link String}
      */
-    private static @NotNull String userIdentificationToStringItem(final @NotNull User user) {
+    @Nonnull
+    private static String userIdentificationToStringItem(final User user) {
         return "**Mention:** " + user.getAsMention() + "\n**Tag:** " + user.getAsTag()
                 + "\n**ID:** " + user.getId();
     }
@@ -188,7 +192,8 @@ public final class WhoIsCommand extends SlashCommandAdapter {
      * @param member member to take the Roles from
      * @return user readable {@link String} of the roles
      */
-    private static String formatRoles(final @NotNull Member member) {
+    @Nonnull
+    private static String formatRoles(final Member member) {
         return member.getRoles().stream().map(Role::getAsMention).collect(Collectors.joining(", "));
     }
 
@@ -199,8 +204,8 @@ public final class WhoIsCommand extends SlashCommandAdapter {
      *        (recommend {@link java.util.EnumSet}
      * @return user readable {@link StringBuilder}
      */
-    private static @NotNull StringBuilder userFlagsToStringItem(
-            final @NotNull Collection<User.UserFlag> flags) {
+    @Nonnull
+    private static StringBuilder userFlagsToStringItem(final Collection<User.UserFlag> flags) {
         String formattedFlags = formatUserFlags(flags);
         StringBuilder result = hypeSquadToStringItem(flags);
 
@@ -218,8 +223,8 @@ public final class WhoIsCommand extends SlashCommandAdapter {
      *        (recommend {@link java.util.EnumSet}
      * @return user readable {@link StringBuilder}
      */
-    private static @NotNull StringBuilder hypeSquadToStringItem(
-            final @NotNull Collection<User.UserFlag> flags) {
+    @Nonnull
+    private static StringBuilder hypeSquadToStringItem(final Collection<User.UserFlag> flags) {
         StringBuilder stringBuilder = new StringBuilder("**\nHypesquad:** ");
 
         if (flags.contains(User.UserFlag.HYPESQUAD_BALANCE)) {
@@ -242,8 +247,8 @@ public final class WhoIsCommand extends SlashCommandAdapter {
      *        (recommend {@link java.util.EnumSet}
      * @return the user readable string
      */
-    @NotNull
-    private static String formatUserFlags(final @NotNull Collection<User.UserFlag> flags) {
+    @Nonnull
+    private static String formatUserFlags(final Collection<User.UserFlag> flags) {
         return flags.stream()
             .map(User.UserFlag::getName)
             .filter(name -> (name.contains("Hypesquad")))

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/package-info.java
@@ -2,4 +2,7 @@
  * This package offers all the moderation commands from the application such as banning and kicking
  * users.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.moderation;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/scam/ScamDetector.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/scam/ScamDetector.java
@@ -1,6 +1,5 @@
 package org.togetherjava.tjbot.commands.moderation.scam;
 
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.utils.StringDistances;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.config.ScamBlockerConfig;
@@ -23,7 +22,7 @@ public final class ScamDetector {
      * 
      * @param config the scam blocker config to use
      */
-    public ScamDetector(@NotNull Config config) {
+    public ScamDetector(Config config) {
         this.config = config.getScamBlocker();
     }
 
@@ -33,20 +32,20 @@ public final class ScamDetector {
      * @param message the message to analyze
      * @return Whether the message classifies as scam
      */
-    public boolean isScam(@NotNull CharSequence message) {
+    public boolean isScam(CharSequence message) {
         AnalyseResults results = new AnalyseResults();
         TOKENIZER.splitAsStream(message).forEach(token -> analyzeToken(token, results));
         return isScam(results);
     }
 
-    private boolean isScam(@NotNull AnalyseResults results) {
+    private boolean isScam(AnalyseResults results) {
         if (results.pingsEveryone && results.containsNitroKeyword && results.hasUrl) {
             return true;
         }
         return results.containsNitroKeyword && results.hasSuspiciousUrl;
     }
 
-    private void analyzeToken(@NotNull String token, @NotNull AnalyseResults results) {
+    private void analyzeToken(String token, AnalyseResults results) {
         if ("@everyone".equalsIgnoreCase(token)) {
             results.pingsEveryone = true;
         }
@@ -60,7 +59,7 @@ public final class ScamDetector {
         }
     }
 
-    private void analyzeUrl(@NotNull String url, @NotNull AnalyseResults results) {
+    private void analyzeUrl(String url, AnalyseResults results) {
         String host;
         try {
             host = URI.create(url).getHost();
@@ -92,7 +91,7 @@ public final class ScamDetector {
         }
     }
 
-    private boolean isHostSimilarToKeyword(@NotNull String host, @NotNull String keyword) {
+    private boolean isHostSimilarToKeyword(String host, String keyword) {
         // NOTE This algorithm is far from optimal.
         // It is good enough for our purpose though and not that complex.
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/scam/ScamHistoryPurgeRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/scam/ScamHistoryPurgeRoutine.java
@@ -1,9 +1,9 @@
 package org.togetherjava.tjbot.commands.moderation.scam;
 
 import net.dv8tion.jda.api.JDA;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.Routine;
 
+import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.time.Period;
 import java.util.concurrent.TimeUnit;
@@ -20,17 +20,18 @@ public final class ScamHistoryPurgeRoutine implements Routine {
      * 
      * @param scamHistoryStore containing the scam history to purge
      */
-    public ScamHistoryPurgeRoutine(@NotNull ScamHistoryStore scamHistoryStore) {
+    public ScamHistoryPurgeRoutine(ScamHistoryStore scamHistoryStore) {
         this.scamHistoryStore = scamHistoryStore;
     }
 
     @Override
-    public @NotNull Schedule createSchedule() {
+    @Nonnull
+    public Schedule createSchedule() {
         return new Schedule(ScheduleMode.FIXED_RATE, 0, 1, TimeUnit.DAYS);
     }
 
     @Override
-    public void runRoutine(@NotNull JDA jda) {
+    public void runRoutine(JDA jda) {
         scamHistoryStore.deleteHistoryOlderThan(Instant.now().minus(DELETE_SCAM_RECORDS_AFTER));
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/scam/ScamHistoryStore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/scam/ScamHistoryStore.java
@@ -1,12 +1,12 @@
 package org.togetherjava.tjbot.commands.moderation.scam;
 
 import net.dv8tion.jda.api.entities.Message;
-import org.jetbrains.annotations.NotNull;
 import org.jooq.Result;
 import org.togetherjava.tjbot.commands.utils.Hashing;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.records.ScamHistoryRecord;
 
+import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -39,7 +39,7 @@ public final class ScamHistoryStore {
      *
      * @param database containing the scam history to work with
      */
-    public ScamHistoryStore(@NotNull Database database) {
+    public ScamHistoryStore(Database database) {
         this.database = database;
     }
 
@@ -49,7 +49,7 @@ public final class ScamHistoryStore {
      * @param scam the message to add
      * @param isDeleted whether the message is already, or about to get, deleted
      */
-    public void addScam(@NotNull Message scam, boolean isDeleted) {
+    public void addScam(Message scam, boolean isDeleted) {
         Objects.requireNonNull(scam);
 
         database.write(context -> context.newRecord(SCAM_HISTORY)
@@ -71,8 +71,8 @@ public final class ScamHistoryStore {
      * @return identifications of all scam messages that have just been marked deleted, which
      *         previously have not been marked accordingly yet
      */
-    public @NotNull Collection<ScamIdentification> markScamDuplicatesDeleted(
-            @NotNull Message scam) {
+    @Nonnull
+    public Collection<ScamIdentification> markScamDuplicatesDeleted(Message scam) {
         return markScamDuplicatesDeleted(scam.getGuild().getIdLong(), scam.getAuthor().getIdLong(),
                 hashMessageContent(scam));
     }
@@ -87,8 +87,9 @@ public final class ScamHistoryStore {
      * @return identifications of all scam messages that have just been marked deleted, which
      *         previously have not been marked accordingly yet
      */
-    public @NotNull Collection<ScamIdentification> markScamDuplicatesDeleted(long guildId,
-            long authorId, @NotNull String contentHash) {
+    @Nonnull
+    public Collection<ScamIdentification> markScamDuplicatesDeleted(long guildId, long authorId,
+            String contentHash) {
         return database.writeAndProvide(context -> {
             Result<ScamHistoryRecord> undeletedDuplicates = context.selectFrom(SCAM_HISTORY)
                 .where(SCAM_HISTORY.GUILD_ID.eq(guildId)
@@ -111,7 +112,7 @@ public final class ScamHistoryStore {
      * @param scam the scam message to look for duplicates
      * @return whether there are recent duplicates
      */
-    public boolean hasRecentScamDuplicate(@NotNull Message scam) {
+    public boolean hasRecentScamDuplicate(Message scam) {
         Instant recentScamThreshold = Instant.now().minus(RECENT_SCAM_DURATION);
 
         return database.read(context -> context.fetchCount(SCAM_HISTORY,
@@ -138,7 +139,8 @@ public final class ScamHistoryStore {
      * @param message the message to hash
      * @return a text representation of the hash
      */
-    public static @NotNull String hashMessageContent(@NotNull Message message) {
+    @Nonnull
+    public static String hashMessageContent(Message message) {
         return Hashing.bytesToHex(Hashing.hash(HASH_METHOD,
                 message.getContentRaw().getBytes(StandardCharsets.UTF_8)));
     }
@@ -154,8 +156,8 @@ public final class ScamHistoryStore {
      */
     public record ScamIdentification(long guildId, long channelId, long messageId, long authorId,
             String contentHash) {
-        private static ScamIdentification ofDatabaseRecord(
-                @NotNull ScamHistoryRecord scamHistoryRecord) {
+        @Nonnull
+        private static ScamIdentification ofDatabaseRecord(ScamHistoryRecord scamHistoryRecord) {
             return new ScamIdentification(scamHistoryRecord.getGuildId(),
                     scamHistoryRecord.getChannelId(), scamHistoryRecord.getMessageId(),
                     scamHistoryRecord.getAuthorId(), scamHistoryRecord.getContentHash());

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/scam/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/scam/package-info.java
@@ -2,4 +2,7 @@
  * This package offers classes dealing with detecting scam messages and taking appropriate action,
  * see {@link org.togetherjava.tjbot.commands.moderation.scam.ScamBlocker} as main entry point.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.moderation.scam;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/RevocableModerationAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/RevocableModerationAction.java
@@ -3,8 +3,9 @@ package org.togetherjava.tjbot.commands.moderation.temp;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.requests.RestAction;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.moderation.ModerationAction;
+
+import javax.annotation.Nonnull;
 
 /**
  * Represents revocable moderation actions, such as temporary bans. Primarily used by
@@ -34,7 +35,7 @@ interface RevocableModerationAction {
      * 
      * @return the type to apply the temporary action
      */
-    @NotNull
+    @Nonnull
     ModerationAction getApplyType();
 
     /**
@@ -43,7 +44,7 @@ interface RevocableModerationAction {
      * 
      * @return the type to revoke the temporary action
      */
-    @NotNull
+    @Nonnull
     ModerationAction getRevokeType();
 
     /**
@@ -54,9 +55,8 @@ interface RevocableModerationAction {
      * @param reason why the action is revoked
      * @return the unsubmitted revocation action
      */
-    @NotNull
-    RestAction<Void> revokeAction(@NotNull Guild guild, @NotNull User target,
-            @NotNull String reason);
+    @Nonnull
+    RestAction<Void> revokeAction(Guild guild, User target, String reason);
 
     /**
      * Handle a failure that might occur during revocation, i.e. execution of the action returned by
@@ -67,6 +67,6 @@ interface RevocableModerationAction {
      * @return a classification of the failure, decides whether the surrounding flow will continue
      *         to handle the error further or not
      */
-    @NotNull
-    FailureIdentification handleRevokeFailure(@NotNull Throwable failure, long targetId);
+    @Nonnull
+    FailureIdentification handleRevokeFailure(Throwable failure, long targetId);
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/RevocableRoleBasedAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/RevocableRoleBasedAction.java
@@ -1,9 +1,10 @@
 package org.togetherjava.tjbot.commands.moderation.temp;
 
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
 
 /**
  * Role based moderation actions that can be revoked, for example a {@link TemporaryMuteAction} or a
@@ -20,13 +21,13 @@ abstract class RevocableRoleBasedAction implements RevocableModerationAction {
      * @param actionName the action name to be used in logging in case of a failure, e.g.
      *        {@code "mute"}, {@code "quarantine"}
      */
-    RevocableRoleBasedAction(@NotNull String actionName) {
+    RevocableRoleBasedAction(String actionName) {
         this.actionName = actionName;
     }
 
     @Override
-    public @NotNull FailureIdentification handleRevokeFailure(@NotNull Throwable failure,
-            long targetId) {
+    @Nonnull
+    public FailureIdentification handleRevokeFailure(Throwable failure, long targetId) {
 
         if (failure instanceof ErrorResponseException errorResponseException) {
             switch (errorResponseException.getErrorResponse()) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryBanAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryBanAction.java
@@ -5,10 +5,11 @@ import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.requests.RestAction;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.moderation.ModerationAction;
+
+import javax.annotation.Nonnull;
 
 /**
  * Action to revoke temporary bans, as applied by
@@ -19,24 +20,26 @@ final class TemporaryBanAction implements RevocableModerationAction {
     private static final Logger logger = LoggerFactory.getLogger(TemporaryBanAction.class);
 
     @Override
-    public @NotNull ModerationAction getApplyType() {
+    @Nonnull
+    public ModerationAction getApplyType() {
         return ModerationAction.BAN;
     }
 
     @Override
-    public @NotNull ModerationAction getRevokeType() {
+    @Nonnull
+    public ModerationAction getRevokeType() {
         return ModerationAction.UNBAN;
     }
 
     @Override
-    public @NotNull RestAction<Void> revokeAction(@NotNull Guild guild, @NotNull User target,
-            @NotNull String reason) {
+    @Nonnull
+    public RestAction<Void> revokeAction(Guild guild, User target, String reason) {
         return guild.unban(target).reason(reason);
     }
 
     @Override
-    public @NotNull FailureIdentification handleRevokeFailure(@NotNull Throwable failure,
-            long targetId) {
+    @Nonnull
+    public FailureIdentification handleRevokeFailure(Throwable failure, long targetId) {
         if (failure instanceof ErrorResponseException errorResponseException) {
             if (errorResponseException.getErrorResponse() == ErrorResponse.UNKNOWN_USER) {
                 logger.debug(

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryMuteAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryMuteAction.java
@@ -3,10 +3,11 @@ package org.togetherjava.tjbot.commands.moderation.temp;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.requests.RestAction;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.moderation.ModerationAction;
 import org.togetherjava.tjbot.commands.moderation.ModerationUtils;
 import org.togetherjava.tjbot.config.Config;
+
+import javax.annotation.Nonnull;
 
 /**
  * Action to revoke temporary mutes, as applied by
@@ -21,25 +22,27 @@ final class TemporaryMuteAction extends RevocableRoleBasedAction {
      * 
      * @param config the config to use to identify the muted role
      */
-    TemporaryMuteAction(@NotNull Config config) {
+    TemporaryMuteAction(Config config) {
         super("mute");
 
         this.config = config;
     }
 
     @Override
-    public @NotNull ModerationAction getApplyType() {
+    @Nonnull
+    public ModerationAction getApplyType() {
         return ModerationAction.MUTE;
     }
 
     @Override
-    public @NotNull ModerationAction getRevokeType() {
+    @Nonnull
+    public ModerationAction getRevokeType() {
         return ModerationAction.UNMUTE;
     }
 
     @Override
-    public @NotNull RestAction<Void> revokeAction(@NotNull Guild guild, @NotNull User target,
-            @NotNull String reason) {
+    @Nonnull
+    public RestAction<Void> revokeAction(Guild guild, User target, String reason) {
         return guild
             .removeRoleFromMember(target.getIdLong(),
                     ModerationUtils.getMutedRole(guild, config).orElseThrow())

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryQuarantineAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryQuarantineAction.java
@@ -3,10 +3,11 @@ package org.togetherjava.tjbot.commands.moderation.temp;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.requests.RestAction;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.moderation.ModerationAction;
 import org.togetherjava.tjbot.commands.moderation.ModerationUtils;
 import org.togetherjava.tjbot.config.Config;
+
+import javax.annotation.Nonnull;
 
 /**
  * Action to revoke temporary quarantines, as applied by
@@ -21,25 +22,27 @@ final class TemporaryQuarantineAction extends RevocableRoleBasedAction {
      *
      * @param config the config to use to identify the quarantined role
      */
-    TemporaryQuarantineAction(@NotNull Config config) {
+    TemporaryQuarantineAction(Config config) {
         super("quarantine");
 
         this.config = config;
     }
 
     @Override
-    public @NotNull ModerationAction getApplyType() {
+    @Nonnull
+    public ModerationAction getApplyType() {
         return ModerationAction.QUARANTINE;
     }
 
     @Override
-    public @NotNull ModerationAction getRevokeType() {
+    @Nonnull
+    public ModerationAction getRevokeType() {
         return ModerationAction.UNQUARANTINE;
     }
 
     @Override
-    public @NotNull RestAction<Void> revokeAction(@NotNull Guild guild, @NotNull User target,
-            @NotNull String reason) {
+    @Nonnull
+    public RestAction<Void> revokeAction(Guild guild, User target, String reason) {
         return guild
             .removeRoleFromMember(target.getIdLong(),
                     ModerationUtils.getQuarantinedRole(guild, config).orElseThrow())

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/package-info.java
@@ -1,4 +1,7 @@
 /**
  * This package offers classes dealing with temporary moderation actions, such as temporary bans.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.moderation.temp;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/package-info.java
@@ -9,4 +9,7 @@
  * {@link org.togetherjava.tjbot.commands.SlashCommand} or using the adapter
  * {@link org.togetherjava.tjbot.commands.SlashCommandAdapter} for convenience.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/reminder/RemindCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/reminder/RemindCommand.java
@@ -7,11 +7,11 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.db.Database;
 
+import javax.annotation.Nonnull;
 import java.time.*;
 import java.time.temporal.TemporalAmount;
 import java.util.List;
@@ -52,7 +52,7 @@ public final class RemindCommand extends SlashCommandAdapter {
      *
      * @param database to store and fetch the reminders from
      */
-    public RemindCommand(@NotNull Database database) {
+    public RemindCommand(Database database) {
         super(COMMAND_NAME, "Reminds you after a given time period has passed (e.g. in 5 weeks)",
                 SlashCommandVisibility.GUILD);
 
@@ -72,7 +72,7 @@ public final class RemindCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         int timeAmount = Math.toIntExact(event.getOption(TIME_AMOUNT_OPTION).getAsLong());
         String timeUnit = event.getOption(TIME_UNIT_OPTION).getAsString();
         String content = event.getOption(CONTENT_OPTION).getAsString();
@@ -102,7 +102,8 @@ public final class RemindCommand extends SlashCommandAdapter {
             .insert());
     }
 
-    private static @NotNull Instant parseWhen(int whenAmount, @NotNull String whenUnit) {
+    @Nonnull
+    private static Instant parseWhen(int whenAmount, String whenUnit) {
         TemporalAmount period = switch (whenUnit) {
             case "second", "seconds" -> Duration.ofSeconds(whenAmount);
             case "minute", "minutes" -> Duration.ofMinutes(whenAmount);
@@ -117,8 +118,7 @@ public final class RemindCommand extends SlashCommandAdapter {
         return ZonedDateTime.now(ZoneOffset.UTC).plus(period).toInstant();
     }
 
-    private static boolean handleIsRemindAtWithinLimits(@NotNull Instant remindAt,
-            @NotNull IReplyCallback event) {
+    private static boolean handleIsRemindAtWithinLimits(Instant remindAt, IReplyCallback event) {
         ZonedDateTime maxWhen = ZonedDateTime.now(ZoneOffset.UTC).plus(MAX_TIME_PERIOD);
 
         if (remindAt.atZone(ZoneOffset.UTC).isBefore(maxWhen)) {
@@ -134,8 +134,8 @@ public final class RemindCommand extends SlashCommandAdapter {
         return false;
     }
 
-    private boolean handleIsUserBelowMaxPendingReminders(@NotNull ISnowflake author,
-            @NotNull ISnowflake guild, @NotNull IReplyCallback event) {
+    private boolean handleIsUserBelowMaxPendingReminders(ISnowflake author, ISnowflake guild,
+            IReplyCallback event) {
         int pendingReminders = database.read(context -> context.fetchCount(PENDING_REMINDERS,
                 PENDING_REMINDERS.AUTHOR_ID.equal(author.getIdLong())
                     .and(PENDING_REMINDERS.GUILD_ID.equal(guild.getIdLong()))));

--- a/application/src/main/java/org/togetherjava/tjbot/commands/reminder/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/reminder/package-info.java
@@ -2,4 +2,7 @@
  * This packages offers all the functionality for the remind-command. The core class is
  * {@link org.togetherjava.tjbot.commands.reminder.RemindCommand}.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.reminder;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/LogLevelCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/LogLevelCommand.java
@@ -6,7 +6,6 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.config.Configurator;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
@@ -44,7 +43,7 @@ public final class LogLevelCommand extends SlashCommandAdapter {
     // Security warning about changing log configs. We only change the level, that is safe.
     @SuppressWarnings("squid:S4792")
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         String levelText = event.getOption(LOG_LEVEL_OPTION).getAsString();
         Level level = Level.getLevel(levelText);
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/ReloadCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/ReloadCommand.java
@@ -10,7 +10,6 @@ import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommand;
@@ -18,6 +17,7 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.commands.utils.MessageUtils;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -46,7 +46,7 @@ public final class ReloadCommand extends SlashCommandAdapter {
      * @param commandProvider the provider of slash commands to reload when this command is
      *        triggered
      */
-    public ReloadCommand(@NotNull SlashCommandProvider commandProvider) {
+    public ReloadCommand(SlashCommandProvider commandProvider) {
         super("reload",
                 "Uploads all existing slash-commands to Discord so they are fully up-to-date.",
                 SlashCommandVisibility.GUILD);
@@ -54,7 +54,7 @@ public final class ReloadCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         Member member = Objects.requireNonNull(event.getMember());
 
         if (!member.hasPermission(Permission.MANAGE_SERVER)) {
@@ -75,7 +75,7 @@ public final class ReloadCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onButtonClick(@NotNull ButtonInteractionEvent event, @NotNull List<String> args) {
+    public void onButtonClick(ButtonInteractionEvent event, List<String> args) {
         // Ignore if another user clicked the button
         String userId = args.get(0);
         if (!userId.equals(Objects.requireNonNull(event.getMember()).getId())) {
@@ -102,8 +102,7 @@ public final class ReloadCommand extends SlashCommandAdapter {
 
                 // Reload guild commands (potentially many guilds)
                 // NOTE Storing the guild actions in a list is potentially dangerous since the
-                // bot
-                // might theoretically be part of so many guilds that it exceeds the max size of
+                // bot might theoretically be part of so many guilds that it exceeds the max size of
                 // list. However, correctly reducing RestActions in a stream is not trivial.
                 getGuildUpdateActions(event.getJDA())
                     .map(updateAction -> updateCommandsIf(
@@ -133,9 +132,9 @@ public final class ReloadCommand extends SlashCommandAdapter {
      * @param updateAction the upstream to update commands
      * @return the given upstream for chaining
      */
-    private @NotNull CommandListUpdateAction updateCommandsIf(
-            @NotNull Predicate<? super SlashCommand> commandFilter,
-            @NotNull CommandListUpdateAction updateAction) {
+    @Nonnull
+    private CommandListUpdateAction updateCommandsIf(Predicate<? super SlashCommand> commandFilter,
+            CommandListUpdateAction updateAction) {
         return commandProvider.getSlashCommands()
             .stream()
             .filter(commandFilter)
@@ -143,12 +142,13 @@ public final class ReloadCommand extends SlashCommandAdapter {
             .reduce(updateAction, CommandListUpdateAction::addCommands, (x, y) -> x);
     }
 
-    private static @NotNull CommandListUpdateAction getGlobalUpdateAction(@NotNull JDA jda) {
+    @Nonnull
+    private static CommandListUpdateAction getGlobalUpdateAction(JDA jda) {
         return jda.updateCommands();
     }
 
-    private static @NotNull Stream<CommandListUpdateAction> getGuildUpdateActions(
-            @NotNull JDA jda) {
+    @Nonnull
+    private static Stream<CommandListUpdateAction> getGuildUpdateActions(JDA jda) {
         return jda.getGuildCache().stream().map(Guild::updateCommands);
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/SlashCommandProvider.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/SlashCommandProvider.java
@@ -1,8 +1,8 @@
 package org.togetherjava.tjbot.commands.system;
 
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.SlashCommand;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -15,7 +15,7 @@ public interface SlashCommandProvider {
      *
      * @return all slash commands
      */
-    @NotNull
+    @Nonnull
     Collection<SlashCommand> getSlashCommands();
 
     /**
@@ -24,6 +24,6 @@ public interface SlashCommandProvider {
      * @param name the name of the command
      * @return the command registered under this name, if any
      */
-    @NotNull
-    Optional<SlashCommand> getSlashCommand(@NotNull String name);
+    @Nonnull
+    Optional<SlashCommand> getSlashCommand(String name);
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/package-info.java
@@ -2,4 +2,7 @@
  * This package represents the core of the command system. The entry point is
  * {@link org.togetherjava.tjbot.commands.system.BotCore}.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.system;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagCommand.java
@@ -5,7 +5,6 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
@@ -43,7 +42,7 @@ public final class TagCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         String id = Objects.requireNonNull(event.getOption(ID_OPTION)).getAsString();
         OptionMapping replyToUserOption = event.getOption(REPLY_TO_USER_OPTION);
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagManageCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagManageCommand.java
@@ -10,21 +10,18 @@ import net.dv8tion.jda.api.interactions.commands.CommandInteraction;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.dv8tion.jda.api.requests.ErrorResponse;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.moderation.ModAuditLogWriter;
 
-import java.time.temporal.TemporalAccessor;
-import java.util.*;
-import java.util.NoSuchElementException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.Objects;
-import java.util.OptionalLong;
+import java.time.temporal.TemporalAccessor;
+import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -71,8 +68,7 @@ public final class TagManageCommand extends SlashCommandAdapter {
      * @param tagSystem the system providing the actual tag data
      * @param modAuditLogWriter to log tag changes for audition
      */
-    public TagManageCommand(@NotNull TagSystem tagSystem,
-            @NotNull ModAuditLogWriter modAuditLogWriter) {
+    public TagManageCommand(TagSystem tagSystem, ModAuditLogWriter modAuditLogWriter) {
         super("tag-manage", "Provides commands to manage all tags", SlashCommandVisibility.GUILD);
 
         this.tagSystem = tagSystem;
@@ -104,8 +100,7 @@ public final class TagManageCommand extends SlashCommandAdapter {
                     .addOption(OptionType.STRING, ID_OPTION, ID_DESCRIPTION, true));
     }
 
-    private static void sendSuccessMessage(@NotNull IReplyCallback event, @NotNull String id,
-            @NotNull String actionVerb) {
+    private static void sendSuccessMessage(IReplyCallback event, String id, String actionVerb) {
         logger.info("User '{}' {} the tag with id '{}'.", event.getUser().getId(), actionVerb, id);
 
         event
@@ -128,8 +123,8 @@ public final class TagManageCommand extends SlashCommandAdapter {
      * @param event the event to send messages with
      * @return the parsed message id, if successful
      */
-    private static OptionalLong parseMessageIdAndHandle(@NotNull String messageId,
-            @NotNull IReplyCallback event) {
+    @Nonnull
+    private static OptionalLong parseMessageIdAndHandle(String messageId, IReplyCallback event) {
         try {
             return OptionalLong.of(Long.parseLong(messageId));
         } catch (NumberFormatException e) {
@@ -143,7 +138,7 @@ public final class TagManageCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         switch (Subcommand.fromName(event.getSubcommandName())) {
             case RAW -> rawTag(event);
             case CREATE -> createTag(event);
@@ -156,7 +151,7 @@ public final class TagManageCommand extends SlashCommandAdapter {
         }
     }
 
-    private void rawTag(@NotNull SlashCommandInteractionEvent event) {
+    private void rawTag(SlashCommandInteractionEvent event) {
         String id = Objects.requireNonNull(event.getOption(ID_OPTION)).getAsString();
         if (tagSystem.handleIsUnknownTag(id, event)) {
             return;
@@ -168,31 +163,31 @@ public final class TagManageCommand extends SlashCommandAdapter {
             .queue();
     }
 
-    private void createTag(@NotNull CommandInteraction event) {
+    private void createTag(CommandInteraction event) {
         String content = Objects.requireNonNull(event.getOption(CONTENT_OPTION)).getAsString();
 
         handleAction(TagStatus.NOT_EXISTS, id -> tagSystem.putTag(id, content), event,
                 Subcommand.CREATE, content);
     }
 
-    private void createTagWithMessage(@NotNull CommandInteraction event) {
+    private void createTagWithMessage(CommandInteraction event) {
         handleActionWithMessage(TagStatus.NOT_EXISTS, tagSystem::putTag, event,
                 Subcommand.CREATE_WITH_MESSAGE);
     }
 
-    private void editTag(@NotNull CommandInteraction event) {
+    private void editTag(CommandInteraction event) {
         String content = Objects.requireNonNull(event.getOption(CONTENT_OPTION)).getAsString();
 
         handleAction(TagStatus.EXISTS, id -> tagSystem.putTag(id, content), event, Subcommand.EDIT,
                 content);
     }
 
-    private void editTagWithMessage(@NotNull CommandInteraction event) {
+    private void editTagWithMessage(CommandInteraction event) {
         handleActionWithMessage(TagStatus.EXISTS, tagSystem::putTag, event,
                 Subcommand.EDIT_WITH_MESSAGE);
     }
 
-    private void deleteTag(@NotNull CommandInteraction event) {
+    private void deleteTag(CommandInteraction event) {
         handleAction(TagStatus.EXISTS, tagSystem::deleteTag, event, Subcommand.DELETE, null);
     }
 
@@ -208,9 +203,8 @@ public final class TagManageCommand extends SlashCommandAdapter {
      * @param subcommand the subcommand to be executed
      * @param newContent the new content of the tag, or null if content is unchanged
      */
-    private void handleAction(@NotNull TagStatus requiredTagStatus,
-            @NotNull Consumer<? super String> idAction, @NotNull CommandInteraction event,
-            @NotNull Subcommand subcommand, @Nullable String newContent) {
+    private void handleAction(TagStatus requiredTagStatus, Consumer<? super String> idAction,
+            CommandInteraction event, Subcommand subcommand, @Nullable String newContent) {
 
         String id = Objects.requireNonNull(event.getOption(ID_OPTION)).getAsString();
         if (isWrongTagStatusAndHandle(requiredTagStatus, id, event)) {
@@ -243,9 +237,9 @@ public final class TagManageCommand extends SlashCommandAdapter {
      *        {@code message-id} option set
      * @param subcommand the subcommand to be executed
      */
-    private void handleActionWithMessage(@NotNull TagStatus requiredTagStatus,
-            @NotNull BiConsumer<? super String, ? super String> idAndContentAction,
-            @NotNull CommandInteraction event, @NotNull Subcommand subcommand) {
+    private void handleActionWithMessage(TagStatus requiredTagStatus,
+            BiConsumer<? super String, ? super String> idAndContentAction, CommandInteraction event,
+            Subcommand subcommand) {
 
         String tagId = Objects.requireNonNull(event.getOption(ID_OPTION)).getAsString();
         OptionalLong messageIdOpt = parseMessageIdAndHandle(
@@ -295,8 +289,8 @@ public final class TagManageCommand extends SlashCommandAdapter {
      * @param id the id of the tag to get its content
      * @return the content of the tag, if present
      */
-    private @NotNull Optional<String> getTagContent(@NotNull Subcommand subcommand,
-            @NotNull String id) {
+    @Nonnull
+    private Optional<String> getTagContent(Subcommand subcommand, String id) {
         if (Subcommand.SUBCOMMANDS_WITH_PREVIOUS_CONTENT.contains(subcommand)) {
             try {
                 return tagSystem.getTag(id);
@@ -322,8 +316,8 @@ public final class TagManageCommand extends SlashCommandAdapter {
      * @param event the event to send messages with
      * @return whether the status of the given tag is <b>not equal</b> to the required status
      */
-    private boolean isWrongTagStatusAndHandle(@NotNull TagStatus requiredTagStatus,
-            @NotNull String id, @NotNull IReplyCallback event) {
+    private boolean isWrongTagStatusAndHandle(TagStatus requiredTagStatus, String id,
+            IReplyCallback event) {
         if (requiredTagStatus == TagStatus.EXISTS) {
             return tagSystem.handleIsUnknownTag(id, event);
         } else if (requiredTagStatus == TagStatus.NOT_EXISTS) {
@@ -339,9 +333,9 @@ public final class TagManageCommand extends SlashCommandAdapter {
         return false;
     }
 
-    private void logAction(@NotNull Subcommand subcommand, @NotNull Guild guild,
-            @NotNull User author, @NotNull TemporalAccessor triggeredAt, @NotNull String id,
-            @Nullable String newContent, @Nullable String previousContent) {
+    private void logAction(Subcommand subcommand, Guild guild, User author,
+            TemporalAccessor triggeredAt, String id, @Nullable String newContent,
+            @Nullable String previousContent) {
 
         List<ModAuditLogWriter.Attachment> attachments = new ArrayList<>();
 
@@ -407,17 +401,18 @@ public final class TagManageCommand extends SlashCommandAdapter {
         private final String name;
         private final String actionVerb;
 
-        Subcommand(@NotNull String name, @NotNull String actionVerb) {
+        Subcommand(String name, String actionVerb) {
             this.name = name;
             this.actionVerb = actionVerb;
         }
 
-        @NotNull
+        @Nonnull
         String getName() {
             return name;
         }
 
-        static Subcommand fromName(@NotNull String name) {
+        @Nonnull
+        static Subcommand fromName(String name) {
             for (Subcommand subcommand : Subcommand.values()) {
                 if (subcommand.name.equals(name)) {
                     return subcommand;
@@ -427,7 +422,7 @@ public final class TagManageCommand extends SlashCommandAdapter {
                     "Subcommand with name '%s' is unknown".formatted(name));
         }
 
-        @NotNull
+        @Nonnull
         String getActionVerb() {
             return actionVerb;
         }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagSystem.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagSystem.java
@@ -4,13 +4,13 @@ import net.dv8tion.jda.api.entities.Emoji;
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.utils.StringDistances;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.Tags;
 import org.togetherjava.tjbot.db.generated.tables.records.TagsRecord;
 
-import java.awt.*;
+import javax.annotation.Nonnull;
+import java.awt.Color;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -58,8 +58,7 @@ public final class TagSystem {
      * @param event the event to send messages with
      * @return whether the given tag is unknown to the system
      */
-    @SuppressWarnings("BooleanMethodNameMustStartWithQuestion")
-    boolean handleIsUnknownTag(@NotNull String id, @NotNull IReplyCallback event) {
+    boolean handleIsUnknownTag(String id, IReplyCallback event) {
         if (hasTag(id)) {
             return false;
         }
@@ -123,6 +122,7 @@ public final class TagSystem {
      * @param id the id of the tag to get
      * @return the content of the tag, if the tag is known to the system
      */
+    @Nonnull
     Optional<String> getTag(String id) {
         return database.readTransaction(context -> Optional
             .ofNullable(context.selectFrom(Tags.TAGS).where(Tags.TAGS.ID.eq(id)).fetchOne())
@@ -134,6 +134,7 @@ public final class TagSystem {
      *
      * @return a set of all ids known to the system, not backed
      */
+    @Nonnull
     Set<String> getAllIds() {
         return database.readTransaction(context -> context.select(Tags.TAGS.ID)
             .from(Tags.TAGS)

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagsCommand.java
@@ -4,7 +4,6 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
@@ -49,7 +48,7 @@ public final class TagsCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         Collection<String> tagIds = tagSystem.getAllIds();
         if (tagIds.size() > MAX_TAGS_THRESHOLD_WARNING) {
             // TODO Implement the edge case
@@ -73,7 +72,7 @@ public final class TagsCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onButtonClick(@NotNull ButtonInteractionEvent event, @NotNull List<String> args) {
+    public void onButtonClick(ButtonInteractionEvent event, List<String> args) {
         String userId = args.get(0);
 
         if (!event.getUser().getId().equals(userId) && !Objects.requireNonNull(event.getMember())

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/package-info.java
@@ -4,4 +4,7 @@
  * like {@link org.togetherjava.tjbot.commands.tags.TagCommand} as entry point to the package's
  * offered functionality.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.tags;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersCommand.java
@@ -10,8 +10,6 @@ import net.dv8tion.jda.api.interactions.callbacks.IDeferrableCallback;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jooq.Records;
 import org.jooq.impl.DSL;
 import org.slf4j.Logger;
@@ -20,6 +18,8 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.db.Database;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.time.*;
 import java.time.format.TextStyle;
@@ -50,7 +50,7 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
      *
      * @param database the database containing the message records of top helpers
      */
-    public TopHelpersCommand(@NotNull Database database) {
+    public TopHelpersCommand(Database database) {
         super(COMMAND_NAME, "Lists top helpers for the last month, or a given month",
                 SlashCommandVisibility.GUILD);
 
@@ -65,7 +65,7 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
     }
 
     @Override
-    public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
         OptionMapping atMonthData = event.getOption(MONTH_OPTION);
 
         TimeRange timeRange = computeTimeRange(computeMonth(atMonthData));
@@ -88,7 +88,8 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
             .onSuccess(members -> handleTopHelpers(topHelpers, members, timeRange, event));
     }
 
-    private static @NotNull Month computeMonth(@Nullable OptionMapping atMonthData) {
+    @Nonnull
+    private static Month computeMonth(OptionMapping atMonthData) {
         if (atMonthData != null) {
             return Month.valueOf(atMonthData.getAsString());
         }
@@ -97,7 +98,8 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
         return Instant.now().atZone(ZoneOffset.UTC).minusMonths(1).getMonth();
     }
 
-    private static @NotNull TimeRange computeTimeRange(@NotNull Month atMonth) {
+    @Nonnull
+    private static TimeRange computeTimeRange(Month atMonth) {
         ZonedDateTime now = Instant.now().atZone(ZoneOffset.UTC);
 
         int atYear = now.getYear();
@@ -115,8 +117,8 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
         return new TimeRange(start, end, description);
     }
 
-    private @NotNull List<TopHelperResult> computeTopHelpersDescending(long guildId,
-            @NotNull TimeRange timeRange) {
+    @Nonnull
+    private List<TopHelperResult> computeTopHelpersDescending(long guildId, TimeRange timeRange) {
         return database.read(context -> context
             .select(HELP_CHANNEL_MESSAGES.AUTHOR_ID, DSL.sum(HELP_CHANNEL_MESSAGES.MESSAGE_LENGTH))
             .from(HELP_CHANNEL_MESSAGES)
@@ -128,14 +130,13 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
             .fetch(Records.mapping(TopHelperResult::new)));
     }
 
-    private static void handleError(@NotNull Throwable error, @NotNull IDeferrableCallback event) {
+    private static void handleError(Throwable error, IDeferrableCallback event) {
         logger.warn("Failed to compute top-helpers", error);
         event.getHook().editOriginal("Sorry, something went wrong.").queue();
     }
 
-    private static void handleTopHelpers(@NotNull Collection<TopHelperResult> topHelpers,
-            @NotNull Collection<? extends Member> members, @NotNull TimeRange timeRange,
-            @NotNull IDeferrableCallback event) {
+    private static void handleTopHelpers(Collection<TopHelperResult> topHelpers,
+            Collection<? extends Member> members, TimeRange timeRange, IDeferrableCallback event) {
         Map<Long, Member> userIdToMember =
                 members.stream().collect(Collectors.toMap(Member::getIdLong, Function.identity()));
 
@@ -150,7 +151,8 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
         event.getHook().editOriginal(message).queue();
     }
 
-    private static @NotNull List<String> topHelperToDataRow(@NotNull TopHelperResult topHelper,
+    @Nonnull
+    private static List<String> topHelperToDataRow(TopHelperResult topHelper,
             @Nullable Member member) {
         String id = Long.toString(topHelper.authorId());
         String name = member == null ? "UNKNOWN_USER" : member.getEffectiveName();
@@ -159,8 +161,9 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
         return List.of(id, name, messageLengths);
     }
 
-    private static @NotNull String dataTableToString(@NotNull Collection<List<String>> dataTable,
-            @NotNull TimeRange timeRange) {
+    @Nonnull
+    private static String dataTableToString(Collection<List<String>> dataTable,
+            TimeRange timeRange) {
         return dataTableToAsciiTable(dataTable,
                 List.of(new ColumnSetting("Id", HorizontalAlign.RIGHT),
                         new ColumnSetting("Name", HorizontalAlign.RIGHT),
@@ -169,9 +172,9 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
                                 HorizontalAlign.RIGHT)));
     }
 
-    private static @NotNull String dataTableToAsciiTable(
-            @NotNull Collection<List<String>> dataTable,
-            @NotNull List<ColumnSetting> columnSettings) {
+    @Nonnull
+    private static String dataTableToAsciiTable(Collection<List<String>> dataTable,
+            List<ColumnSetting> columnSettings) {
         IntFunction<String> headerToAlignment = i -> columnSettings.get(i).headerName();
         IntFunction<HorizontalAlign> indexToAlignment = i -> columnSettings.get(i).alignment();
 
@@ -186,15 +189,14 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
         return AsciiTable.getTable(AsciiTable.BASIC_ASCII_NO_DATA_SEPARATORS, dataTable, columns);
     }
 
-    private record TimeRange(@NotNull Instant start, @NotNull Instant end,
-            @NotNull String description) {
+    private record TimeRange(Instant start, Instant end, String description) {
     }
 
 
-    private record TopHelperResult(long authorId, @NotNull BigDecimal messageLengths) {
+    private record TopHelperResult(long authorId, BigDecimal messageLengths) {
     }
 
 
-    private record ColumnSetting(@NotNull String headerName, @NotNull HorizontalAlign alignment) {
+    private record ColumnSetting(String headerName, HorizontalAlign alignment) {
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersCommand.java
@@ -89,7 +89,7 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
     }
 
     @Nonnull
-    private static Month computeMonth(OptionMapping atMonthData) {
+    private static Month computeMonth(@Nullable OptionMapping atMonthData) {
         if (atMonthData != null) {
             return Month.valueOf(atMonthData.getAsString());
         }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersMessageListener.java
@@ -3,7 +3,6 @@ package org.togetherjava.tjbot.commands.tophelper;
 import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.entities.ThreadChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.commands.MessageReceiverAdapter;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.db.Database;
@@ -29,7 +28,7 @@ public final class TopHelpersMessageListener extends MessageReceiverAdapter {
      * @param database to store message meta-data in
      * @param config the config to use for this
      */
-    public TopHelpersMessageListener(@NotNull Database database, @NotNull Config config) {
+    public TopHelpersMessageListener(Database database, Config config) {
         super(Pattern.compile(".*"));
 
         this.database = database;
@@ -41,7 +40,7 @@ public final class TopHelpersMessageListener extends MessageReceiverAdapter {
     }
 
     @Override
-    public void onMessageReceived(@NotNull MessageReceivedEvent event) {
+    public void onMessageReceived(MessageReceivedEvent event) {
         if (event.getAuthor().isBot() || event.isWebhookMessage()) {
             return;
         }
@@ -53,7 +52,7 @@ public final class TopHelpersMessageListener extends MessageReceiverAdapter {
         addMessageRecord(event);
     }
 
-    private boolean isHelpThread(@NotNull MessageReceivedEvent event) {
+    private boolean isHelpThread(MessageReceivedEvent event) {
         if (event.getChannelType() != ChannelType.GUILD_PUBLIC_THREAD) {
             return false;
         }
@@ -64,7 +63,7 @@ public final class TopHelpersMessageListener extends MessageReceiverAdapter {
                 || isOverviewChannelName.test(rootChannelName);
     }
 
-    private void addMessageRecord(@NotNull MessageReceivedEvent event) {
+    private void addMessageRecord(MessageReceivedEvent event) {
         database.write(context -> context.newRecord(HELP_CHANNEL_MESSAGES)
             .setMessageId(event.getMessage().getIdLong())
             .setGuildId(event.getGuild().getIdLong())

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersPurgeMessagesRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersPurgeMessagesRoutine.java
@@ -1,12 +1,12 @@
 package org.togetherjava.tjbot.commands.tophelper;
 
 import net.dv8tion.jda.api.JDA;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.Routine;
 import org.togetherjava.tjbot.db.Database;
 
+import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.time.Period;
 import java.util.concurrent.TimeUnit;
@@ -28,17 +28,18 @@ public final class TopHelpersPurgeMessagesRoutine implements Routine {
      *
      * @param database the database that contains the messages to purge
      */
-    public TopHelpersPurgeMessagesRoutine(@NotNull Database database) {
+    public TopHelpersPurgeMessagesRoutine(Database database) {
         this.database = database;
     }
 
     @Override
-    public @NotNull Schedule createSchedule() {
+    @Nonnull
+    public Schedule createSchedule() {
         return new Schedule(ScheduleMode.FIXED_RATE, 0, 4, TimeUnit.HOURS);
     }
 
     @Override
-    public void runRoutine(@NotNull JDA jda) {
+    public void runRoutine(JDA jda) {
         int recordsDeleted =
                 database.writeAndProvide(context -> context.deleteFrom(HELP_CHANNEL_MESSAGES)
                     .where(HELP_CHANNEL_MESSAGES.SENT_AT

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/package-info.java
@@ -2,4 +2,7 @@
  * This packages offers all the functionality for the top-helpers command system. The core class is
  * {@link org.togetherjava.tjbot.commands.tophelper.TopHelpersCommand}.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.tophelper;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/DiscordClientAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/DiscordClientAction.java
@@ -3,8 +3,8 @@ package org.togetherjava.tjbot.commands.utils;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
 import java.util.regex.Pattern;
 
 /**
@@ -261,7 +261,8 @@ public final class DiscordClientAction {
      * @return The formatted URL as an {@link String}
      * @throws IllegalArgumentException When missing arguments
      */
-    public String formatUrl(final String @NotNull... arguments) {
+    @Nonnull
+    public String formatUrl(final String... arguments) {
         String localUrl = url;
 
         for (final String argument : arguments) {
@@ -284,11 +285,13 @@ public final class DiscordClientAction {
      * @return A {@link Button} of {@link ButtonStyle#LINK} with the given label
      * @throws IllegalArgumentException When missing arguments
      */
-    public Button asLinkButton(@NotNull final String label, final String... arguments) {
+    @Nonnull
+    public Button asLinkButton(final String label, final String... arguments) {
         return Button.link(formatUrl(arguments), label);
     }
 
     @Override
+    @Nonnull
     public String toString() {
         return "DiscordClientAction{" + "url='" + url + '\'' + '}';
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/Hashing.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/Hashing.java
@@ -1,7 +1,6 @@
 package org.togetherjava.tjbot.commands.utils;
 
-import org.jetbrains.annotations.NotNull;
-
+import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -26,9 +25,8 @@ public class Hashing {
      * @param bytes the binary data to convert
      * @return a hexadecimal representation
      */
-    @SuppressWarnings("MagicNumber")
-    @NotNull
-    public static String bytesToHex(byte @NotNull [] bytes) {
+    @Nonnull
+    public static String bytesToHex(byte[] bytes) {
         Objects.requireNonNull(bytes);
         // See https://stackoverflow.com/a/9855338/2411243
         // noinspection MultiplyOrDivideByPowerOfTwo
@@ -52,7 +50,8 @@ public class Hashing {
      * @param data the data to hash
      * @return the computed hash
      */
-    public static byte @NotNull [] hash(@NotNull String method, byte @NotNull [] data) {
+    @Nonnull
+    public static byte[] hash(String method, byte[] data) {
         Objects.requireNonNull(method);
         Objects.requireNonNull(data);
         try {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
@@ -4,8 +4,8 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.utils.MarkdownSanitizer;
-import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -28,7 +28,7 @@ public class MessageUtils {
      * @param message the message that contains at least one button
      * @throws IllegalArgumentException when the given message does not contain any button
      */
-    public static void disableButtons(@NotNull Message message) {
+    public static void disableButtons(Message message) {
         List<Button> buttons = message.getButtons();
         if (buttons.isEmpty()) {
             throw new IllegalArgumentException("Message must contain at least one button");
@@ -48,7 +48,8 @@ public class MessageUtils {
      * @param text the text to escape
      * @return the escaped text
      */
-    public static @NotNull String escapeMarkdown(@NotNull String text) {
+    @Nonnull
+    public static String escapeMarkdown(String text) {
         // NOTE Unfortunately the utility does not escape backslashes '\', so we have to do it
         // ourselves
         // NOTE It also does not properly escape three backticks '```', it makes it '\```' but we

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/StringDistances.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/StringDistances.java
@@ -1,7 +1,6 @@
 package org.togetherjava.tjbot.commands.utils;
 
-import org.jetbrains.annotations.NotNull;
-
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
@@ -18,18 +17,19 @@ public class StringDistances {
 
     /**
      * Computes the candidate that matches the given query string best.
-     *
+     * <p>
      * It is given that, if the candidates contain the query literally, the query will also be the
      * returned match. If the candidates do not contain the query literally, the best match will be
      * determined. The measures for this are unspecified.
-     * 
+     *
      * @param query the query string to find a match for
      * @param candidates the set of candidates to select a match from
      * @param <S> the type of the candidates
      * @return the best matching candidate, or empty iff the candidates are empty
      */
-    public static <S extends CharSequence> Optional<S> closestMatch(@NotNull CharSequence query,
-            @NotNull Collection<S> candidates) {
+    @Nonnull
+    public static <S extends CharSequence> Optional<S> closestMatch(CharSequence query,
+            Collection<S> candidates) {
         return candidates.stream()
             .min(Comparator.comparingInt(candidate -> editDistance(query, candidate)));
     }
@@ -37,33 +37,33 @@ public class StringDistances {
     /**
      * Attempts to autocomplete the given prefix string by selecting the candidate that matches the
      * prefix best.
-     *
+     * <p>
      * It is given that, if the candidates contain the query literally, the query will also be the
      * returned match. If the candidates do not contain the query literally, the best match will be
      * determined. The measures for this are unspecified.
-     * 
+     *
      * @param prefix the prefix string to find a match for
      * @param candidates the set of candidates to select a match from
      * @param <S> the type of the candidates
      * @return the best matching candidate, or empty iff the candidates are empty
      */
-    public static <S extends CharSequence> Optional<S> autocomplete(@NotNull CharSequence prefix,
-            @NotNull Collection<S> candidates) {
+    @Nonnull
+    public static <S extends CharSequence> Optional<S> autocomplete(CharSequence prefix,
+            Collection<S> candidates) {
         return candidates.stream()
             .min(Comparator.comparingInt(candidate -> prefixEditDistance(prefix, candidate)));
     }
 
     /**
      * Distance to receive {@code destination} from {@code source} by editing.
-     *
+     * <p>
      * For example {@code editDistance("hello", "hallo")} is {@code 1}.
      *
      * @param source the source string to start with
      * @param destination the destination string to receive by editing the source
      * @return the edit distance
      */
-    public static int editDistance(@NotNull CharSequence source,
-            @NotNull CharSequence destination) {
+    public static int editDistance(CharSequence source, CharSequence destination) {
         // Given by the value in the last row and column
         int[][] table = computeLevenshteinDistanceTable(source, destination);
         int rows = table.length;
@@ -75,15 +75,14 @@ public class StringDistances {
     /**
      * Distance to receive a prefix of {@code destination} from {@code source} by editing that
      * minimizes the distance.
-     *
+     * <p>
      * For example {@code prefixEditDistance("foa", "foobar")} is {@code 1}.
      *
      * @param source the source string to start with
      * @param destination the destination string to receive a prefix of by editing the source
      * @return the prefix edit distance
      */
-    public static int prefixEditDistance(@NotNull CharSequence source,
-            @NotNull CharSequence destination) {
+    public static int prefixEditDistance(CharSequence source, CharSequence destination) {
         // Given by the smallest value in the last row
         int[][] table = computeLevenshteinDistanceTable(source, destination);
         int lastRowIndex = table.length - 1;
@@ -95,9 +94,9 @@ public class StringDistances {
      * Computes the Levenshtein distance table for the given strings. See
      * <a href="https://en.wikipedia.org/wiki/Levenshtein_distance">Levenshtein distance</a> for
      * details.
-     *
+     * <p>
      * An example for {@code "abc"} to {@code "abcdefg"} would be:
-     * 
+     *
      * <pre>
      *   | 0 a b c d e f g
      * -------------------
@@ -106,13 +105,14 @@ public class StringDistances {
      * b | 2 1 0 1 2 3 4 5
      * c | 3 2 1 0 1 2 3 4
      * </pre>
-     * 
+     *
      * @param source the source string to start with
      * @param destination the destination string to receive by editing the source
      * @return the levenshtein distance table
      */
-    private static int @NotNull [][] computeLevenshteinDistanceTable(@NotNull CharSequence source,
-            @NotNull CharSequence destination) {
+    @Nonnull
+    private static int[][] computeLevenshteinDistanceTable(CharSequence source,
+            CharSequence destination) {
         int rows = source.length() + 1;
         int columns = destination.length() + 1;
         int[][] table = new int[rows][columns];

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/package-info.java
@@ -1,4 +1,7 @@
 /**
  * This package contains general utility used by commands.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.utils;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -231,7 +231,8 @@ public final class Config {
      *
      * @return the channel name pattern
      */
-    public @NotNull String getMediaOnlyChannelPattern() {
+    @Nonnull
+    public String getMediaOnlyChannelPattern() {
         return mediaOnlyChannelPattern;
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -181,7 +181,8 @@ public final class Config {
      *
      * @return the suggestion system config
      */
-    public @NotNull SuggestionsConfig getSuggestions() {
+    @Nonnull
+    public SuggestionsConfig getSuggestions() {
         return suggestions;
     }
 
@@ -190,6 +191,7 @@ public final class Config {
      *
      * @return the role name pattern
      */
+    @Nonnull
     public String getQuarantinedRolePattern() {
         return quarantinedRolePattern;
     }
@@ -199,7 +201,8 @@ public final class Config {
      *
      * @return the scam blocker system config
      */
-    public @NotNull ScamBlockerConfig getScamBlocker() {
+    @Nonnull
+    public ScamBlockerConfig getScamBlocker() {
         return scamBlocker;
     }
 
@@ -208,7 +211,8 @@ public final class Config {
      *
      * @return the application ID for the WolframAlpha API
      */
-    public @NotNull String getWolframAlphaAppId() {
+    @Nonnull
+    public String getWolframAlphaAppId() {
         return wolframAlphaAppId;
     }
 
@@ -217,7 +221,8 @@ public final class Config {
      *
      * @return the help system config
      */
-    public @NotNull HelpSystemConfig getHelpSystem() {
+    @Nonnull
+    public HelpSystemConfig getHelpSystem() {
         return helpSystem;
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/config/HelpSystemConfig.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/HelpSystemConfig.java
@@ -3,8 +3,8 @@ package org.togetherjava.tjbot.config;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
-import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -37,7 +37,8 @@ public final class HelpSystemConfig {
      *
      * @return the channel name pattern
      */
-    public @NotNull String getStagingChannelPattern() {
+    @Nonnull
+    public String getStagingChannelPattern() {
         return stagingChannelPattern;
     }
 
@@ -47,7 +48,8 @@ public final class HelpSystemConfig {
      *
      * @return the channel name pattern
      */
-    public @NotNull String getOverviewChannelPattern() {
+    @Nonnull
+    public String getOverviewChannelPattern() {
         return overviewChannelPattern;
     }
 
@@ -56,7 +58,8 @@ public final class HelpSystemConfig {
      *
      * @return a list of all categories
      */
-    public @NotNull List<String> getCategories() {
+    @Nonnull
+    public List<String> getCategories() {
         return Collections.unmodifiableList(categories);
     }
 
@@ -70,7 +73,8 @@ public final class HelpSystemConfig {
      *
      * @return the suffix
      */
-    public @NotNull String getCategoryRoleSuffix() {
+    @Nonnull
+    public String getCategoryRoleSuffix() {
         return categoryRoleSuffix;
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/config/ScamBlockerConfig.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/ScamBlockerConfig.java
@@ -3,8 +3,8 @@ package org.togetherjava.tjbot.config;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
-import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -43,7 +43,7 @@ public final class ScamBlockerConfig {
      *
      * @return the scam blockers mode
      */
-    public @NotNull Mode getMode() {
+    public Mode getMode() {
         return mode;
     }
 
@@ -53,6 +53,7 @@ public final class ScamBlockerConfig {
      *
      * @return the channel name pattern
      */
+    @Nonnull
     public String getReportChannelPattern() {
         return reportChannelPattern;
     }
@@ -62,7 +63,8 @@ public final class ScamBlockerConfig {
      *
      * @return the whitelist of hosts
      */
-    public @NotNull Set<String> getHostWhitelist() {
+    @Nonnull
+    public Set<String> getHostWhitelist() {
         return Collections.unmodifiableSet(hostWhitelist);
     }
 
@@ -71,7 +73,8 @@ public final class ScamBlockerConfig {
      *
      * @return the blacklist of hosts
      */
-    public @NotNull Set<String> getHostBlacklist() {
+    @Nonnull
+    public Set<String> getHostBlacklist() {
         return Collections.unmodifiableSet(hostBlacklist);
     }
 
@@ -81,7 +84,8 @@ public final class ScamBlockerConfig {
      *
      * @return the set of suspicious host keywords
      */
-    public @NotNull Set<String> getSuspiciousHostKeywords() {
+    @Nonnull
+    public Set<String> getSuspiciousHostKeywords() {
         return Collections.unmodifiableSet(suspiciousHostKeywords);
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/config/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/package-info.java
@@ -2,4 +2,7 @@
  * This package contains the configuration of the application. It revolves around the class
  * {@link org.togetherjava.tjbot.config.Config}.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.config;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/logging/FlaggedFilter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/logging/FlaggedFilter.java
@@ -7,7 +7,8 @@ import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.filter.AbstractFilter;
-import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nonnull;
 
 
 /**
@@ -30,7 +31,7 @@ public class FlaggedFilter extends AbstractFilter {
      * @param onMatch The action to take on a match.
      * @param onMismatch The action to take on a mismatch.
      */
-    public FlaggedFilter(@NotNull Result onMatch, @NotNull Result onMismatch) {
+    public FlaggedFilter(Result onMatch, Result onMismatch) {
         super(onMatch, onMismatch);
     }
 
@@ -43,6 +44,7 @@ public class FlaggedFilter extends AbstractFilter {
      * @return {@link Result#DENY} if the Flag is not set, else {@link Result#NEUTRAL}
      */
     @Override
+    @Nonnull
     public Result filter(LogEvent event) {
         return isLoggingEnabled() ? Result.NEUTRAL : Result.DENY;
     }
@@ -59,9 +61,10 @@ public class FlaggedFilter extends AbstractFilter {
      * @return The created FlaggedFilter.
      */
     @PluginFactory
+    @Nonnull
     public static FlaggedFilter createFilter(
-            @NotNull @PluginAttribute(value = "onMatch", defaultString = "NEUTRAL") Result onMatch,
-            @NotNull
+            @PluginAttribute(value = "onMatch", defaultString = "NEUTRAL") Result onMatch,
+
             @PluginAttribute(value = "onMismatch", defaultString = "DENY") Result onMismatch) {
         return new FlaggedFilter(onMatch, onMismatch);
     }

--- a/application/src/main/java/org/togetherjava/tjbot/logging/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/logging/package-info.java
@@ -1,4 +1,7 @@
 /**
  * This package is for custom logging plugins of the bot.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.logging;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/moderation/ModAuditLogWriter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/moderation/ModAuditLogWriter.java
@@ -6,13 +6,13 @@ import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
 import net.dv8tion.jda.api.utils.AttachmentOption;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.config.Config;
 
-import java.awt.*;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.awt.Color;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.time.temporal.TemporalAccessor;
@@ -41,7 +41,7 @@ public final class ModAuditLogWriter {
      *
      * @param config the config to use for this
      */
-    public ModAuditLogWriter(@NotNull Config config) {
+    public ModAuditLogWriter(Config config) {
         this.config = config;
         auditLogChannelNamePredicate =
                 Pattern.compile(config.getModAuditLogChannelPattern()).asMatchPredicate();
@@ -57,9 +57,8 @@ public final class ModAuditLogWriter {
      * @param guild the guild to write this log to
      * @param attachments attachments that will be added to the message. none or many.
      */
-    public void write(@NotNull String title, @NotNull String description, @Nullable User author,
-            @NotNull TemporalAccessor timestamp, @NotNull Guild guild,
-            @NotNull Attachment... attachments) {
+    public void write(String title, String description, @Nullable User author,
+            TemporalAccessor timestamp, Guild guild, Attachment... attachments) {
         Optional<TextChannel> auditLogChannel = getAndHandleModAuditLogChannel(guild);
         if (auditLogChannel.isEmpty()) {
             return;
@@ -89,7 +88,8 @@ public final class ModAuditLogWriter {
      * @param guild the guild to look for the channel in
      * @return the channel used for moderation audit logs, if present
      */
-    public Optional<TextChannel> getAndHandleModAuditLogChannel(@NotNull Guild guild) {
+    @Nonnull
+    public Optional<TextChannel> getAndHandleModAuditLogChannel(Guild guild) {
         Optional<TextChannel> auditLogChannel = guild.getTextChannelCache()
             .stream()
             .filter(channel -> auditLogChannelNamePredicate.test(channel.getName()))
@@ -110,13 +110,14 @@ public final class ModAuditLogWriter {
      * @param name the name of the attachment, example: {@code "foo.md"}
      * @param content the content of the attachment
      */
-    public record Attachment(@NotNull String name, @NotNull String content) {
+    public record Attachment(String name, String content) {
         /**
          * Gets the content raw, interpreted as UTF-8.
          *
          * @return the raw content of the attachment
          */
-        public byte @NotNull [] getContentRaw() {
+        @Nonnull
+        public byte[] getContentRaw() {
             return content.getBytes(StandardCharsets.UTF_8);
         }
     }

--- a/application/src/main/java/org/togetherjava/tjbot/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/package-info.java
@@ -1,4 +1,7 @@
 /**
  * Entry package for the TJ-Bot. See {@link org.togetherjava.tjbot.Application} to get started.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/routines/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/routines/package-info.java
@@ -5,4 +5,7 @@
  * Routines are actions that are executed periodically on a schedule. They are added to the system
  * in {@link org.togetherjava.tjbot.commands.Features}.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.routines;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/test/java/org/togetherjava/tjbot/commands/SlashCommandAdapterTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/SlashCommandAdapterTest.java
@@ -2,7 +2,6 @@ package org.togetherjava.tjbot.commands;
 
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.togetherjava.tjbot.commands.componentids.Lifespan;
 
@@ -19,7 +18,7 @@ final class SlashCommandAdapterTest {
         // noinspection AnonymousInnerClass
         return new SlashCommandAdapter(NAME, DESCRIPTION, VISIBILITY) {
             @Override
-            public void onSlashCommand(@NotNull SlashCommandInteractionEvent event) {
+            public void onSlashCommand(SlashCommandInteractionEvent event) {
                 // No implementation needed for the test
             }
         };

--- a/application/src/test/java/org/togetherjava/tjbot/commands/basic/PingCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/basic/PingCommandTest.java
@@ -1,7 +1,6 @@
 package org.togetherjava.tjbot.commands.basic;
 
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,7 +13,8 @@ final class PingCommandTest {
     private JdaTester jdaTester;
     private SlashCommand command;
 
-    private @NotNull SlashCommandInteractionEvent triggerSlashCommand() {
+    @Nonnull
+    private SlashCommandInteractionEvent triggerSlashCommand() {
         SlashCommandInteractionEvent event =
                 jdaTester.createSlashCommandInteractionEvent(command).build();
         command.onSlashCommand(event);

--- a/application/src/test/java/org/togetherjava/tjbot/commands/basic/PingCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/basic/PingCommandTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.togetherjava.tjbot.commands.SlashCommand;
 import org.togetherjava.tjbot.jda.JdaTester;
 
+import javax.annotation.Nonnull;
+
 import static org.mockito.Mockito.verify;
 
 final class PingCommandTest {

--- a/application/src/test/java/org/togetherjava/tjbot/commands/mathcommands/TeXCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/mathcommands/TeXCommandTest.java
@@ -1,7 +1,6 @@
 package org.togetherjava.tjbot.commands.mathcommands;
 
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -9,6 +8,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.togetherjava.tjbot.commands.SlashCommand;
 import org.togetherjava.tjbot.jda.JdaTester;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,7 +26,8 @@ final class TeXCommandTest {
         command = jdaTester.spySlashCommand(new TeXCommand());
     }
 
-    private @NotNull SlashCommandInteractionEvent triggerSlashCommand(@NotNull String latex) {
+    @Nonnull
+    private SlashCommandInteractionEvent triggerSlashCommand(String latex) {
         SlashCommandInteractionEvent event = jdaTester.createSlashCommandInteractionEvent(command)
             .setOption(TeXCommand.LATEX_OPTION, latex)
             .build();
@@ -35,8 +36,7 @@ final class TeXCommandTest {
         return event;
     }
 
-    private void verifySuccessfulResponse(@NotNull SlashCommandInteractionEvent event,
-            @NotNull String query) {
+    private void verifySuccessfulResponse(SlashCommandInteractionEvent event, String query) {
         verify(jdaTester.getInteractionHookMock(), description("Testing query: " + query))
             .editOriginal(any(byte[].class), eq("tex.png"));
     }
@@ -61,7 +61,7 @@ final class TeXCommandTest {
     @ParameterizedTest
     @MethodSource("provideSupportedQueries")
     @DisplayName("The command supports and renders all supported latex queries")
-    void canRenderSupportedQuery(@NotNull String supportedQuery) {
+    void canRenderSupportedQuery(String supportedQuery) {
         // GIVEN a supported latex query
 
         // WHEN triggering the command
@@ -78,7 +78,7 @@ final class TeXCommandTest {
     @ParameterizedTest
     @MethodSource("provideBadInlineQueries")
     @DisplayName("The command does not support bad inline latex queries, for example with missing dollars")
-    void failsOnBadInlineQuery(@NotNull String badInlineQuery) {
+    void failsOnBadInlineQuery(String badInlineQuery) {
         // GIVEN a bad inline latex query
 
         // WHEN triggering the command
@@ -96,7 +96,7 @@ final class TeXCommandTest {
     @ParameterizedTest
     @MethodSource("provideBadQueries")
     @DisplayName("The command does not support bad latex queries, for example with unknown symbols or incomplete braces")
-    void failsOnBadQuery(@NotNull String badQuery) {
+    void failsOnBadQuery(String badQuery) {
         // GIVEN a bad inline latex query
 
         // WHEN triggering the command

--- a/application/src/test/java/org/togetherjava/tjbot/commands/moderation/scam/ScamDetectorTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/moderation/scam/ScamDetectorTest.java
@@ -1,6 +1,5 @@
 package org.togetherjava.tjbot.commands.moderation.scam;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,6 +8,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.config.ScamBlockerConfig;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Set;
 
@@ -39,7 +39,7 @@ final class ScamDetectorTest {
     @ParameterizedTest
     @MethodSource("provideRealScamMessages")
     @DisplayName("Can detect real scam messages")
-    void detectsRealScam(@NotNull String scamMessage) {
+    void detectsRealScam(String scamMessage) {
         // GIVEN a real scam message
         // WHEN analyzing it
         boolean isScamResult = scamDetector.isScam(scamMessage);
@@ -103,7 +103,8 @@ final class ScamDetectorTest {
         assertFalse(isScamResult);
     }
 
-    private static @NotNull List<String> provideRealScamMessages() {
+    @Nonnull
+    private static List<String> provideRealScamMessages() {
         return List.of("""
                 🤩bro steam gived nitro - https://nitro-ds.online/LfgUfMzqYyx12""",
                 """

--- a/application/src/test/java/org/togetherjava/tjbot/commands/reminder/RawReminderTestHelper.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/reminder/RawReminderTestHelper.java
@@ -2,12 +2,12 @@ package org.togetherjava.tjbot.commands.reminder;
 
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.TextChannel;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.Tables;
 import org.togetherjava.tjbot.db.generated.tables.records.PendingRemindersRecord;
 import org.togetherjava.tjbot.jda.JdaTester;
 
+import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.util.List;
 
@@ -17,22 +17,20 @@ final class RawReminderTestHelper {
     private Database database;
     private JdaTester jdaTester;
 
-    RawReminderTestHelper(@NotNull Database database, @NotNull JdaTester jdaTester) {
+    RawReminderTestHelper(Database database, JdaTester jdaTester) {
         this.database = database;
         this.jdaTester = jdaTester;
     }
 
-    void insertReminder(@NotNull String content, @NotNull Instant remindAt) {
+    void insertReminder(String content, Instant remindAt) {
         insertReminder(content, remindAt, jdaTester.getMemberSpy(), jdaTester.getTextChannelSpy());
     }
 
-    void insertReminder(@NotNull String content, @NotNull Instant remindAt,
-            @NotNull Member author) {
+    void insertReminder(String content, Instant remindAt, Member author) {
         insertReminder(content, remindAt, author, jdaTester.getTextChannelSpy());
     }
 
-    void insertReminder(@NotNull String content, @NotNull Instant remindAt, @NotNull Member author,
-            @NotNull TextChannel channel) {
+    void insertReminder(String content, Instant remindAt, Member author, TextChannel channel) {
         long channelId = channel.getIdLong();
         long guildId = channel.getGuild().getIdLong();
         long authorId = author.getIdLong();
@@ -47,13 +45,13 @@ final class RawReminderTestHelper {
             .insert());
     }
 
-    @NotNull
+    @Nonnull
     List<String> readReminders() {
         return readReminders(jdaTester.getMemberSpy());
     }
 
-    @NotNull
-    List<String> readReminders(@NotNull Member author) {
+    @Nonnull
+    List<String> readReminders(Member author) {
         long guildId = jdaTester.getTextChannelSpy().getGuild().getIdLong();
         long authorId = author.getIdLong();
 

--- a/application/src/test/java/org/togetherjava/tjbot/commands/reminder/RemindCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/reminder/RemindCommandTest.java
@@ -2,7 +2,6 @@ package org.togetherjava.tjbot.commands.reminder;
 
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -12,6 +11,7 @@ import org.togetherjava.tjbot.commands.SlashCommand;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.jda.JdaTester;
 
+import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -35,13 +35,15 @@ final class RemindCommandTest {
         rawReminders = new RawReminderTestHelper(database, jdaTester);
     }
 
-    private @NotNull SlashCommandInteractionEvent triggerSlashCommand(int timeAmount,
-            @NotNull String timeUnit, @NotNull String content) {
+    @Nonnull
+    private SlashCommandInteractionEvent triggerSlashCommand(int timeAmount, String timeUnit,
+            String content) {
         return triggerSlashCommand(timeAmount, timeUnit, content, jdaTester.getMemberSpy());
     }
 
-    private @NotNull SlashCommandInteractionEvent triggerSlashCommand(int timeAmount,
-            @NotNull String timeUnit, @NotNull String content, @NotNull Member author) {
+    @Nonnull
+    private SlashCommandInteractionEvent triggerSlashCommand(int timeAmount, String timeUnit,
+            String content, Member author) {
         SlashCommandInteractionEvent event = jdaTester.createSlashCommandInteractionEvent(command)
             .setOption(RemindCommand.TIME_AMOUNT_OPTION, timeAmount)
             .setOption(RemindCommand.TIME_UNIT_OPTION, timeUnit)

--- a/application/src/test/java/org/togetherjava/tjbot/commands/reminder/RemindRoutineTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/reminder/RemindRoutineTest.java
@@ -3,7 +3,6 @@ package org.togetherjava.tjbot.commands.reminder;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.requests.RestAction;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,6 +12,7 @@ import org.togetherjava.tjbot.commands.Routine;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.jda.JdaTester;
 
+import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
@@ -39,13 +39,15 @@ final class RemindRoutineTest {
         routine.runRoutine(jdaTester.getJdaMock());
     }
 
-    private static @NotNull MessageEmbed getLastMessageFrom(@NotNull MessageChannel channel) {
+    @Nonnull
+    private static MessageEmbed getLastMessageFrom(MessageChannel channel) {
         ArgumentCaptor<MessageEmbed> responseCaptor = ArgumentCaptor.forClass(MessageEmbed.class);
         verify(channel).sendMessageEmbeds(responseCaptor.capture());
         return responseCaptor.getValue();
     }
 
-    private @NotNull Member createAndSetupUnknownMember() {
+    @Nonnull
+    private Member createAndSetupUnknownMember() {
         int unknownMemberId = 2;
 
         Member member = jdaTester.createMemberSpy(unknownMemberId);
@@ -65,7 +67,8 @@ final class RemindRoutineTest {
         return member;
     }
 
-    private @NotNull TextChannel createAndSetupUnknownChannel() {
+    @Nonnull
+    private TextChannel createAndSetupUnknownChannel() {
         long unknownChannelId = 2;
 
         TextChannel channel = jdaTester.createTextChannelSpy(unknownChannelId);
@@ -173,7 +176,7 @@ final class RemindRoutineTest {
         verify(jdaTester.getTextChannelSpy(), never()).sendMessageEmbeds(any(MessageEmbed.class));
     }
 
-    private static void assertSimilar(@NotNull Instant expected, @NotNull Instant actual) {
+    private static void assertSimilar(Instant expected, Instant actual) {
         // NOTE For some reason, the instant ends up in the database slightly wrong already (about
         // half a second), seems to be an issue with jOOQ
         assertEquals(expected.toEpochMilli(), actual.toEpochMilli(), TimeUnit.SECONDS.toMillis(1));

--- a/application/src/test/java/org/togetherjava/tjbot/commands/system/ReloadCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/system/ReloadCommandTest.java
@@ -1,9 +1,9 @@
 package org.togetherjava.tjbot.commands.system;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.togetherjava.tjbot.commands.SlashCommand;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -17,12 +17,14 @@ final class ReloadCommandTest {
                 "AnonymousInnerClassMayBeStatic"})
         SlashCommandProvider slashCommandProvider = new SlashCommandProvider() {
             @Override
-            public @NotNull Collection<SlashCommand> getSlashCommands() {
+            @Nonnull
+            public Collection<SlashCommand> getSlashCommands() {
                 return List.of();
             }
 
             @Override
-            public @NotNull Optional<SlashCommand> getSlashCommand(@NotNull String name) {
+            @Nonnull
+            public Optional<SlashCommand> getSlashCommand(String name) {
                 return Optional.empty();
             }
         };

--- a/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagCommandTest.java
@@ -3,8 +3,6 @@ package org.togetherjava.tjbot.commands.tags;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,6 +11,9 @@ import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.Tags;
 import org.togetherjava.tjbot.jda.JdaTester;
 import org.togetherjava.tjbot.jda.SlashCommandInteractionEventBuilder;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static org.mockito.Mockito.*;
 
@@ -29,7 +30,8 @@ final class TagCommandTest {
         command = new TagCommand(system);
     }
 
-    private @NotNull SlashCommandInteractionEvent triggerSlashCommand(@NotNull String id,
+    @Nonnull
+    private SlashCommandInteractionEvent triggerSlashCommand(String id,
             @Nullable Member userToReplyTo) {
         SlashCommandInteractionEventBuilder builder =
                 jdaTester.createSlashCommandInteractionEvent(command)

--- a/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagManageCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagManageCommandTest.java
@@ -8,7 +8,6 @@ import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.requests.ErrorResponse;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,6 +19,7 @@ import org.togetherjava.tjbot.db.generated.tables.Tags;
 import org.togetherjava.tjbot.jda.JdaTester;
 import org.togetherjava.tjbot.moderation.ModAuditLogWriter;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -36,7 +36,8 @@ final class TagManageCommandTest {
     private Member moderator;
     private ModAuditLogWriter modAuditLogWriter;
 
-    private static @NotNull MessageEmbed getResponse(@NotNull SlashCommandInteractionEvent event) {
+    @Nonnull
+    private static MessageEmbed getResponse(SlashCommandInteractionEvent event) {
         ArgumentCaptor<MessageEmbed> responseCaptor = ArgumentCaptor.forClass(MessageEmbed.class);
         verify(event).replyEmbeds(responseCaptor.capture());
         return responseCaptor.getValue();
@@ -61,12 +62,13 @@ final class TagManageCommandTest {
         when(moderatorRole.getName()).thenReturn(moderatorRoleName);
     }
 
-    private @NotNull SlashCommandInteractionEvent triggerRawCommand(@NotNull String tagId) {
+    @Nonnull
+    private SlashCommandInteractionEvent triggerRawCommand(String tagId) {
         return triggerRawCommandWithUser(tagId, moderator);
     }
 
-    private @NotNull SlashCommandInteractionEvent triggerRawCommandWithUser(@NotNull String tagId,
-            @NotNull Member user) {
+    @Nonnull
+    private SlashCommandInteractionEvent triggerRawCommandWithUser(String tagId, Member user) {
         SlashCommandInteractionEvent event = jdaTester.createSlashCommandInteractionEvent(command)
             .setSubcommand(TagManageCommand.Subcommand.RAW.getName())
             .setOption(TagManageCommand.ID_OPTION, tagId)
@@ -77,19 +79,19 @@ final class TagManageCommandTest {
         return event;
     }
 
-    private @NotNull SlashCommandInteractionEvent triggerCreateCommand(@NotNull String tagId,
-            @NotNull String content) {
+    @Nonnull
+    private SlashCommandInteractionEvent triggerCreateCommand(String tagId, String content) {
         return triggerTagContentCommand(TagManageCommand.Subcommand.CREATE, tagId, content);
     }
 
-    private @NotNull SlashCommandInteractionEvent triggerEditCommand(@NotNull String tagId,
-            @NotNull String content) {
+    @Nonnull
+    private SlashCommandInteractionEvent triggerEditCommand(String tagId, String content) {
         return triggerTagContentCommand(TagManageCommand.Subcommand.EDIT, tagId, content);
     }
 
-    private @NotNull SlashCommandInteractionEvent triggerTagContentCommand(
-            @NotNull TagManageCommand.Subcommand subcommand, @NotNull String tagId,
-            @NotNull String content) {
+    @Nonnull
+    private SlashCommandInteractionEvent triggerTagContentCommand(
+            TagManageCommand.Subcommand subcommand, String tagId, String content) {
         SlashCommandInteractionEvent event = jdaTester.createSlashCommandInteractionEvent(command)
             .setSubcommand(subcommand.getName())
             .setOption(TagManageCommand.ID_OPTION, tagId)
@@ -101,21 +103,23 @@ final class TagManageCommandTest {
         return event;
     }
 
-    private @NotNull SlashCommandInteractionEvent triggerCreateWithMessageCommand(
-            @NotNull String tagId, @NotNull String messageId) {
+    @Nonnull
+    private SlashCommandInteractionEvent triggerCreateWithMessageCommand(String tagId,
+            String messageId) {
         return triggerTagMessageCommand(TagManageCommand.Subcommand.CREATE_WITH_MESSAGE, tagId,
                 messageId);
     }
 
-    private @NotNull SlashCommandInteractionEvent triggerEditWithMessageCommand(
-            @NotNull String tagId, @NotNull String messageId) {
+    @Nonnull
+    private SlashCommandInteractionEvent triggerEditWithMessageCommand(String tagId,
+            String messageId) {
         return triggerTagMessageCommand(TagManageCommand.Subcommand.EDIT_WITH_MESSAGE, tagId,
                 messageId);
     }
 
-    private @NotNull SlashCommandInteractionEvent triggerTagMessageCommand(
-            @NotNull TagManageCommand.Subcommand subcommand, @NotNull String tagId,
-            @NotNull String messageId) {
+    @Nonnull
+    private SlashCommandInteractionEvent triggerTagMessageCommand(
+            TagManageCommand.Subcommand subcommand, String tagId, String messageId) {
         SlashCommandInteractionEvent event = jdaTester.createSlashCommandInteractionEvent(command)
             .setSubcommand(subcommand.getName())
             .setOption(TagManageCommand.ID_OPTION, tagId)
@@ -127,7 +131,8 @@ final class TagManageCommandTest {
         return event;
     }
 
-    private @NotNull SlashCommandInteractionEvent triggerDeleteCommand(@NotNull String tagId) {
+    @Nonnull
+    private SlashCommandInteractionEvent triggerDeleteCommand(String tagId) {
         SlashCommandInteractionEvent event = jdaTester.createSlashCommandInteractionEvent(command)
             .setSubcommand(TagManageCommand.Subcommand.DELETE.getName())
             .setOption(TagManageCommand.ID_OPTION, tagId)
@@ -138,13 +143,13 @@ final class TagManageCommandTest {
         return event;
     }
 
-    private void postMessage(@NotNull String content, @NotNull String id) {
+    private void postMessage(String content, String id) {
         Message message = new MessageBuilder(content).build();
         doReturn(jdaTester.createSucceededActionMock(message)).when(jdaTester.getTextChannelSpy())
             .retrieveMessageById(id);
     }
 
-    private void failOnRetrieveMessage(@NotNull String messageId, @NotNull Throwable failure) {
+    private void failOnRetrieveMessage(String messageId, Throwable failure) {
         doReturn(jdaTester.createFailedActionMock(failure)).when(jdaTester.getTextChannelSpy())
             .retrieveMessageById(messageId);
     }

--- a/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagsCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagsCommandTest.java
@@ -6,8 +6,6 @@ import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +15,8 @@ import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.Tags;
 import org.togetherjava.tjbot.jda.JdaTester;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,22 +28,23 @@ final class TagsCommandTest {
     private JdaTester jdaTester;
     private SlashCommand command;
 
-    private static @Nullable String getResponseDescription(
-            @NotNull SlashCommandInteractionEvent event) {
+    @Nullable
+    private static String getResponseDescription(SlashCommandInteractionEvent event) {
         ArgumentCaptor<MessageEmbed> responseCaptor = ArgumentCaptor.forClass(MessageEmbed.class);
         verify(event).replyEmbeds(responseCaptor.capture());
         return responseCaptor.getValue().getDescription();
     }
 
-    private @NotNull SlashCommandInteractionEvent triggerSlashCommand() {
+    @Nonnull
+    private SlashCommandInteractionEvent triggerSlashCommand() {
         SlashCommandInteractionEvent event =
                 jdaTester.createSlashCommandInteractionEvent(command).build();
         command.onSlashCommand(event);
         return event;
     }
 
-    private @NotNull ButtonInteractionEvent triggerButtonClick(@NotNull Member userWhoClicked,
-            long idOfAuthor) {
+    @Nonnull
+    private ButtonInteractionEvent triggerButtonClick(Member userWhoClicked, long idOfAuthor) {
         ButtonInteractionEvent event = jdaTester.createButtonInteractionEvent()
             .setUserWhoClicked(userWhoClicked)
             .setActionRows(ActionRow.of(TagSystem.createDeleteButton("foo")))

--- a/application/src/test/java/org/togetherjava/tjbot/commands/utils/StringDistancesTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/utils/StringDistancesTest.java
@@ -1,18 +1,16 @@
 package org.togetherjava.tjbot.commands.utils;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 final class StringDistancesTest {
 
     @Test
     void editDistance() {
-        record TestCase(@NotNull String name, int expectedDistance, @NotNull String source,
-                @NotNull String destination) {
+        record TestCase(String name, int expectedDistance, String source, String destination) {
         }
         List<TestCase> tests = List.of(new TestCase("identity", 0, "-", "-"),
                 new TestCase("empty_identity", 0, "", ""), new TestCase("empty_remove", 1, "a", ""),
@@ -31,8 +29,7 @@ final class StringDistancesTest {
 
     @Test
     void prefixEditDistance() {
-        record TestCase(@NotNull String name, int expectedDistance, @NotNull String source,
-                @NotNull String destination) {
+        record TestCase(String name, int expectedDistance, String source, String destination) {
         }
         List<TestCase> tests = List.of(new TestCase("identity", 0, "-", "-"),
                 new TestCase("empty_identity", 0, "", ""), new TestCase("empty_remove", 1, "a", ""),

--- a/application/src/test/java/org/togetherjava/tjbot/jda/ButtonClickEventBuilder.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/ButtonClickEventBuilder.java
@@ -9,10 +9,10 @@ import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.togetherjava.tjbot.commands.SlashCommand;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -69,13 +69,13 @@ import static org.mockito.Mockito.when;
  */
 public final class ButtonClickEventBuilder {
     private static final ObjectMapper JSON = new ObjectMapper();
-    private final @NotNull Supplier<? extends ButtonInteractionEvent> mockEventSupplier;
+    private final Supplier<? extends ButtonInteractionEvent> mockEventSupplier;
     private final UnaryOperator<Message> mockMessageOperator;
     private MessageBuilder messageBuilder;
     private Member userWhoClicked;
 
-    ButtonClickEventBuilder(@NotNull Supplier<? extends ButtonInteractionEvent> mockEventSupplier,
-            @NotNull UnaryOperator<Message> mockMessageOperator) {
+    ButtonClickEventBuilder(Supplier<? extends ButtonInteractionEvent> mockEventSupplier,
+            UnaryOperator<Message> mockMessageOperator) {
         this.mockEventSupplier = mockEventSupplier;
         this.mockMessageOperator = mockMessageOperator;
 
@@ -94,7 +94,8 @@ public final class ButtonClickEventBuilder {
      * @param message the message to set
      * @return this builder instance for chaining
      */
-    public @NotNull ButtonClickEventBuilder setMessage(@NotNull Message message) {
+    @Nonnull
+    public ButtonClickEventBuilder setMessage(Message message) {
         messageBuilder = new MessageBuilder(message);
         return this;
     }
@@ -106,7 +107,8 @@ public final class ButtonClickEventBuilder {
      * @param content the content of the message
      * @return this builder instance for chaining
      */
-    public @NotNull ButtonClickEventBuilder setContent(@NotNull String content) {
+    @Nonnull
+    public ButtonClickEventBuilder setContent(String content) {
         messageBuilder.setContent(content);
         return this;
     }
@@ -118,7 +120,8 @@ public final class ButtonClickEventBuilder {
      * @param embeds the embeds of the message
      * @return this builder instance for chaining
      */
-    public @NotNull ButtonClickEventBuilder setEmbeds(@NotNull MessageEmbed... embeds) {
+    @Nonnull
+    public ButtonClickEventBuilder setEmbeds(MessageEmbed... embeds) {
         messageBuilder.setEmbeds(embeds);
         return this;
     }
@@ -132,7 +135,8 @@ public final class ButtonClickEventBuilder {
      * @param rows the action rows of the message
      * @return this builder instance for chaining
      */
-    public @NotNull ButtonClickEventBuilder setActionRows(@NotNull ActionRow... rows) {
+    @Nonnull
+    public ButtonClickEventBuilder setActionRows(ActionRow... rows) {
         messageBuilder.setActionRows(rows);
         return this;
     }
@@ -143,8 +147,8 @@ public final class ButtonClickEventBuilder {
      * @param userWhoClicked the user who clicked the button
      * @return this builder instance for chaining
      */
-    @NotNull
-    public ButtonClickEventBuilder setUserWhoClicked(@NotNull Member userWhoClicked) {
+    @Nonnull
+    public ButtonClickEventBuilder setUserWhoClicked(Member userWhoClicked) {
         this.userWhoClicked = userWhoClicked;
         return this;
     }
@@ -158,7 +162,8 @@ public final class ButtonClickEventBuilder {
      *
      * @return the created slash command instance
      */
-    public @NotNull ButtonInteractionEvent buildWithSingleButton() {
+    @Nonnull
+    public ButtonInteractionEvent buildWithSingleButton() {
         return createEvent(null);
     }
 
@@ -173,19 +178,22 @@ public final class ButtonClickEventBuilder {
      *        contained in the message.
      * @return the created slash command instance
      */
-    public @NotNull ButtonInteractionEvent build(@NotNull Button clickedButton) {
+    @Nonnull
+    public ButtonInteractionEvent build(Button clickedButton) {
         return createEvent(clickedButton);
     }
 
-    private @NotNull ButtonInteractionEvent createEvent(@Nullable Button maybeClickedButton) {
+    @Nonnull
+    private ButtonInteractionEvent createEvent(@Nullable Button maybeClickedButton) {
         Message message = mockMessageOperator.apply(messageBuilder.build());
         Button clickedButton = determineClickedButton(maybeClickedButton, message);
 
         return mockButtonClickEvent(message, clickedButton);
     }
 
-    private static @NotNull Button determineClickedButton(@Nullable Button maybeClickedButton,
-            @NotNull Message message) {
+    @Nonnull
+    private static Button determineClickedButton(@Nullable Button maybeClickedButton,
+            Message message) {
         if (maybeClickedButton != null) {
             return requireButtonInMessage(maybeClickedButton, message);
         }
@@ -195,8 +203,8 @@ public final class ButtonClickEventBuilder {
         return requireSingleButton(getMessageButtons(message));
     }
 
-    private static @NotNull Button requireButtonInMessage(@NotNull Button clickedButton,
-            @NotNull Message message) {
+    @Nonnull
+    private static Button requireButtonInMessage(Button clickedButton, Message message) {
         boolean isClickedButtonUnknown =
                 getMessageButtons(message).noneMatch(clickedButton::equals);
 
@@ -208,7 +216,8 @@ public final class ButtonClickEventBuilder {
         return clickedButton;
     }
 
-    private static @NotNull Button requireSingleButton(@NotNull Stream<? extends Button> stream) {
+    @Nonnull
+    private static Button requireSingleButton(Stream<? extends Button> stream) {
         Function<String, ? extends RuntimeException> descriptionToException =
                 IllegalArgumentException::new;
 
@@ -222,12 +231,13 @@ public final class ButtonClickEventBuilder {
                             + " Add the button to the message first."));
     }
 
-    private static @NotNull Stream<Button> getMessageButtons(@NotNull Message message) {
+    @Nonnull
+    private static Stream<Button> getMessageButtons(Message message) {
         return message.getActionRows().stream().map(ActionRow::getButtons).flatMap(List::stream);
     }
 
-    private @NotNull ButtonInteractionEvent mockButtonClickEvent(@NotNull Message message,
-            @NotNull Button clickedButton) {
+    @Nonnull
+    private ButtonInteractionEvent mockButtonClickEvent(Message message, Button clickedButton) {
         ButtonInteractionEvent event = mockEventSupplier.get();
 
         when(event.getMessage()).thenReturn(message);

--- a/application/src/test/java/org/togetherjava/tjbot/jda/JdaTester.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/JdaTester.java
@@ -477,8 +477,8 @@ public final class JdaTester {
      */
     @SuppressWarnings("unchecked")
     @Nonnull
-    public <T, R extends RestAction<T>> R createFailedActionMock(
-            Throwable failureReason, Class<R> restActionType) {
+    public <T, R extends RestAction<T>> R createFailedActionMock(Throwable failureReason,
+            Class<R> restActionType) {
         R action = mock(restActionType);
 
         Answer<Void> failureExecution = invocation -> {

--- a/application/src/test/java/org/togetherjava/tjbot/jda/JdaTester.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/JdaTester.java
@@ -26,14 +26,13 @@ import net.dv8tion.jda.internal.requests.restaction.MessageActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.WebhookMessageUpdateActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.interactions.ReplyCallbackActionImpl;
 import net.dv8tion.jda.internal.utils.config.AuthorizationConfig;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.mockito.ArgumentMatchers;
 import org.mockito.stubbing.Answer;
 import org.togetherjava.tjbot.commands.SlashCommand;
 import org.togetherjava.tjbot.commands.componentids.ComponentIdGenerator;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -208,8 +207,9 @@ public final class JdaTester {
      * @param command the command to create an event for
      * @return a builder used to create a Mockito mocked slash command event
      */
-    public @NotNull SlashCommandInteractionEventBuilder createSlashCommandInteractionEvent(
-            @NotNull SlashCommand command) {
+    @Nonnull
+    public SlashCommandInteractionEventBuilder createSlashCommandInteractionEvent(
+            SlashCommand command) {
         UnaryOperator<SlashCommandInteractionEvent> mockOperator = event -> {
             SlashCommandInteractionEvent SlashCommandInteractionEvent = spy(event);
             mockInteraction(SlashCommandInteractionEvent);
@@ -234,7 +234,8 @@ public final class JdaTester {
      *
      * @return a builder used to create a Mockito mocked slash command event
      */
-    public @NotNull ButtonClickEventBuilder createButtonInteractionEvent() {
+    @Nonnull
+    public ButtonClickEventBuilder createButtonInteractionEvent() {
         Supplier<ButtonInteractionEvent> mockEventSupplier = () -> {
             ButtonInteractionEvent event = mock(ButtonInteractionEvent.class);
             mockButtonClickEvent(event);
@@ -261,7 +262,8 @@ public final class JdaTester {
      * @param <T> the type of the command to spy on
      * @return the created spy
      */
-    public <T extends SlashCommand> @NotNull T spySlashCommand(@NotNull T command) {
+    @Nonnull
+    public <T extends SlashCommand> T spySlashCommand(T command) {
         T spiedCommand = spy(command);
         spiedCommand
             .acceptComponentIdGenerator((componentId, lifespan) -> UUID.randomUUID().toString());
@@ -276,7 +278,8 @@ public final class JdaTester {
      * @param userId the id of the member to create
      * @return the created spy
      */
-    public @NotNull Member createMemberSpy(long userId) {
+    @Nonnull
+    public Member createMemberSpy(long userId) {
         UserImpl user = spy(new UserImpl(userId, jda));
         return spy(new MemberImpl(guild, user));
     }
@@ -289,7 +292,8 @@ public final class JdaTester {
      * @param channelId the id of the text channel to create
      * @return the created spy
      */
-    public @NotNull TextChannel createTextChannelSpy(long channelId) {
+    @Nonnull
+    public TextChannel createTextChannelSpy(long channelId) {
         return spy(new TextChannelImpl(channelId, guild));
     }
 
@@ -302,7 +306,8 @@ public final class JdaTester {
      *
      * @return the reply action mock used by this tester
      */
-    public @NotNull ReplyCallbackAction getReplyActionMock() {
+    @Nonnull
+    public ReplyCallbackAction getReplyActionMock() {
         return replyAction;
     }
 
@@ -315,7 +320,8 @@ public final class JdaTester {
      *
      * @return the interaction hook mock used by this tester
      */
-    public @NotNull InteractionHook getInteractionHookMock() {
+    @Nonnull
+    public InteractionHook getInteractionHookMock() {
         return interactionHook;
     }
 
@@ -328,7 +334,8 @@ public final class JdaTester {
      *
      * @return the text channel spy used by this tester
      */
-    public @NotNull TextChannel getTextChannelSpy() {
+    @Nonnull
+    public TextChannel getTextChannelSpy() {
         return textChannel;
     }
 
@@ -341,7 +348,8 @@ public final class JdaTester {
      *
      * @return the private channel spy used by this tester
      */
-    public @NotNull PrivateChannel getPrivateChannelSpy() {
+    @Nonnull
+    public PrivateChannel getPrivateChannelSpy() {
         return privateChannel;
     }
 
@@ -355,7 +363,8 @@ public final class JdaTester {
      *
      * @return the member spy used by this tester
      */
-    public @NotNull Member getMemberSpy() {
+    @Nonnull
+    public Member getMemberSpy() {
         return member;
     }
 
@@ -364,7 +373,8 @@ public final class JdaTester {
      *
      * @return the JDA mock used by this tester
      */
-    public @NotNull JDA getJdaMock() {
+    @Nonnull
+    public JDA getJdaMock() {
         return jda;
     }
 
@@ -392,8 +402,9 @@ public final class JdaTester {
      * @param <R> the specific type of the Rest Action to return
      * @return the mocked action
      */
+    @Nonnull
     @SuppressWarnings("unchecked")
-    public <T, R extends RestAction<T>> @NotNull R createSucceededActionMock(@Nullable T t,
+    public <T, R extends RestAction<T>> R createSucceededActionMock(@Nullable T t,
             Class<R> restActionType) {
         R action = mock(restActionType);
 
@@ -435,7 +446,8 @@ public final class JdaTester {
      * @see #createSucceededActionMock(Object, Class)
      */
     @SuppressWarnings("unchecked")
-    public <T> @NotNull RestAction<T> createSucceededActionMock(@Nullable T t) {
+    @Nonnull
+    public <T> RestAction<T> createSucceededActionMock(@Nullable T t) {
         return createSucceededActionMock(t, RestAction.class);
     }
 
@@ -464,8 +476,9 @@ public final class JdaTester {
      * @return the mocked action
      */
     @SuppressWarnings("unchecked")
-    public <T, R extends RestAction<T>> @NotNull R createFailedActionMock(
-            @NotNull Throwable failureReason, Class<R> restActionType) {
+    @Nonnull
+    public <T, R extends RestAction<T>> R createFailedActionMock(
+            Throwable failureReason, Class<R> restActionType) {
         R action = mock(restActionType);
 
         Answer<Void> failureExecution = invocation -> {
@@ -509,7 +522,8 @@ public final class JdaTester {
      * @see #createFailedActionMock(Throwable, Class)
      */
     @SuppressWarnings("unchecked")
-    public <T> @NotNull RestAction<T> createFailedActionMock(@NotNull Throwable failureReason) {
+    @Nonnull
+    public <T> RestAction<T> createFailedActionMock(Throwable failureReason) {
         return createFailedActionMock(failureReason, RestAction.class);
     }
 
@@ -522,8 +536,8 @@ public final class JdaTester {
      * @param reason the reason of the error
      * @return the created exception
      */
-    public @NotNull ErrorResponseException createErrorResponseException(
-            @NotNull ErrorResponse reason) {
+    @Nonnull
+    public ErrorResponseException createErrorResponseException(ErrorResponse reason) {
         return ErrorResponseException.create(reason, new Response(null, -1, "", -1, Set.of()));
     }
 
@@ -545,7 +559,7 @@ public final class JdaTester {
         return new MessageReceivedEvent(jda, responseNumber.getAndIncrement(), spyMessage);
     }
 
-    private void mockInteraction(@NotNull IReplyCallback interaction) {
+    private void mockInteraction(IReplyCallback interaction) {
         doReturn(replyAction).when(interaction).reply(anyString());
         doReturn(replyAction).when(interaction).replyEmbeds(ArgumentMatchers.<MessageEmbed>any());
         doReturn(replyAction).when(interaction).replyEmbeds(anyCollection());
@@ -564,13 +578,13 @@ public final class JdaTester {
         doReturn(replyCallbackAction).when(interaction).deferReply(anyBoolean());
     }
 
-    private void mockButtonClickEvent(@NotNull ButtonInteractionEvent event) {
+    private void mockButtonClickEvent(ButtonInteractionEvent event) {
         mockInteraction(event);
 
         doReturn(replyAction).when(event).editButton(any());
     }
 
-    private void mockMessage(@NotNull Message message) {
+    private void mockMessage(Message message) {
         doReturn(messageAction).when(message).reply(anyString());
         doReturn(messageAction).when(message).replyEmbeds(ArgumentMatchers.<MessageEmbed>any());
         doReturn(messageAction).when(message).replyEmbeds(anyCollection());

--- a/application/src/test/java/org/togetherjava/tjbot/jda/SlashCommandInteractionEventBuilder.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/SlashCommandInteractionEventBuilder.java
@@ -11,13 +11,13 @@ import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.interactions.command.SlashCommandInteractionImpl;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.togetherjava.tjbot.commands.SlashCommand;
 import org.togetherjava.tjbot.jda.payloads.PayloadMember;
 import org.togetherjava.tjbot.jda.payloads.PayloadUser;
 import org.togetherjava.tjbot.jda.payloads.slashcommand.*;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +77,7 @@ public final class SlashCommandInteractionEventBuilder {
     private String subcommand;
     private Member userWhoTriggered;
 
-    SlashCommandInteractionEventBuilder(@NotNull JDAImpl jda,
+    SlashCommandInteractionEventBuilder(JDAImpl jda,
             UnaryOperator<SlashCommandInteractionEvent> mockOperator) {
         this.jda = jda;
         this.mockOperator = mockOperator;
@@ -97,8 +97,8 @@ public final class SlashCommandInteractionEventBuilder {
      * @throws IllegalArgumentException if the option does not exist in the corresponding command,
      *         as specified by its {@link SlashCommand#getData()}
      */
-    public @NotNull SlashCommandInteractionEventBuilder setOption(@NotNull String name,
-            @NotNull String value) {
+    @Nonnull
+    public SlashCommandInteractionEventBuilder setOption(String name, String value) {
         putOptionRaw(name, value, OptionType.STRING);
         return this;
     }
@@ -117,8 +117,8 @@ public final class SlashCommandInteractionEventBuilder {
      * @throws IllegalArgumentException if the option does not exist in the corresponding command,
      *         as specified by its {@link SlashCommand#getData()}
      */
-    public @NotNull SlashCommandInteractionEventBuilder setOption(@NotNull String name,
-            long value) {
+    @Nonnull
+    public SlashCommandInteractionEventBuilder setOption(String name, long value) {
         putOptionRaw(name, value, OptionType.INTEGER);
         return this;
     }
@@ -137,8 +137,8 @@ public final class SlashCommandInteractionEventBuilder {
      * @throws IllegalArgumentException if the option does not exist in the corresponding command,
      *         as specified by its {@link SlashCommand#getData()}
      */
-    public @NotNull SlashCommandInteractionEventBuilder setOption(@NotNull String name,
-            @NotNull User value) {
+    @Nonnull
+    public SlashCommandInteractionEventBuilder setOption(String name, User value) {
         putOptionRaw(name, value, OptionType.USER);
         return this;
     }
@@ -157,8 +157,8 @@ public final class SlashCommandInteractionEventBuilder {
      * @throws IllegalArgumentException if the option does not exist in the corresponding command,
      *         as specified by its {@link SlashCommand#getData()}
      */
-    public @NotNull SlashCommandInteractionEventBuilder setOption(@NotNull String name,
-            @NotNull Member value) {
+    @Nonnull
+    public SlashCommandInteractionEventBuilder setOption(String name, Member value) {
         putOptionRaw(name, value, OptionType.USER);
         return this;
     }
@@ -168,7 +168,8 @@ public final class SlashCommandInteractionEventBuilder {
      *
      * @return this builder instance for chaining
      */
-    public @NotNull SlashCommandInteractionEventBuilder clearOptions() {
+    @Nonnull
+    public SlashCommandInteractionEventBuilder clearOptions() {
         nameToOption.clear();
         return this;
     }
@@ -184,7 +185,8 @@ public final class SlashCommandInteractionEventBuilder {
      * @throws IllegalArgumentException if the subcommand does not exist in the corresponding
      *         command, as specified by its {@link SlashCommand#getData()}
      */
-    public @NotNull SlashCommandInteractionEventBuilder setSubcommand(@Nullable String subcommand) {
+    @Nonnull
+    public SlashCommandInteractionEventBuilder setSubcommand(@Nullable String subcommand) {
         if (subcommand != null) {
             requireSubcommand(subcommand);
         }
@@ -199,45 +201,44 @@ public final class SlashCommandInteractionEventBuilder {
      * @param userWhoTriggered the user who triggered the slash command
      * @return this builder instance for chaining
      */
-    @NotNull
-    public SlashCommandInteractionEventBuilder setUserWhoTriggered(
-            @NotNull Member userWhoTriggered) {
+    @Nonnull
+    public SlashCommandInteractionEventBuilder setUserWhoTriggered(Member userWhoTriggered) {
         this.userWhoTriggered = userWhoTriggered;
         return this;
     }
 
-    @NotNull
-    SlashCommandInteractionEventBuilder setCommand(@NotNull SlashCommand command) {
+    @Nonnull
+    SlashCommandInteractionEventBuilder setCommand(SlashCommand command) {
         this.command = command;
         return this;
     }
 
-    @NotNull
-    SlashCommandInteractionEventBuilder setChannelId(@NotNull String channelId) {
+    @Nonnull
+    SlashCommandInteractionEventBuilder setChannelId(String channelId) {
         this.channelId = channelId;
         return this;
     }
 
-    @NotNull
-    SlashCommandInteractionEventBuilder setToken(@NotNull String token) {
+    @Nonnull
+    SlashCommandInteractionEventBuilder setToken(String token) {
         this.token = token;
         return this;
     }
 
-    @NotNull
-    SlashCommandInteractionEventBuilder setApplicationId(@NotNull String applicationId) {
+    @Nonnull
+    SlashCommandInteractionEventBuilder setApplicationId(String applicationId) {
         this.applicationId = applicationId;
         return this;
     }
 
-    @NotNull
-    SlashCommandInteractionEventBuilder setGuildId(@NotNull String guildId) {
+    @Nonnull
+    SlashCommandInteractionEventBuilder setGuildId(String guildId) {
         this.guildId = guildId;
         return this;
     }
 
-    @NotNull
-    SlashCommandInteractionEventBuilder setUserId(@NotNull String userId) {
+    @Nonnull
+    SlashCommandInteractionEventBuilder setUserId(String userId) {
         this.userId = userId;
         return this;
     }
@@ -248,7 +249,8 @@ public final class SlashCommandInteractionEventBuilder {
      *
      * @return the created slash command instance
      */
-    public @NotNull SlashCommandInteractionEvent build() {
+    @Nonnull
+    public SlashCommandInteractionEvent build() {
         PayloadSlashCommand event = createEvent();
 
         String json;
@@ -261,6 +263,7 @@ public final class SlashCommandInteractionEventBuilder {
         return spySlashCommandEvent(json);
     }
 
+    @Nonnull
     private SlashCommandInteractionEvent spySlashCommandEvent(String jsonData) {
         SlashCommandInteractionEvent event = spy(new SlashCommandInteractionEvent(jda, 0,
                 new SlashCommandInteractionImpl(jda, DataObject.fromJson(jsonData))));
@@ -273,7 +276,8 @@ public final class SlashCommandInteractionEventBuilder {
         return event;
     }
 
-    private @NotNull PayloadSlashCommand createEvent() {
+    @Nonnull
+    private PayloadSlashCommand createEvent() {
         // TODO Validate that required options are set, check that subcommand is given if the
         // command has one
         // TODO Make as much of this configurable as needed
@@ -296,8 +300,9 @@ public final class SlashCommandInteractionEventBuilder {
                 applicationId, token, member, data);
     }
 
-    private static @Nullable List<PayloadSlashCommandOption> extractOptionsOrNull(
-            @NotNull Map<String, Option<?>> nameToOption) {
+    @Nullable
+    private static List<PayloadSlashCommandOption> extractOptionsOrNull(
+            Map<String, Option<?>> nameToOption) {
         if (nameToOption.isEmpty()) {
             return null;
         }
@@ -308,8 +313,8 @@ public final class SlashCommandInteractionEventBuilder {
             .toList();
     }
 
-    private static <T> @NotNull String serializeOptionValue(@NotNull T value,
-            @NotNull OptionType type) {
+    @Nonnull
+    private static <T> String serializeOptionValue(T value, OptionType type) {
         if (type == OptionType.STRING) {
             return (String) value;
         } else if (type == OptionType.INTEGER) {
@@ -337,8 +342,9 @@ public final class SlashCommandInteractionEventBuilder {
                     .formatted(type, value.getClass()));
     }
 
-    private static @Nullable PayloadSlashCommandResolved extractResolvedOrNull(
-            @NotNull Map<String, Option<?>> nameToOption) {
+    @Nullable
+    private static PayloadSlashCommandResolved extractResolvedOrNull(
+            Map<String, Option<?>> nameToOption) {
         PayloadSlashCommandUsers users = extractUsersOrNull(nameToOption);
         PayloadSlashCommandMembers members = extractMembersOrNull(nameToOption);
 
@@ -349,8 +355,9 @@ public final class SlashCommandInteractionEventBuilder {
         return new PayloadSlashCommandResolved(members, users);
     }
 
-    private static @Nullable PayloadSlashCommandUsers extractUsersOrNull(
-            @NotNull Map<String, Option<?>> nameToOption) {
+    @Nullable
+    private static PayloadSlashCommandUsers extractUsersOrNull(
+            Map<String, Option<?>> nameToOption) {
         Map<String, PayloadUser> idToUser = nameToOption.values()
             .stream()
             .filter(option -> option.type == OptionType.USER)
@@ -366,8 +373,9 @@ public final class SlashCommandInteractionEventBuilder {
         return idToUser.isEmpty() ? null : new PayloadSlashCommandUsers(idToUser);
     }
 
-    private static @Nullable PayloadSlashCommandMembers extractMembersOrNull(
-            @NotNull Map<String, Option<?>> nameToOption) {
+    @Nullable
+    private static PayloadSlashCommandMembers extractMembersOrNull(
+            Map<String, Option<?>> nameToOption) {
         Map<String, PayloadMember> idToMember = nameToOption.values()
             .stream()
             .filter(option -> option.type == OptionType.USER)
@@ -379,14 +387,14 @@ public final class SlashCommandInteractionEventBuilder {
         return idToMember.isEmpty() ? null : new PayloadSlashCommandMembers(idToMember);
     }
 
-    private <T> void putOptionRaw(@NotNull String name, @NotNull T value,
-            @NotNull OptionType type) {
+    private <T> void putOptionRaw(String name, T value, OptionType type) {
         requireOption(name, type);
         nameToOption.put(name, new Option<>(name, value, type));
     }
 
     @SuppressWarnings("UnusedReturnValue")
-    private @NotNull OptionData requireOption(@NotNull String name, @NotNull OptionType type) {
+    @Nonnull
+    private OptionData requireOption(String name, OptionType type) {
         List<OptionData> options = subcommand == null ? command.getData().getOptions()
                 : requireSubcommand(subcommand).getOptions();
 
@@ -405,7 +413,8 @@ public final class SlashCommandInteractionEventBuilder {
             });
     }
 
-    private @NotNull SubcommandData requireSubcommand(@NotNull String name) {
+    @Nonnull
+    private SubcommandData requireSubcommand(String name) {
         return command.getData()
             .getSubcommands()
             .stream()
@@ -418,6 +427,6 @@ public final class SlashCommandInteractionEventBuilder {
             });
     }
 
-    private record Option<T> (@NotNull String name, @NotNull T value, @NotNull OptionType type) {
+    private record Option<T> (String name, T value, OptionType type) {
     }
 }

--- a/application/src/test/java/org/togetherjava/tjbot/jda/package-info.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/package-info.java
@@ -2,4 +2,7 @@
  * Provides utilities for testing with JDA, such as mocks. See
  * {@link org.togetherjava.tjbot.jda.JdaTester} as entry point.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.jda;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/PayloadMember.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/PayloadMember.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,11 +28,9 @@ public final class PayloadMember {
     private boolean isPending;
     private PayloadUser user;
 
-    @SuppressWarnings("ConstructorWithTooManyParameters")
-    public PayloadMember(@Nullable String premiumSince, @Nullable String nick,
-            @NotNull String joinedAt, @NotNull String permissions, @NotNull List<String> roles,
-            boolean pending, boolean deaf, boolean mute, @Nullable String avatar, boolean isPending,
-            PayloadUser user) {
+    public PayloadMember(@Nullable String premiumSince, @Nullable String nick, String joinedAt,
+            String permissions, List<String> roles, boolean pending, boolean deaf, boolean mute,
+            @Nullable String avatar, boolean isPending, PayloadUser user) {
         this.premiumSince = premiumSince;
         this.nick = nick;
         this.joinedAt = joinedAt;
@@ -46,7 +44,8 @@ public final class PayloadMember {
         this.user = user;
     }
 
-    public static @NotNull PayloadMember of(@NotNull Member member) {
+    @Nonnull
+    public static PayloadMember of(Member member) {
         String permissions = Long
             .toString(Permission.getRaw(member.getPermissions().toArray(Permission[]::new)));
         List<String> roles = member.getRoles().stream().map(Role::getId).toList();
@@ -57,11 +56,12 @@ public final class PayloadMember {
                 member.isPending(), user);
     }
 
-    public @NotNull PayloadUser getUser() {
+    @Nonnull
+    public PayloadUser getUser() {
         return user;
     }
 
-    public void setUser(@NotNull PayloadUser user) {
+    public void setUser(PayloadUser user) {
         this.user = user;
     }
 
@@ -83,30 +83,30 @@ public final class PayloadMember {
         this.nick = nick;
     }
 
-    @NotNull
+    @Nonnull
     public String getJoinedAt() {
         return joinedAt;
     }
 
-    public void setJoinedAt(@NotNull String joinedAt) {
+    public void setJoinedAt(String joinedAt) {
         this.joinedAt = joinedAt;
     }
 
-    @NotNull
+    @Nonnull
     public String getPermissions() {
         return permissions;
     }
 
-    public void setPermissions(@NotNull String permissions) {
+    public void setPermissions(String permissions) {
         this.permissions = permissions;
     }
 
-    @NotNull
+    @Nonnull
     public List<String> getRoles() {
         return Collections.unmodifiableList(roles);
     }
 
-    public void setRoles(@NotNull List<String> roles) {
+    public void setRoles(List<String> roles) {
         this.roles = new ArrayList<>(roles);
     }
 

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/PayloadUser.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/PayloadUser.java
@@ -2,8 +2,9 @@ package org.togetherjava.tjbot.jda.payloads;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import net.dv8tion.jda.api.entities.User;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public final class PayloadUser {
     private boolean bot;
@@ -14,8 +15,8 @@ public final class PayloadUser {
     private String username;
     private String discriminator;
 
-    public PayloadUser(boolean bot, long publicFlags, @NotNull String id, @Nullable String avatar,
-            @NotNull String username, @NotNull String discriminator) {
+    public PayloadUser(boolean bot, long publicFlags, String id, @Nullable String avatar,
+            String username, String discriminator) {
         this.publicFlags = publicFlags;
         this.id = id;
         this.avatar = avatar;
@@ -23,7 +24,8 @@ public final class PayloadUser {
         this.discriminator = discriminator;
     }
 
-    public static @NotNull PayloadUser of(@NotNull User user) {
+    @Nonnull
+    public static PayloadUser of(User user) {
         return new PayloadUser(user.isBot(), user.getFlagsRaw(), user.getId(), user.getAvatarId(),
                 user.getName(), user.getDiscriminator());
     }
@@ -44,12 +46,12 @@ public final class PayloadUser {
         this.publicFlags = publicFlags;
     }
 
-    @NotNull
+    @Nonnull
     public String getId() {
         return id;
     }
 
-    public void setId(@NotNull String id) {
+    public void setId(String id) {
         this.id = id;
     }
 
@@ -62,21 +64,21 @@ public final class PayloadUser {
         this.avatar = avatar;
     }
 
-    @NotNull
+    @Nonnull
     public String getUsername() {
         return username;
     }
 
-    public void setUsername(@NotNull String username) {
+    public void setUsername(String username) {
         this.username = username;
     }
 
-    @NotNull
+    @Nonnull
     public String getDiscriminator() {
         return discriminator;
     }
 
-    public void setDiscriminator(@NotNull String discriminator) {
+    public void setDiscriminator(String discriminator) {
         this.discriminator = discriminator;
     }
 }

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommand.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommand.java
@@ -1,8 +1,9 @@
 package org.togetherjava.tjbot.jda.payloads.slashcommand;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.jda.payloads.PayloadMember;
+
+import javax.annotation.Nonnull;
 
 public final class PayloadSlashCommand {
     @JsonProperty("guild_id")
@@ -18,10 +19,9 @@ public final class PayloadSlashCommand {
     private PayloadMember member;
     private PayloadSlashCommandData data;
 
-    @SuppressWarnings("ConstructorWithTooManyParameters")
-    public PayloadSlashCommand(@NotNull String guildId, @NotNull String id, int type, int version,
-            @NotNull String channelId, @NotNull String applicationId, @NotNull String token,
-            @NotNull PayloadMember member, @NotNull PayloadSlashCommandData data) {
+    public PayloadSlashCommand(String guildId, String id, int type, int version, String channelId,
+            String applicationId, String token, PayloadMember member,
+            PayloadSlashCommandData data) {
         this.guildId = guildId;
         this.id = id;
         this.type = type;
@@ -33,21 +33,21 @@ public final class PayloadSlashCommand {
         this.data = data;
     }
 
-    @NotNull
+    @Nonnull
     public String getGuildId() {
         return guildId;
     }
 
-    public void setGuildId(@NotNull String guildId) {
+    public void setGuildId(String guildId) {
         this.guildId = guildId;
     }
 
-    @NotNull
+    @Nonnull
     public String getId() {
         return id;
     }
 
-    public void setId(@NotNull String id) {
+    public void setId(String id) {
         this.id = id;
     }
 
@@ -67,48 +67,48 @@ public final class PayloadSlashCommand {
         this.version = version;
     }
 
-    @NotNull
+    @Nonnull
     public String getChannelId() {
         return channelId;
     }
 
-    public void setChannelId(@NotNull String channelId) {
+    public void setChannelId(String channelId) {
         this.channelId = channelId;
     }
 
-    @NotNull
+    @Nonnull
     public String getApplicationId() {
         return applicationId;
     }
 
-    public void setApplicationId(@NotNull String applicationId) {
+    public void setApplicationId(String applicationId) {
         this.applicationId = applicationId;
     }
 
-    @NotNull
+    @Nonnull
     public String getToken() {
         return token;
     }
 
-    public void setToken(@NotNull String token) {
+    public void setToken(String token) {
         this.token = token;
     }
 
-    @NotNull
+    @Nonnull
     public PayloadMember getMember() {
         return member;
     }
 
-    public void setMember(@NotNull PayloadMember member) {
+    public void setMember(PayloadMember member) {
         this.member = member;
     }
 
-    @NotNull
+    @Nonnull
     public PayloadSlashCommandData getData() {
         return data;
     }
 
-    public void setData(@NotNull PayloadSlashCommandData data) {
+    public void setData(PayloadSlashCommandData data) {
         this.data = data;
     }
 }

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandData.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandData.java
@@ -1,9 +1,9 @@
 package org.togetherjava.tjbot.jda.payloads.slashcommand;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -17,7 +17,7 @@ public final class PayloadSlashCommandData {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private PayloadSlashCommandResolved resolved;
 
-    public PayloadSlashCommandData(@NotNull String name, @NotNull String id, int type,
+    public PayloadSlashCommandData(String name, String id, int type,
             @Nullable List<PayloadSlashCommandOption> options,
             @Nullable PayloadSlashCommandResolved resolved) {
         this.name = name;
@@ -27,21 +27,21 @@ public final class PayloadSlashCommandData {
         this.resolved = resolved;
     }
 
-    @NotNull
+    @Nonnull
     public String getName() {
         return name;
     }
 
-    public void setName(@NotNull String name) {
+    public void setName(String name) {
         this.name = name;
     }
 
-    @NotNull
+    @Nonnull
     public String getId() {
         return id;
     }
 
-    public void setId(@NotNull String id) {
+    public void setId(String id) {
         this.id = id;
     }
 
@@ -53,7 +53,8 @@ public final class PayloadSlashCommandData {
         this.type = type;
     }
 
-    public @Nullable List<PayloadSlashCommandOption> getOptions() {
+    @Nullable
+    public List<PayloadSlashCommandOption> getOptions() {
         return options == null ? null : Collections.unmodifiableList(options);
     }
 
@@ -61,7 +62,8 @@ public final class PayloadSlashCommandData {
         this.options = options == null ? null : new ArrayList<>(options);
     }
 
-    public @Nullable PayloadSlashCommandResolved getResolved() {
+    @Nullable
+    public PayloadSlashCommandResolved getResolved() {
         return resolved;
     }
 

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandMembers.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandMembers.java
@@ -2,9 +2,9 @@ package org.togetherjava.tjbot.jda.payloads.slashcommand;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.jda.payloads.PayloadMember;
 
+import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -12,17 +12,18 @@ import java.util.Map;
 public final class PayloadSlashCommandMembers {
     private Map<String, PayloadMember> idToMember;
 
-    public PayloadSlashCommandMembers(@NotNull Map<String, PayloadMember> idToMember) {
+    public PayloadSlashCommandMembers(Map<String, PayloadMember> idToMember) {
         this.idToMember = new HashMap<>(idToMember);
     }
 
     @JsonAnyGetter
-    public @NotNull Map<String, PayloadMember> getIdToMember() {
+    @Nonnull
+    public Map<String, PayloadMember> getIdToMember() {
         return Collections.unmodifiableMap(idToMember);
     }
 
     @JsonAnySetter
-    public void setIdToMember(@NotNull Map<String, PayloadMember> idToMember) {
+    public void setIdToMember(Map<String, PayloadMember> idToMember) {
         this.idToMember = new HashMap<>(idToMember);
     }
 }

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandOption.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandOption.java
@@ -1,9 +1,9 @@
 package org.togetherjava.tjbot.jda.payloads.slashcommand;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -15,7 +15,7 @@ public final class PayloadSlashCommandOption {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private List<PayloadSlashCommandOption> options;
 
-    public PayloadSlashCommandOption(@NotNull String name, int type, @Nullable String value,
+    public PayloadSlashCommandOption(String name, int type, @Nullable String value,
             @Nullable List<PayloadSlashCommandOption> options) {
         this.name = name;
         this.type = type;
@@ -23,12 +23,12 @@ public final class PayloadSlashCommandOption {
         this.options = options == null ? null : new ArrayList<>(options);
     }
 
-    @NotNull
+    @Nonnull
     public String getName() {
         return name;
     }
 
-    public void setName(@NotNull String name) {
+    public void setName(String name) {
         this.name = name;
     }
 

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandResolved.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandResolved.java
@@ -1,7 +1,7 @@
 package org.togetherjava.tjbot.jda.payloads.slashcommand;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import org.jetbrains.annotations.Nullable;
+import javax.annotation.Nullable;
 
 public final class PayloadSlashCommandResolved {
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -15,7 +15,8 @@ public final class PayloadSlashCommandResolved {
         this.users = users;
     }
 
-    public @Nullable PayloadSlashCommandMembers getMembers() {
+    @Nullable
+    public PayloadSlashCommandMembers getMembers() {
         return members;
     }
 
@@ -23,7 +24,8 @@ public final class PayloadSlashCommandResolved {
         this.members = members;
     }
 
-    public @Nullable PayloadSlashCommandUsers getUsers() {
+    @Nullable
+    public PayloadSlashCommandUsers getUsers() {
         return users;
     }
 

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandUsers.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandUsers.java
@@ -2,9 +2,9 @@ package org.togetherjava.tjbot.jda.payloads.slashcommand;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import org.jetbrains.annotations.NotNull;
 import org.togetherjava.tjbot.jda.payloads.PayloadUser;
 
+import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -12,17 +12,18 @@ import java.util.Map;
 public final class PayloadSlashCommandUsers {
     private Map<String, PayloadUser> idToUser;
 
-    public PayloadSlashCommandUsers(@NotNull Map<String, PayloadUser> idToUser) {
+    public PayloadSlashCommandUsers(Map<String, PayloadUser> idToUser) {
         this.idToUser = new HashMap<>(idToUser);
     }
 
     @JsonAnyGetter
-    public @NotNull Map<String, PayloadUser> getIdToUser() {
+    @Nonnull
+    public Map<String, PayloadUser> getIdToUser() {
         return Collections.unmodifiableMap(idToUser);
     }
 
     @JsonAnySetter
-    public void setIdToUser(@NotNull Map<String, PayloadUser> idToUser) {
+    public void setIdToUser(Map<String, PayloadUser> idToUser) {
         this.idToUser = new HashMap<>(idToUser);
     }
 }

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -5,6 +5,7 @@ plugins {
 var sqliteVersion = "3.39.2.0"
 
 dependencies {
+    implementation 'com.google.code.findbugs:jsr305:3.0.2'
     implementation "org.xerial:sqlite-jdbc:${sqliteVersion}"
     implementation 'org.flywaydb:flyway-core:9.2.0'
     implementation 'org.jooq:jooq:3.17.2'

--- a/database/src/main/java/org/togetherjava/tjbot/db/package-info.java
+++ b/database/src/main/java/org/togetherjava/tjbot/db/package-info.java
@@ -2,4 +2,7 @@
  * This package contains the database management of the application. See
  * {@link org.togetherjava.tjbot.db.Database} to get started.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.db;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/database/src/main/java/org/togetherjava/tjbot/db/util/package-info.java
+++ b/database/src/main/java/org/togetherjava/tjbot/db/util/package-info.java
@@ -2,4 +2,7 @@
  * General utility package containing various helper classes and methods used throughout the
  * application.
  */
+@ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.db.util;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
## Overview

Closes #539.

This cleans up the usage of `@NotNull/@Nonnull/@Nullable` and improves the situation by adding `@ParametersAreNonnullByDefault` to all packages.

The changes are:
* adding `@ParametersAreNonnullByDefault` to all existing `package-info.java` (in application and database)
* removing all `@NotNull` from all method parameters (its the default now)
* replacing all `@NotNull` on return types and similar by `@Nonnull` to consistently use `javax.annotations`
* replacing all `@Nullable` from Jetbrains by `@Nullable` from `javax.annotations`
* adding some missing `@Nonnull/@Nullable` on some return types
* removed some suppressions that do not seem to be important for Sonar and only cause confusion for people who do not have the inspections enabled

Fun fact, with these changes, Sonar even found a missing `@Nullable` in `TopHelperCommand`.

## Review

This is a huge PR, but with very minor and simple changes. It will also confuse a lot of merge conflicts (but simple conflicts). Ideally we merge this PR as soon as possible, as it will get conflicts with each merge while it is open.

For reviewing this, it is only really important to make sure that I neither removed a `@Nullable`, nor replaced one with `@Nonnull` or similar.

It is not important to actually really read the code. Skimming over the changes should be sufficient.

It is possible that some formatting went weird due to the heavy annotation removal + spotless. If you found any odd looking spot, tell in review and I will correct it.