### PR TITLE
Allow linked media posts

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/mediaonly/MediaOnlyChannelListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mediaonly/MediaOnlyChannelListener.java
@@ -46,7 +46,8 @@ public final class MediaOnlyChannelListener extends MessageReceiverAdapter {
 
     private static boolean messageHasNoMediaAttached(MessageReceivedEvent event) {
         Message message = event.getMessage();
-        return message.getAttachments().isEmpty() && message.getEmbeds().isEmpty();
+        return message.getAttachments().isEmpty() && message.getEmbeds().isEmpty()
+                && !message.getContentRaw().contains("http");
     }
 
     @Nonnull

--- a/application/src/test/java/org/togetherjava/tjbot/commands/mediaonly/MediaOnlyChannelListenerTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/mediaonly/MediaOnlyChannelListenerTest.java
@@ -66,7 +66,20 @@ final class MediaOnlyChannelListenerTest {
 
         // THEN it does not get deleted
         verify(event.getMessage(), never()).delete();
+    }
 
+    @Test
+    void keepsMessageWithLinkedMedia() {
+        // GIVEN a message with media linked in the message
+        Message message = new MessageBuilder()
+            .setContent("Check out this cute cat https://i.imgur.com/HLFByUJ.png")
+            .build();
+
+        // WHEN sending the message
+        MessageReceivedEvent event = sendMessage(message);
+
+        // THEN it does not get deleted
+        verify(event.getMessage(), never()).delete();
     }
 
     @Test


### PR DESCRIPTION
Closes #543.

## Problem

The recent PR #518 added functionality to disallow posts in `#memes` without media attached.

It works well, but there is an edge case it blocks, which it shouldnt. Namely if the message contains an URL (which Discord will then, later, transform into an attachment):

![message](https://i.imgur.com/HrxBScn.png)

## Fix

This PR adds a simple check whether the message contains `http`, then its not blocked. Easy and effective, all we need. Also added an unit test.

![example](https://i.imgur.com/Xu0y9vE.png)