### PR TITLE
Add @MethodsReturnNonnullByDefault

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/BootstrapLauncher.java
+++ b/application/src/main/java/org/togetherjava/tjbot/BootstrapLauncher.java
@@ -20,7 +20,6 @@ public class BootstrapLauncher {
         Application.main(args);
     }
 
-
     /**
      * Sets any system-properties before anything else is touched.
      */

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
@@ -31,7 +31,6 @@ import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.moderation.ModAuditLogWriter;
 import org.togetherjava.tjbot.routines.ModAuditLogRoutine;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -59,7 +58,6 @@ public class Features {
      * @param config the configuration features should use
      * @return a collection of all features
      */
-    @Nonnull
     public static Collection<Feature> createFeatures(JDA jda, Database database, Config config) {
         TagSystem tagSystem = new TagSystem(database);
         ModerationActionsStore actionsStore = new ModerationActionsStore(database);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/MessageReceiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/MessageReceiver.java
@@ -3,7 +3,6 @@ package org.togetherjava.tjbot.commands;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.MessageUpdateEvent;
 
-import javax.annotation.Nonnull;
 import java.util.regex.Pattern;
 
 /**
@@ -28,7 +27,6 @@ public interface MessageReceiver extends Feature {
      *
      * @return the pattern matching the names of relevant channels
      */
-    @Nonnull
     Pattern getChannelNamePattern();
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/commands/MessageReceiverAdapter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/MessageReceiverAdapter.java
@@ -3,7 +3,6 @@ package org.togetherjava.tjbot.commands;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.MessageUpdateEvent;
 
-import javax.annotation.Nonnull;
 import java.util.regex.Pattern;
 
 /**
@@ -29,7 +28,6 @@ public abstract class MessageReceiverAdapter implements MessageReceiver {
     }
 
     @Override
-    @Nonnull
     public final Pattern getChannelNamePattern() {
         return channelNamePattern;
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Routine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Routine.java
@@ -2,7 +2,6 @@ package org.togetherjava.tjbot.commands;
 
 import net.dv8tion.jda.api.JDA;
 
-import javax.annotation.Nonnull;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -24,7 +23,6 @@ public interface Routine extends Feature {
      *
      * @return the schedule of this routine
      */
-    @Nonnull
     Schedule createSchedule();
 
     /**
@@ -48,7 +46,6 @@ public interface Routine extends Feature {
      */
     record Schedule(ScheduleMode mode, long initialDuration, long duration, TimeUnit unit) {
     }
-
 
     /**
      * Whether subsequent executions of a routine are executed at a fixed rate or are delayed.

--- a/application/src/main/java/org/togetherjava/tjbot/commands/SlashCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/SlashCommand.java
@@ -13,7 +13,6 @@ import org.togetherjava.tjbot.commands.componentids.ComponentId;
 import org.togetherjava.tjbot.commands.componentids.ComponentIdGenerator;
 import org.togetherjava.tjbot.commands.componentids.Lifespan;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -49,7 +48,6 @@ public interface SlashCommand extends UserInteractor {
      *
      * @return the description of the command
      */
-    @Nonnull
     String getDescription();
 
     /**
@@ -59,7 +57,6 @@ public interface SlashCommand extends UserInteractor {
      *
      * @return the visibility of the command
      */
-    @Nonnull
     SlashCommandVisibility getVisibility();
 
     /**
@@ -77,7 +74,6 @@ public interface SlashCommand extends UserInteractor {
      *
      * @return the command data of this command
      */
-    @Nonnull
     SlashCommandData getData();
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/commands/SlashCommandAdapter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/SlashCommandAdapter.java
@@ -15,7 +15,6 @@ import org.togetherjava.tjbot.commands.componentids.ComponentId;
 import org.togetherjava.tjbot.commands.componentids.ComponentIdGenerator;
 import org.togetherjava.tjbot.commands.componentids.Lifespan;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -90,25 +89,21 @@ public abstract class SlashCommandAdapter implements SlashCommand {
     }
 
     @Override
-    @Nonnull
     public final String getName() {
         return name;
     }
 
     @Override
-    @Nonnull
     public final String getDescription() {
         return description;
     }
 
     @Override
-    @Nonnull
     public final SlashCommandVisibility getVisibility() {
         return visibility;
     }
 
     @Override
-    @Nonnull
     public final SlashCommandData getData() {
         return data;
     }
@@ -145,7 +140,6 @@ public abstract class SlashCommandAdapter implements SlashCommand {
      * @return the generated component ID
      */
     @SuppressWarnings("OverloadedVarargsMethod")
-    @Nonnull
     protected final String generateComponentId(String... args) {
         return generateComponentId(Lifespan.REGULAR, args);
     }
@@ -163,7 +157,6 @@ public abstract class SlashCommandAdapter implements SlashCommand {
      * @return the generated component ID
      */
     @SuppressWarnings({"OverloadedVarargsMethod", "WeakerAccess"})
-    @Nonnull
     protected final String generateComponentId(Lifespan lifespan, String... args) {
         return Objects.requireNonNull(componentIdGenerator)
             .generate(new ComponentId(getName(), Arrays.asList(args)), lifespan);
@@ -194,7 +187,6 @@ public abstract class SlashCommandAdapter implements SlashCommand {
      * @return the generated list of options
      */
     @Unmodifiable
-    @Nonnull
     protected static List<OptionData> generateMultipleOptions(OptionData optionData,
             @Range(from = 1, to = 25) int amount) {
         String baseName = optionData.getName();
@@ -216,7 +208,6 @@ public abstract class SlashCommandAdapter implements SlashCommand {
      * @return all options with the given prefix
      */
     @Unmodifiable
-    @Nonnull
     protected static List<OptionMapping> getMultipleOptionsByNamePrefix(
             CommandInteractionPayload event, String namePrefix) {
         return event.getOptions()

--- a/application/src/main/java/org/togetherjava/tjbot/commands/UserInteractor.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/UserInteractor.java
@@ -5,7 +5,6 @@ import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.SelectMenuInteractionEvent;
 import org.togetherjava.tjbot.commands.componentids.ComponentIdGenerator;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -27,7 +26,6 @@ public interface UserInteractor extends Feature {
      *
      * @return the name of the interactor
      */
-    @Nonnull
     String getName();
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/RoleSelectCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/RoleSelectCommand.java
@@ -19,12 +19,10 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.commands.componentids.Lifespan;
 
-import javax.annotation.Nonnull;
 import java.awt.Color;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 
 /**
  * Implements the {@code /role-select} command.
@@ -56,7 +54,6 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
     private static final Color AMBIENT_COLOR = new Color(24, 221, 136, 255);
 
     private static final int OPTIONAL_ROLES_AMOUNT = 22;
-
 
     /**
      * Construct an instance.
@@ -193,7 +190,6 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
         event.replyEmbeds(embed).addActionRow(menu.build()).queue();
     }
 
-    @Nonnull
     private static SelectOption mapToSelectOption(Role role) {
         RoleIcon roleIcon = role.getIcon();
 
@@ -243,7 +239,6 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
         modifyRoles(event, event.getMember(), guild, rolesToAdd, rolesToRemove);
     }
 
-    @Nonnull
     private static Function<SelectOption, Optional<Role>> optionToRole(Guild guild) {
         return option -> {
             Role role = guild.getRoleById(option.getValue());
@@ -265,7 +260,6 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
             .queue();
     }
 
-    @Nonnull
     private static MessageEmbed createEmbed(String title, CharSequence description) {
         return new EmbedBuilder().setTitle(title)
             .setDescription(description)

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/SuggestionsUpDownVoter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/SuggestionsUpDownVoter.java
@@ -12,7 +12,6 @@ import org.togetherjava.tjbot.commands.MessageReceiverAdapter;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.config.SuggestionsConfig;
 
-import javax.annotation.Nonnull;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -89,7 +88,6 @@ public final class SuggestionsUpDownVoter extends MessageReceiverAdapter {
         });
     }
 
-    @Nonnull
     private static Optional<Emote> getEmoteByName(String name, Guild guild) {
         return guild.getEmotesByName(name, false).stream().findAny();
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/VcActivityCommand.java
@@ -18,14 +18,12 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-
 
 /**
  * Implements the {@code vc-activity} command. Creates VC activities.
@@ -125,23 +123,19 @@ public final class VcActivityCommand extends SlashCommandAdapter {
                 "Starts a VC activity (you need to be in an voice channel to run this command)",
                 SlashCommandVisibility.GUILD);
 
-
         SubcommandData applicationSubCommand =
                 new SubcommandData(APPLICATION_SUBCOMMAND, "Choose an application from our list")
                     .addOptions(new OptionData(OptionType.STRING, APPLICATION_OPTION,
                             "the application", true).addChoices(VC_APPLICATIONS))
                     .addOptions(inviteOptions);
 
-
         SubcommandData idSubCommand =
                 new SubcommandData("id", "specify the ID for the application manually")
                     .addOption(OptionType.STRING, ID_OPTION, "the ID of the application", true)
                     .addOptions(inviteOptions);
 
-
         getData().addSubcommands(applicationSubCommand, idSubCommand);
     }
-
 
     @Override
     public void onSlashCommand(SlashCommandInteractionEvent event) {
@@ -191,7 +185,6 @@ public final class VcActivityCommand extends SlashCommandAdapter {
         handleSubcommand(event, voiceChannel, applicationId, maxUses, maxAgeDays, applicationName);
     }
 
-    @Nonnull
     private static <K, V> Optional<K> getKeyByValue(Map<K, V> map, V value) {
         for (Map.Entry<K, V> entry : map.entrySet()) {
             if (value.equals(entry.getKey())) {
@@ -206,7 +199,6 @@ public final class VcActivityCommand extends SlashCommandAdapter {
             VoiceChannel voiceChannel, String applicationId, @Nullable Integer maxUses,
             @Nullable Integer maxAgeDays, String applicationName) {
 
-
         voiceChannel.createInvite()
             .setTargetApplication(applicationId)
             .setMaxUses(maxUses)
@@ -217,7 +209,6 @@ public final class VcActivityCommand extends SlashCommandAdapter {
 
     }
 
-    @Nonnull
     private static ReplyCallbackAction replyInvite(SlashCommandInteractionEvent event,
             Invite invite, String applicationName) {
         return event.reply("""

--- a/application/src/main/java/org/togetherjava/tjbot/commands/basic/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/basic/package-info.java
@@ -2,7 +2,10 @@
  * This package offers some basic commands that act as example for how to use the command system of
  * the application.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.basic;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdGenerator.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdGenerator.java
@@ -7,8 +7,6 @@ import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 import org.togetherjava.tjbot.commands.SlashCommand;
 
-import javax.annotation.Nonnull;
-
 /**
  * Provides component ID generation.
  * <p>
@@ -37,6 +35,5 @@ public interface ComponentIdGenerator {
      * @throws InvalidComponentIdFormatException if the given component ID was in an unexpected
      *         format and could not be serialized
      */
-    @Nonnull
     String generate(ComponentId componentId, Lifespan lifespan);
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdParser.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdParser.java
@@ -6,7 +6,6 @@ import net.dv8tion.jda.api.interactions.components.ComponentInteraction;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 
-import javax.annotation.Nonnull;
 import java.util.Optional;
 
 /**
@@ -38,6 +37,5 @@ public interface ComponentIdParser {
      * @throws InvalidComponentIdFormatException if the component ID associated to the given UUID
      *         was in an unexpected format and could not be deserialized
      */
-    @Nonnull
     Optional<ComponentId> parse(String uuid);
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdStore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/componentids/ComponentIdStore.java
@@ -13,7 +13,6 @@ import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.ComponentIds;
 import org.togetherjava.tjbot.db.generated.tables.records.ComponentIdsRecord;
 
-import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
@@ -155,7 +154,6 @@ public final class ComponentIdStore implements AutoCloseable {
      *         format and could not be serialized
      */
     @SuppressWarnings("WeakerAccess")
-    @Nonnull
     public Optional<ComponentId> get(UUID uuid) {
         synchronized (storeLock) {
             // Get it from the cache or, if not found, the database
@@ -217,7 +215,6 @@ public final class ComponentIdStore implements AutoCloseable {
         }
     }
 
-    @Nonnull
     private Optional<ComponentId> getFromDatabase(UUID uuid) {
         return database.read(context -> Optional
             .ofNullable(context.selectFrom(ComponentIds.COMPONENT_IDS)
@@ -294,7 +291,6 @@ public final class ComponentIdStore implements AutoCloseable {
         }
     }
 
-    @Nonnull
     private static String serializeComponentId(ComponentId componentId) {
         try {
             return CSV.writerFor(ComponentId.class)
@@ -305,7 +301,6 @@ public final class ComponentIdStore implements AutoCloseable {
         }
     }
 
-    @Nonnull
     private static ComponentId deserializeComponentId(String componentId) {
         try {
             return CSV.readerFor(ComponentId.class)

--- a/application/src/main/java/org/togetherjava/tjbot/commands/componentids/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/componentids/package-info.java
@@ -10,7 +10,10 @@
  * {@link org.togetherjava.tjbot.commands.componentids.ComponentIdGenerator} and
  * {@link org.togetherjava.tjbot.commands.componentids.ComponentIdParser}.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.componentids;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.MessageReceiverAdapter;
 import org.togetherjava.tjbot.config.Config;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -79,7 +78,6 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
             return;
         }
 
-
         List<Message.Attachment> attachments = event.getMessage()
             .getAttachments()
             .stream()
@@ -109,7 +107,6 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
         return extensionFilter.contains(extension);
     }
 
-
     private void processAttachments(MessageReceivedEvent event,
             List<Message.Attachment> attachments) {
 
@@ -133,7 +130,6 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
         sendResponse(event, url);
     }
 
-    @Nonnull
     private String readAttachment(InputStream stream) {
         try (stream) {
             return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
@@ -142,7 +138,6 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
         }
     }
 
-    @Nonnull
     private String getNameOf(Message.Attachment attachment) {
         String fileName = attachment.getFileName();
         String fileExtension = attachment.getFileExtension();
@@ -163,7 +158,6 @@ public class FileSharingMessageListener extends MessageReceiverAdapter {
         return fileName;
     }
 
-    @Nonnull
     private String uploadToGist(GistRequest jsonRequest) {
         String body;
         try {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/GistResponse.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/GistResponse.java
@@ -3,8 +3,6 @@ package org.togetherjava.tjbot.commands.filesharing;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import javax.annotation.Nonnull;
-
 /**
  * @see <a href="https://docs.github.com/en/rest/gists/gists#create-a-gist">Create a Gist via
  *      API</a>
@@ -14,7 +12,6 @@ final class GistResponse {
     @JsonProperty("html_url")
     private String htmlUrl;
 
-    @Nonnull
     public String getHtmlUrl() {
         return htmlUrl;
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/package-info.java
@@ -2,7 +2,10 @@
  * This package offers all the functionality for automatically uploading files to sharing services.
  * The core class is {@link org.togetherjava.tjbot.commands.filesharing.FileSharingMessageListener}.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.filesharing;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
@@ -15,7 +15,6 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
-import javax.annotation.Nonnull;
 import java.util.Optional;
 
 import static org.togetherjava.tjbot.commands.help.HelpSystemHelper.TITLE_COMPACT_LENGTH_MAX;
@@ -119,7 +118,6 @@ public final class AskCommand extends SlashCommandAdapter {
         return false;
     }
 
-    @Nonnull
     private RestAction<Message> handleEvent(InteractionHook eventHook, ThreadChannel threadChannel,
             Member author, String title, String category, Guild guild) {
         helper.writeHelpThreadToDatabase(author, threadChannel);
@@ -128,7 +126,6 @@ public final class AskCommand extends SlashCommandAdapter {
             .flatMap(any -> helper.sendExplanationMessage(threadChannel));
     }
 
-    @Nonnull
     private RestAction<Message> sendInitialMessage(Guild guild, ThreadChannel threadChannel,
             Member author, String title, String category) {
         String roleMentionDescription = helper.handleFindRoleForCategory(category, guild)
@@ -148,7 +145,6 @@ public final class AskCommand extends SlashCommandAdapter {
             .flatMap(message -> message.editMessage(contentWithRole));
     }
 
-    @Nonnull
     private static RestAction<Message> notifyUser(InteractionHook eventHook,
             IMentionable threadChannel) {
         return eventHook.editOriginal("""

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/AutoPruneHelperRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/AutoPruneHelperRoutine.java
@@ -12,7 +12,6 @@ import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.moderation.ModAuditLogWriter;
 
-import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.Period;
@@ -59,7 +58,6 @@ public final class AutoPruneHelperRoutine implements Routine {
     }
 
     @Override
-    @Nonnull
     public Schedule createSchedule() {
         return new Schedule(ScheduleMode.FIXED_RATE, 0, 1, TimeUnit.HOURS);
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/BotMessageCleanup.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/BotMessageCleanup.java
@@ -13,7 +13,6 @@ import org.togetherjava.tjbot.commands.Routine;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.config.HelpSystemConfig;
 
-import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -54,7 +53,6 @@ public final class BotMessageCleanup implements Routine {
     }
 
     @Override
-    @Nonnull
     public Schedule createSchedule() {
         return new Schedule(ScheduleMode.FIXED_RATE, 1, 1, TimeUnit.MINUTES);
     }
@@ -79,7 +77,6 @@ public final class BotMessageCleanup implements Routine {
             .queue();
     }
 
-    @Nonnull
     private Optional<TextChannel> handleRequireStagingChannel(Guild guild) {
         Optional<TextChannel> maybeChannel = guild.getTextChannelCache()
             .stream()
@@ -108,7 +105,6 @@ public final class BotMessageCleanup implements Routine {
         return deleteWhen.isBefore(Instant.now());
     }
 
-    @Nonnull
     private static RestAction<Void> cleanupBotMessages(GuildMessageChannel channel,
             Collection<? extends Message> messages) {
         logger.debug("Cleaning up old bot messages in the staging channel");

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpCategoryCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ChangeHelpCategoryCommand.java
@@ -15,7 +15,6 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
-import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Locale;
@@ -96,7 +95,6 @@ public final class ChangeHelpCategoryCommand extends SlashCommandAdapter {
             .queue();
     }
 
-    @Nonnull
     private RestAction<Message> sendCategoryChangedMessage(Guild guild, InteractionHook hook,
             ThreadChannel helpThread, String category) {
         String changedContent = "Changed the category to **%s**.".formatted(category);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -13,7 +13,6 @@ import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.HelpThreads;
 import org.togetherjava.tjbot.db.generated.tables.records.HelpThreadsRecord;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.awt.Color;
 import java.io.InputStream;
@@ -73,7 +72,6 @@ public final class HelpSystemHelper {
         categoryRoleSuffix = helpConfig.getCategoryRoleSuffix();
     }
 
-    @Nonnull
     RestAction<Message> sendExplanationMessage(MessageChannel threadChannel) {
         boolean useCodeSyntaxExampleImage = true;
         InputStream codeSyntaxExampleData =
@@ -120,12 +118,10 @@ public final class HelpSystemHelper {
         });
     }
 
-    @Nonnull
     private static MessageEmbed embedWith(CharSequence message) {
         return embedWith(message, null);
     }
 
-    @Nonnull
     private static MessageEmbed embedWith(CharSequence message, @Nullable String imageUrl) {
         return new EmbedBuilder().setColor(AMBIENT_COLOR)
             .setDescription(message)
@@ -133,7 +129,6 @@ public final class HelpSystemHelper {
             .build();
     }
 
-    @Nonnull
     Optional<Role> handleFindRoleForCategory(String category, Guild guild) {
         String roleName = category + categoryRoleSuffix;
         Optional<Role> maybeHelperRole = guild.getRolesByName(roleName, true).stream().findAny();
@@ -145,12 +140,10 @@ public final class HelpSystemHelper {
         return maybeHelperRole;
     }
 
-    @Nonnull
     Optional<String> getCategoryOfChannel(Channel channel) {
         return Optional.ofNullable(HelpThreadName.ofChannelName(channel.getName()).category);
     }
 
-    @Nonnull
     RestAction<Void> renameChannelToCategory(GuildChannel channel, String category) {
         HelpThreadName currentName = HelpThreadName.ofChannelName(channel.getName());
         HelpThreadName nextName =
@@ -159,7 +152,6 @@ public final class HelpSystemHelper {
         return renameChannel(channel, currentName, nextName);
     }
 
-    @Nonnull
     RestAction<Void> renameChannelToTitle(GuildChannel channel, String title) {
         HelpThreadName currentName = HelpThreadName.ofChannelName(channel.getName());
         HelpThreadName nextName =
@@ -168,7 +160,6 @@ public final class HelpSystemHelper {
         return renameChannel(channel, currentName, nextName);
     }
 
-    @Nonnull
     RestAction<Void> renameChannelToActivity(GuildChannel channel, ThreadActivity activity) {
         HelpThreadName currentName = HelpThreadName.ofChannelName(channel.getName());
         HelpThreadName nextName =
@@ -177,7 +168,6 @@ public final class HelpSystemHelper {
         return renameChannel(channel, currentName, nextName);
     }
 
-    @Nonnull
     private RestAction<Void> renameChannel(GuildChannel channel, HelpThreadName currentName,
             HelpThreadName nextName) {
         if (currentName.equals(nextName)) {
@@ -192,7 +182,6 @@ public final class HelpSystemHelper {
         return isOverviewChannelName.test(channelName);
     }
 
-    @Nonnull
     String getOverviewChannelPattern() {
         return overviewChannelPattern;
     }
@@ -201,7 +190,6 @@ public final class HelpSystemHelper {
         return isStagingChannelName.test(channelName);
     }
 
-    @Nonnull
     String getStagingChannelPattern() {
         return stagingChannelPattern;
     }
@@ -214,7 +202,6 @@ public final class HelpSystemHelper {
                 && !titleCompact.toLowerCase(Locale.US).contains("help");
     }
 
-    @Nonnull
     Optional<TextChannel> handleRequireOverviewChannel(Guild guild,
             Consumer<? super String> consumeChannelPatternIfNotFound) {
         Predicate<String> isChannelName = this::isOverviewChannelName;
@@ -232,7 +219,6 @@ public final class HelpSystemHelper {
         return maybeChannel;
     }
 
-    @Nonnull
     Optional<TextChannel> handleRequireOverviewChannelForAsk(Guild guild,
             MessageChannel respondTo) {
         return handleRequireOverviewChannel(guild, channelPattern -> {
@@ -246,7 +232,6 @@ public final class HelpSystemHelper {
         });
     }
 
-    @Nonnull
     List<ThreadChannel> getActiveThreadsIn(TextChannel channel) {
         return channel.getThreadChannels()
             .stream()
@@ -256,7 +241,6 @@ public final class HelpSystemHelper {
 
     record HelpThreadName(@Nullable ThreadActivity activity, @Nullable String category,
             String title) {
-        @Nonnull
         static HelpThreadName ofChannelName(CharSequence channelName) {
             Matcher matcher = EXTRACT_HELP_NAME_PATTERN.matcher(channelName);
 
@@ -274,7 +258,6 @@ public final class HelpSystemHelper {
             return new HelpThreadName(activity, category, title);
         }
 
-        @Nonnull
         String toChannelName() {
             String activityText = activity == null ? "" : activity.getSymbol() + " ";
             String categoryText = category == null ? "" : "[%s] ".formatted(category);
@@ -294,12 +277,10 @@ public final class HelpSystemHelper {
             this.symbol = symbol;
         }
 
-        @Nonnull
         public String getSymbol() {
             return symbol;
         }
 
-        @Nonnull
         static ThreadActivity ofSymbol(String symbol) {
             return Stream.of(values())
                 .filter(activity -> activity.getSymbol().equals(symbol))

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadActivityUpdater.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadActivityUpdater.java
@@ -7,7 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.Routine;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -38,7 +37,6 @@ public final class HelpThreadActivityUpdater implements Routine {
     }
 
     @Override
-    @Nonnull
     public Schedule createSchedule() {
         return new Schedule(ScheduleMode.FIXED_RATE, 1, SCHEDULE_MINUTES, TimeUnit.MINUTES);
     }
@@ -74,7 +72,6 @@ public final class HelpThreadActivityUpdater implements Routine {
             .queue();
     }
 
-    @Nonnull
     private static RestAction<HelpSystemHelper.ThreadActivity> determineActivity(
             MessageChannel channel) {
         return channel.getHistory().retrievePast(ACTIVITY_DETERMINE_MESSAGE_LIMIT).map(messages -> {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadAutoArchiver.java
@@ -8,7 +8,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.Routine;
 
-import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -36,7 +35,6 @@ public final class HelpThreadAutoArchiver implements Routine {
     }
 
     @Override
-    @Nonnull
     public Schedule createSchedule() {
         return new Schedule(ScheduleMode.FIXED_RATE, 0, SCHEDULE_MINUTES, TimeUnit.MINUTES);
     }
@@ -67,7 +65,6 @@ public final class HelpThreadAutoArchiver implements Routine {
             .forEach(activeThread -> autoArchiveForThread(activeThread, archiveAfterMoment));
     }
 
-    @Nonnull
     private Instant computeArchiveAfterMoment() {
         return Instant.now().minus(ARCHIVE_AFTER_INACTIVITY_OF);
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadMetadataPurger.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadMetadataPurger.java
@@ -7,7 +7,6 @@ import org.togetherjava.tjbot.commands.Routine;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.HelpThreads;
 
-import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.time.Period;
 import java.util.concurrent.TimeUnit;
@@ -30,7 +29,6 @@ public class HelpThreadMetadataPurger implements Routine {
     }
 
     @Override
-    @Nonnull
     public Schedule createSchedule() {
         return new Schedule(ScheduleMode.FIXED_RATE, 0, 4, TimeUnit.HOURS);
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
@@ -12,7 +12,6 @@ import org.togetherjava.tjbot.commands.MessageReceiverAdapter;
 import org.togetherjava.tjbot.commands.Routine;
 import org.togetherjava.tjbot.config.Config;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.Executors;
@@ -59,7 +58,6 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
     }
 
     @Override
-    @Nonnull
     public Schedule createSchedule() {
         return new Schedule(ScheduleMode.FIXED_RATE, 1, 1, TimeUnit.MINUTES);
     }
@@ -124,7 +122,6 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
             .queue();
     }
 
-    @Nonnull
     private String createDescription(Collection<ThreadChannel> activeThreads) {
         if (activeThreads.isEmpty()) {
             return "Currently none.";
@@ -150,7 +147,6 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
             .collect(Collectors.joining("\n\n"));
     }
 
-    @Nonnull
     private static RestAction<Optional<Message>> getStatusMessage(MessageChannel channel) {
         return channel.getHistory()
             .retrievePast(1)
@@ -168,7 +164,6 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
         return content.startsWith(STATUS_TITLE);
     }
 
-    @Nonnull
     private RestAction<Message> sendUpdatedOverview(@Nullable Message statusMessage,
             Message updatedStatusMessage, MessageChannel overviewChannel) {
         logger.debug("Sending the updated question overview");
@@ -203,7 +198,6 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
             return "**%s**:%n%s".formatted(category, threadListText);
         }
 
-        @Nonnull
         static CategoryWithThreads ofEntry(
                 Map.Entry<String, ? extends List<ThreadChannel>> categoryAndThreads) {
             return new CategoryWithThreads(categoryAndThreads.getKey(),

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
@@ -15,7 +15,6 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.MessageReceiverAdapter;
 import org.togetherjava.tjbot.config.Config;
 
-import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
@@ -125,7 +124,6 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
         return false;
     }
 
-    @Nonnull
     private Optional<HelpThread> getLastHelpThreadIfOnCooldown(long userId) {
         return Optional.ofNullable(userIdToLastHelpThread.getIfPresent(userId))
             .filter(lastHelpThread -> {
@@ -137,7 +135,6 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
             });
     }
 
-    @Nonnull
     private static String createTitle(String message) {
         String titleCandidate;
         if (message.length() < TITLE_MAX_LENGTH) {
@@ -156,7 +153,6 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
         return HelpSystemHelper.isTitleValid(titleCandidate) ? titleCandidate : "Untitled";
     }
 
-    @Nonnull
     private RestAction<?> handleEvent(ThreadChannel threadChannel, Message message, String title) {
         Member author = message.getMember();
         helper.writeHelpThreadToDatabase(author, threadChannel);
@@ -169,13 +165,11 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
             .flatMap(any -> helper.sendExplanationMessage(threadChannel));
     }
 
-    @Nonnull
     private static RestAction<Void> inviteUsersToThread(ThreadChannel threadChannel,
             Member author) {
         return threadChannel.addThreadMember(author);
     }
 
-    @Nonnull
     private static MessageAction sendInitialMessage(ThreadChannel threadChannel,
             Message originalMessage, String title) {
         String content = originalMessage.getContentRaw();
@@ -194,11 +188,9 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
                         Please use `/change-help-category` to greatly increase the visibility of the question."""
                     .formatted(author, title)).setEmbeds(embed).build();
 
-
         return threadChannel.sendMessage(threadMessage);
     }
 
-    @Nonnull
     private static MessageAction notifyUser(IMentionable threadChannel, Message message) {
         return message.getChannel()
             .sendMessage(

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/package-info.java
@@ -2,7 +2,10 @@
  * This package offers all functionality for the help system. For example commands that let users
  * ask questions, such as {@link org.togetherjava.tjbot.commands.help.AskCommand}.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.help;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/TeXCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/TeXCommand.java
@@ -14,7 +14,6 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
-import javax.annotation.Nonnull;
 import javax.imageio.ImageIO;
 import java.awt.Color;
 import java.awt.Image;
@@ -97,7 +96,6 @@ public final class TeXCommand extends SlashCommandAdapter {
         }
     }
 
-    @Nonnull
     private Image renderImage(TeXFormula formula) {
         Image image = formula.createBufferedImage(TeXConstants.STYLE_DISPLAY, DEFAULT_IMAGE_SIZE,
                 FOREGROUND_COLOR, BACKGROUND_COLOR);
@@ -117,7 +115,6 @@ public final class TeXCommand extends SlashCommandAdapter {
             .queue();
     }
 
-    @Nonnull
     private ByteArrayOutputStream getRenderedTextImageStream(Image image) throws IOException {
         BufferedImage renderedTextImage = new BufferedImage(image.getWidth(null),
                 image.getHeight(null), BufferedImage.TYPE_4BYTE_ABGR);
@@ -137,7 +134,6 @@ public final class TeXCommand extends SlashCommandAdapter {
      * @param latex the latex to convert
      * @return the converted latex
      */
-    @Nonnull
     private String convertInlineLatexToFull(String latex) {
         if (isInvalidInlineFormat(latex)) {
             throw new ParseException(INVALID_INLINE_FORMAT_ERROR_MESSAGE);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/WolframAlphaHandler.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/WolframAlphaHandler.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.mathcommands.wolframalpha.api.Error;
 import org.togetherjava.tjbot.commands.mathcommands.wolframalpha.api.*;
 
-import javax.annotation.Nonnull;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -73,7 +72,6 @@ final class WolframAlphaHandler {
      * @param apiResponse response of the Wolfram Alpha API query
      * @return user-friendly message for display, as list of embeds
      */
-    @Nonnull
     HandlerResponse handleApiResponse(HttpResponse<String> apiResponse) {
         // Check status code
         int statusCode = apiResponse.statusCode();
@@ -111,7 +109,6 @@ final class WolframAlphaHandler {
         return handleSuccessfulResponse(queryResult);
     }
 
-    @Nonnull
     private HandlerResponse handleMisunderstoodQuery(QueryResult result) {
         StringJoiner output = new StringJoiner("\n");
         output.add("Sorry, I did not understand your query.");
@@ -152,7 +149,6 @@ final class WolframAlphaHandler {
         return responseOf(output.toString());
     }
 
-    @Nonnull
     private static <E> String createBulletPointList(Collection<? extends E> elements,
             Function<E, String> elementToText) {
         return elements.stream()
@@ -161,7 +157,6 @@ final class WolframAlphaHandler {
             .collect(Collectors.joining("\n"));
     }
 
-    @Nonnull
     private HandlerResponse handleSuccessfulResponse(QueryResult queryResult) {
         StringJoiner messages = new StringJoiner("\n\n");
         messages.add("Click the link to see full results.");
@@ -201,7 +196,6 @@ final class WolframAlphaHandler {
         return responseOf(messages.toString(), tilesToDisplay);
     }
 
-    @Nonnull
     private HandlerResponse responseOf(CharSequence text) {
         MessageEmbed embed = new EmbedBuilder().setTitle(buildTitle(), userApiQuery)
             .setDescription(text)
@@ -211,7 +205,6 @@ final class WolframAlphaHandler {
         return new HandlerResponse(List.of(embed), List.of());
     }
 
-    @Nonnull
     private HandlerResponse responseOf(CharSequence text,
             Collection<? extends BufferedImage> tiles) {
         List<MessageEmbed> embeds = new ArrayList<>();
@@ -237,14 +230,12 @@ final class WolframAlphaHandler {
         return new HandlerResponse(embeds, attachments);
     }
 
-    @Nonnull
     private String buildTitle() {
         return query + " - " + SERVICE_NAME;
     }
 
     record HandlerResponse(List<MessageEmbed> embeds, List<Attachment> attachments) {
     }
-
 
     record Attachment(String name, byte[] data) {
         @Override

--- a/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/WolframAlphaImages.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/WolframAlphaImages.java
@@ -3,7 +3,6 @@ package org.togetherjava.tjbot.commands.mathcommands.wolframalpha;
 import org.togetherjava.tjbot.commands.mathcommands.wolframalpha.api.SubPod;
 import org.togetherjava.tjbot.commands.mathcommands.wolframalpha.api.WolframAlphaImage;
 
-import javax.annotation.Nonnull;
 import javax.imageio.ImageIO;
 import java.awt.Color;
 import java.awt.Font;
@@ -39,7 +38,6 @@ class WolframAlphaImages {
         throw new UnsupportedOperationException("Utility class, construction not supported");
     }
 
-    @Nonnull
     static BufferedImage renderTitle(String title) {
         Rectangle2D titleBounds = TITLE_FONT.getStringBounds(title, TITLE_RENDER_CONTEXT);
         int widthPx = (int) Math.ceil(titleBounds.getWidth()) + 2 * IMAGE_MARGIN_PX;
@@ -56,7 +54,6 @@ class WolframAlphaImages {
         return image;
     }
 
-    @Nonnull
     static BufferedImage renderSubPod(SubPod subPod) {
         WolframAlphaImage sourceImage = subPod.getImage();
 
@@ -77,12 +74,10 @@ class WolframAlphaImages {
         return destinationImage;
     }
 
-    @Nonnull
     static BufferedImage renderFooter() {
         return new BufferedImage(1, IMAGE_MARGIN_PX, BufferedImage.TYPE_4BYTE_ABGR);
     }
 
-    @Nonnull
     static List<BufferedImage> combineImagesIntoTiles(Collection<? extends BufferedImage> images,
             int maxTileHeight) {
         if (images.isEmpty()) {
@@ -124,7 +119,6 @@ class WolframAlphaImages {
         return tileHeight != 0 && tileHeight + heightOfImageToAdd > maxTileHeight;
     }
 
-    @Nonnull
     private static BufferedImage combineImages(Collection<? extends BufferedImage> images,
             int widthPx) {
         if (images.isEmpty()) {
@@ -151,7 +145,6 @@ class WolframAlphaImages {
         return destinationImage;
     }
 
-    @Nonnull
     static byte[] imageToBytes(RenderedImage img) {
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             ImageIO.write(img, IMAGE_FORMAT, outputStream);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/api/DidYouMeans.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/api/DidYouMeans.java
@@ -52,6 +52,4 @@ public final class DidYouMeans {
         this.didYouMeanTips = new ArrayList<>(didYouMeanTips);
     }
 
-
-
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/api/Error.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/api/Error.java
@@ -32,5 +32,4 @@ public final class Error {
         this.message = message;
     }
 
-
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/api/LanguageMessage.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/api/LanguageMessage.java
@@ -43,5 +43,4 @@ public final class LanguageMessage {
         this.other = other;
     }
 
-
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/api/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/api/package-info.java
@@ -3,7 +3,10 @@
  * <a href="https://products.wolframalpha.com/docs/WolframAlpha-API-Reference.pdf">WolframAlpha
  * API</a>.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.mathcommands.wolframalpha.api;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mathcommands/wolframalpha/package-info.java
@@ -2,7 +2,10 @@
  * This packages offers all the functionality for the wolfram-alpha command. Sending queries to
  * their official API, rendering results and displaying them.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.mathcommands.wolframalpha;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/mediaonly/MediaOnlyChannelListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/mediaonly/MediaOnlyChannelListener.java
@@ -10,7 +10,6 @@ import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import org.togetherjava.tjbot.commands.MessageReceiverAdapter;
 import org.togetherjava.tjbot.config.Config;
 
-import javax.annotation.Nonnull;
 import java.awt.Color;
 import java.util.regex.Pattern;
 
@@ -32,7 +31,6 @@ public final class MediaOnlyChannelListener extends MessageReceiverAdapter {
         super(Pattern.compile(config.getMediaOnlyChannelPattern()));
     }
 
-
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
         if (event.getAuthor().isBot() || event.isWebhookMessage()) {
@@ -50,17 +48,14 @@ public final class MediaOnlyChannelListener extends MessageReceiverAdapter {
                 && !message.getContentRaw().contains("http");
     }
 
-    @Nonnull
     private AuditableRestAction<Void> deleteMessage(MessageReceivedEvent event) {
         return event.getMessage().delete();
     }
 
-    @Nonnull
     private RestAction<Message> dmUser(MessageReceivedEvent event) {
         return dmUser(event.getMessage());
     }
 
-    @Nonnull
     private RestAction<Message> dmUser(Message originalMessage) {
         String originalMessageContent = originalMessage.getContentRaw();
         MessageEmbed originalMessageEmbed =

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ActionRecord.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ActionRecord.java
@@ -2,7 +2,6 @@ package org.togetherjava.tjbot.commands.moderation;
 
 import org.togetherjava.tjbot.db.generated.tables.records.ModerationActionsRecord;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.time.Instant;
 
@@ -29,7 +28,6 @@ public record ActionRecord(int caseId, Instant issuedAt, long guildId, long auth
      * @param action the action to convert
      * @return the corresponding action record
      */
-    @Nonnull
     static ActionRecord of(ModerationActionsRecord action) {
         return new ActionRecord(action.getCaseId(), action.getIssuedAt(), action.getGuildId(),
                 action.getAuthorId(), action.getTargetId(),

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/AuditCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/AuditCommand.java
@@ -17,7 +17,6 @@ import net.dv8tion.jda.internal.requests.CompletedRestAction;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -87,7 +86,6 @@ public final class AuditCommand extends SlashCommandAdapter {
      *        can contain {@link AuditCommand#MAX_PAGE_LENGTH} actions, {@code -1} encodes the last
      *        page
      */
-    @Nonnull
     private RestAction<Message> auditUser(long guildId, long targetId, long callerId,
             int pageNumber, JDA jda) {
         List<ActionRecord> actions = actionsStore.getActionsByTargetAscending(guildId, targetId);
@@ -109,7 +107,6 @@ public final class AuditCommand extends SlashCommandAdapter {
                     guildId, targetId, callerId));
     }
 
-    @Nonnull
     private List<List<ActionRecord>> groupActionsByPages(List<ActionRecord> actions) {
         List<List<ActionRecord>> groupedActions = new ArrayList<>();
         for (int i = 0; i < actions.size(); i++) {
@@ -127,7 +124,6 @@ public final class AuditCommand extends SlashCommandAdapter {
         return Math.min(Math.max(minInclusive, value), maxInclusive);
     }
 
-    @Nonnull
     private static EmbedBuilder createSummaryEmbed(User user, Collection<ActionRecord> actions) {
         return new EmbedBuilder().setTitle("Audit log of **%s**".formatted(user.getAsTag()))
             .setAuthor(user.getName(), null, user.getAvatarUrl())
@@ -135,7 +131,6 @@ public final class AuditCommand extends SlashCommandAdapter {
             .setColor(ModerationUtils.AMBIENT_COLOR);
     }
 
-    @Nonnull
     private static String createSummaryMessageDescription(Collection<ActionRecord> actions) {
         int actionAmount = actions.size();
 
@@ -161,7 +156,6 @@ public final class AuditCommand extends SlashCommandAdapter {
         return shortSummary + "\n" + typeCountSummary;
     }
 
-    @Nonnull
     private RestAction<EmbedBuilder> attachEmbedFields(EmbedBuilder auditEmbed,
             List<? extends List<ActionRecord>> groupedActions, int pageNumber, int totalPages,
             JDA jda) {
@@ -181,7 +175,6 @@ public final class AuditCommand extends SlashCommandAdapter {
         });
     }
 
-    @Nonnull
     private static RestAction<MessageEmbed.Field> actionToField(ActionRecord action, JDA jda) {
         return jda.retrieveUserById(action.authorId())
             .map(author -> author == null ? "(unknown user)" : author.getAsTag())
@@ -200,12 +193,10 @@ public final class AuditCommand extends SlashCommandAdapter {
             });
     }
 
-    @Nonnull
     private static String formatTime(Instant when) {
         return TimeUtil.getDateTimeString(when.atOffset(ZoneOffset.UTC));
     }
 
-    @Nonnull
     private Message attachPageTurnButtons(EmbedBuilder auditEmbed, int pageNumber, int totalPages,
             long guildId, long targetId, long callerId) {
         var messageBuilder = new MessageBuilder(auditEmbed.build());
@@ -219,7 +210,6 @@ public final class AuditCommand extends SlashCommandAdapter {
         return messageBuilder.setActionRows(pageTurnButtons).build();
     }
 
-    @Nonnull
     private ActionRow createPageTurnButtons(long guildId, long targetId, long callerId,
             int pageNumber, int totalPages) {
         int previousButtonTurnPageBy = -1;
@@ -239,7 +229,6 @@ public final class AuditCommand extends SlashCommandAdapter {
         return ActionRow.of(previousButton, nextButton);
     }
 
-    @Nonnull
     private Button createPageTurnButton(String label, long guildId, long targetId, long callerId,
             long pageNumber, int turnPageBy) {
         return Button.primary(generateComponentId(String.valueOf(guildId), String.valueOf(targetId),

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/BanCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/BanCommand.java
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.List;
@@ -100,7 +99,6 @@ public final class BanCommand extends SlashCommandAdapter {
             .map(Result::isSuccess);
     }
 
-    @Nonnull
     private static MessageEmbed sendFeedback(boolean hasSentDm, User target, Member author,
             @Nullable ModerationUtils.TemporaryData temporaryData, String reason) {
         String durationText = "The ban duration is: "
@@ -113,7 +111,6 @@ public final class BanCommand extends SlashCommandAdapter {
                 durationText + dmNoticeText, reason);
     }
 
-    @Nonnull
     private static Optional<RestAction<InteractionHook>> handleNotAlreadyBannedResponse(
             Throwable alreadyBannedFailure, IReplyCallback event, Guild guild, User target) {
         if (alreadyBannedFailure instanceof ErrorResponseException errorResponseException) {
@@ -136,7 +133,6 @@ public final class BanCommand extends SlashCommandAdapter {
             .setEphemeral(true));
     }
 
-    @Nonnull
     private RestAction<InteractionHook> banUserFlow(User target, Member author,
             @Nullable ModerationUtils.TemporaryData temporaryData, String reason,
             int deleteHistoryDays, Guild guild, SlashCommandInteractionEvent event) {
@@ -147,7 +143,6 @@ public final class BanCommand extends SlashCommandAdapter {
             .flatMap(event::replyEmbeds);
     }
 
-    @Nonnull
     private AuditableRestAction<Void> banUser(User target, Member author,
             @Nullable ModerationUtils.TemporaryData temporaryData, String reason,
             int deleteHistoryDays, Guild guild) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/KickCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/KickCommand.java
@@ -17,7 +17,6 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
@@ -66,7 +65,6 @@ public final class KickCommand extends SlashCommandAdapter {
             .queue();
     }
 
-    @Nonnull
     private static RestAction<Boolean> sendDm(ISnowflake target, String reason, Guild guild,
             GenericEvent event) {
         return event.getJDA()
@@ -82,7 +80,6 @@ public final class KickCommand extends SlashCommandAdapter {
             .map(Result::isSuccess);
     }
 
-    @Nonnull
     private AuditableRestAction<Void> kickUser(Member target, Member author, String reason,
             Guild guild) {
         logger.info("'{}' ({}) kicked the user '{}' ({}) from guild '{}' for reason '{}'.",
@@ -95,7 +92,6 @@ public final class KickCommand extends SlashCommandAdapter {
         return guild.kick(target, reason).reason(reason);
     }
 
-    @Nonnull
     private static MessageEmbed sendFeedback(boolean hasSentDm, Member target, Member author,
             String reason) {
         String dmNoticeText = "";
@@ -106,7 +102,6 @@ public final class KickCommand extends SlashCommandAdapter {
                 target.getUser(), dmNoticeText, reason);
     }
 
-    @Nonnull
     private boolean handleChecks(Member bot, Member author, @Nullable Member target,
             CharSequence reason, Guild guild, IReplyCallback event) {
         // Member doesn't exist if attempting to kick a user who is not part of the guild anymore.

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationAction.java
@@ -1,7 +1,5 @@
 package org.togetherjava.tjbot.commands.moderation;
 
-import javax.annotation.Nonnull;
-
 /**
  * All available moderation actions.
  */
@@ -62,7 +60,6 @@ public enum ModerationAction {
      *
      * @return the verb of this action
      */
-    @Nonnull
     public String getVerb() {
         return verb;
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationActionsStore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationActionsStore.java
@@ -5,7 +5,6 @@ import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.ModerationActions;
 import org.togetherjava.tjbot.db.generated.tables.records.ModerationActionsRecord;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.List;
@@ -45,7 +44,6 @@ public final class ModerationActionsStore {
      * 
      * @return a list of all expired actions, chronologically ascending
      */
-    @Nonnull
     public List<ActionRecord> getExpiredActionsAscending() {
         return getActionsAscendingWhere(
                 ModerationActions.MODERATION_ACTIONS.ACTION_EXPIRES_AT.isNotNull()
@@ -62,7 +60,6 @@ public final class ModerationActionsStore {
      * @param actionType the type of action to filter for
      * @return a list of all actions with the given type, chronologically ascending
      */
-    @Nonnull
     public List<ActionRecord> getActionsByTypeAscending(long guildId, ModerationAction actionType) {
         Objects.requireNonNull(actionType);
 
@@ -79,7 +76,6 @@ public final class ModerationActionsStore {
      * @param targetId the id of the target user to filter for
      * @return a list of all actions executed against the target, chronologically ascending
      */
-    @Nonnull
     public List<ActionRecord> getActionsByTargetAscending(long guildId, long targetId) {
         return getActionsFromGuildAscending(guildId,
                 ModerationActions.MODERATION_ACTIONS.TARGET_ID.eq(targetId));
@@ -94,7 +90,6 @@ public final class ModerationActionsStore {
      * @param authorId the id of the author user to filter for
      * @return a list of all actions executed by the author, chronologically ascending
      */
-    @Nonnull
     public List<ActionRecord> getActionsByAuthorAscending(long guildId, long authorId) {
         return getActionsFromGuildAscending(guildId,
                 ModerationActions.MODERATION_ACTIONS.AUTHOR_ID.eq(authorId));
@@ -110,7 +105,6 @@ public final class ModerationActionsStore {
      * @param actionType the type of the action
      * @return the last action issued against the given user of the given type, if present
      */
-    @Nonnull
     public Optional<ActionRecord> findLastActionAgainstTargetByType(long guildId, long targetId,
             ModerationAction actionType) {
         return database
@@ -130,7 +124,6 @@ public final class ModerationActionsStore {
      * @param caseId the actions' case id to search for
      * @return the action with the given case id, if present
      */
-    @Nonnull
     public Optional<ActionRecord> findActionByCaseId(int caseId) {
         return database
             .read(context -> context.selectFrom(ModerationActions.MODERATION_ACTIONS)
@@ -177,7 +170,6 @@ public final class ModerationActionsStore {
         });
     }
 
-    @Nonnull
     private List<ActionRecord> getActionsFromGuildAscending(long guildId, Condition condition) {
         Objects.requireNonNull(condition);
 
@@ -185,7 +177,6 @@ public final class ModerationActionsStore {
                 ModerationActions.MODERATION_ACTIONS.GUILD_ID.eq(guildId).and(condition));
     }
 
-    @Nonnull
     private List<ActionRecord> getActionsAscendingWhere(Condition condition) {
         Objects.requireNonNull(condition);
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/ModerationUtils.java
@@ -8,7 +8,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.config.Config;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.awt.Color;
 import java.time.Instant;
@@ -270,7 +269,6 @@ public class ModerationUtils {
      * @param reason an optional reason for why the action is executed, {@code null} if not desired
      * @return the created response
      */
-    @Nonnull
     static MessageEmbed createActionResponse(User author, ModerationAction action, User target,
             @Nullable String extraMessage, @Nullable String reason) {
         String description = "%s **%s** (id: %s).".formatted(action.getVerb(), target.getAsTag(),
@@ -305,7 +303,6 @@ public class ModerationUtils {
      * @param config the config used to identify the muted role
      * @return the muted role, if found
      */
-    @Nonnull
     public static Optional<Role> getMutedRole(Guild guild, Config config) {
         Predicate<String> isMutedRole = getIsMutedRolePredicate(config);
         return guild.getRoles().stream().filter(role -> isMutedRole.test(role.getName())).findAny();
@@ -328,7 +325,6 @@ public class ModerationUtils {
      * @param config the config used to identify the quarantined role
      * @return the quarantined role, if found
      */
-    @Nonnull
     public static Optional<Role> getQuarantinedRole(Guild guild, Config config) {
         Predicate<String> isQuarantinedRole = getIsQuarantinedRolePredicate(config);
         return guild.getRoles()
@@ -346,7 +342,6 @@ public class ModerationUtils {
      * @return the temporary data represented by the given duration or empty if the duration is
      *         {@code "permanent"}
      */
-    @Nonnull
     static Optional<TemporaryData> computeTemporaryData(String durationText) {
         if (PERMANENT_DURATION.equals(durationText)) {
             return Optional.empty();

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/MuteCommand.java
@@ -15,7 +15,6 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.List;
@@ -68,7 +67,6 @@ public final class MuteCommand extends SlashCommandAdapter {
         event.reply("The user is already muted.").setEphemeral(true).queue();
     }
 
-    @Nonnull
     private static RestAction<Boolean> sendDm(ISnowflake target,
             @Nullable ModerationUtils.TemporaryData temporaryData, String reason, Guild guild,
             GenericEvent event) {
@@ -89,7 +87,6 @@ public final class MuteCommand extends SlashCommandAdapter {
             .map(Result::isSuccess);
     }
 
-    @Nonnull
     private static MessageEmbed sendFeedback(boolean hasSentDm, Member target, Member author,
             @Nullable ModerationUtils.TemporaryData temporaryData, String reason) {
         String durationText = "The mute duration is: "
@@ -102,7 +99,6 @@ public final class MuteCommand extends SlashCommandAdapter {
                 target.getUser(), durationText + dmNoticeText, reason);
     }
 
-    @Nonnull
     private AuditableRestAction<Void> muteUser(Member target, Member author,
             @Nullable ModerationUtils.TemporaryData temporaryData, String reason, Guild guild) {
         String durationMessage =

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/QuarantineCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/QuarantineCommand.java
@@ -14,7 +14,6 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
@@ -59,7 +58,6 @@ public final class QuarantineCommand extends SlashCommandAdapter {
         event.reply("The user is already quarantined.").setEphemeral(true).queue();
     }
 
-    @Nonnull
     private static RestAction<Boolean> sendDm(ISnowflake target, String reason, Guild guild,
             GenericEvent event) {
         String dmMessage =
@@ -78,7 +76,6 @@ public final class QuarantineCommand extends SlashCommandAdapter {
             .map(Result::isSuccess);
     }
 
-    @Nonnull
     private static MessageEmbed sendFeedback(boolean hasSentDm, Member target, Member author,
             String reason) {
         String dmNoticeText = "";
@@ -89,7 +86,6 @@ public final class QuarantineCommand extends SlashCommandAdapter {
                 target.getUser(), dmNoticeText, reason);
     }
 
-    @Nonnull
     private AuditableRestAction<Void> quarantineUser(Member target, Member author, String reason,
             Guild guild) {
         logger.info("'{}' ({}) quarantined the user '{}' ({}) in guild '{}' for reason '{}'.",

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnmuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnmuteCommand.java
@@ -14,7 +14,6 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
@@ -56,7 +55,6 @@ public final class UnmuteCommand extends SlashCommandAdapter {
         event.reply("The user is not muted.").setEphemeral(true).queue();
     }
 
-    @Nonnull
     private static RestAction<Boolean> sendDm(ISnowflake target, String reason, Guild guild,
             GenericEvent event) {
         String dmMessage = """
@@ -71,7 +69,6 @@ public final class UnmuteCommand extends SlashCommandAdapter {
             .map(Result::isSuccess);
     }
 
-    @Nonnull
     private static MessageEmbed sendFeedback(boolean hasSentDm, Member target, Member author,
             String reason) {
         String dmNoticeText = "";
@@ -82,7 +79,6 @@ public final class UnmuteCommand extends SlashCommandAdapter {
                 target.getUser(), dmNoticeText, reason);
     }
 
-    @Nonnull
     private AuditableRestAction<Void> unmuteUser(Member target, Member author, String reason,
             Guild guild) {
         logger.info("'{}' ({}) unmuted the user '{}' ({}) in guild '{}' for reason '{}'.",

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnquarantineCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/UnquarantineCommand.java
@@ -14,7 +14,6 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.config.Config;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
@@ -60,7 +59,6 @@ public final class UnquarantineCommand extends SlashCommandAdapter {
         event.reply("The user is not quarantined.").setEphemeral(true).queue();
     }
 
-    @Nonnull
     private static RestAction<Boolean> sendDm(ISnowflake target, String reason, Guild guild,
             GenericEvent event) {
         String dmMessage = """
@@ -76,7 +74,6 @@ public final class UnquarantineCommand extends SlashCommandAdapter {
             .map(Result::isSuccess);
     }
 
-    @Nonnull
     private static MessageEmbed sendFeedback(boolean hasSentDm, Member target, Member author,
             String reason) {
         String dmNoticeText = "";
@@ -87,7 +84,6 @@ public final class UnquarantineCommand extends SlashCommandAdapter {
                 target.getUser(), dmNoticeText, reason);
     }
 
-    @Nonnull
     private AuditableRestAction<Void> unquarantineUser(Member target, Member author, String reason,
             Guild guild) {
         logger.info("'{}' ({}) unquarantined the user '{}' ({}) in guild '{}' for reason '{}'.",

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/WarnCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/WarnCommand.java
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
@@ -44,7 +43,6 @@ public final class WarnCommand extends SlashCommandAdapter {
         this.actionsStore = Objects.requireNonNull(actionsStore);
     }
 
-    @Nonnull
     private RestAction<InteractionHook> warnUserFlow(User target, Member author, String reason,
             Guild guild, SlashCommandInteractionEvent event) {
         return dmUser(target, reason, guild, event).map(hasSentDm -> {
@@ -55,7 +53,6 @@ public final class WarnCommand extends SlashCommandAdapter {
             .flatMap(event::replyEmbeds);
     }
 
-    @Nonnull
     private static RestAction<Boolean> dmUser(ISnowflake target, String reason, Guild guild,
             SlashCommandInteractionEvent event) {
         return event.getJDA()
@@ -80,7 +77,6 @@ public final class WarnCommand extends SlashCommandAdapter {
                 ModerationAction.WARN, null, reason);
     }
 
-    @Nonnull
     private static MessageEmbed sendFeedback(boolean hasSentDm, User target, Member author,
             String reason) {
         String dmNoticeText = "";

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/WhoIsCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/WhoIsCommand.java
@@ -13,7 +13,6 @@ import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.commands.utils.DiscordClientAction;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import java.awt.Color;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -70,7 +69,6 @@ public final class WhoIsCommand extends SlashCommandAdapter {
     }
 
     @CheckReturnValue
-    @Nonnull
     private static ReplyCallbackAction handleWhoIsUser(final IReplyCallback event, final User user,
             final User.Profile profile) {
         String description = userIdentificationToStringItem(user) + "\n**Is bot:** " + user.isBot()
@@ -86,7 +84,6 @@ public final class WhoIsCommand extends SlashCommandAdapter {
     }
 
     @CheckReturnValue
-    @Nonnull
     private static ReplyCallbackAction handleWhoIsMember(final IReplyCallback event,
             final Member member, final User.Profile profile) {
         User user = member.getUser();
@@ -109,7 +106,6 @@ public final class WhoIsCommand extends SlashCommandAdapter {
         return sendEmbedWithProfileAction(event, embedBuilder.build(), user.getId());
     }
 
-    @Nonnull
     private static ReplyCallbackAction sendEmbedWithProfileAction(final IReplyCallback event,
             MessageEmbed embed, String userId) {
         return event.replyEmbeds(embed)
@@ -117,7 +113,6 @@ public final class WhoIsCommand extends SlashCommandAdapter {
                     DiscordClientAction.General.USER.asLinkButton("Click to see profile!", userId));
     }
 
-    @Nonnull
     private static String voiceStateToStringItem(final Member member) {
         GuildVoiceState voiceState = Objects.requireNonNull(member.getVoiceState(),
                 "The given voiceState cannot be null");
@@ -129,7 +124,6 @@ public final class WhoIsCommand extends SlashCommandAdapter {
         return "\n**In voicechannel:** " + (voiceState.getChannel().getAsMention());
     }
 
-
     /**
      * Generates whois embed based on the given parameters.
      *
@@ -139,7 +133,6 @@ public final class WhoIsCommand extends SlashCommandAdapter {
      * @param effectiveColor the {@link Color} that the embed will become
      * @return the generated {@link EmbedBuilder}
      */
-    @Nonnull
     private static EmbedBuilder generateEmbedBuilder(final Interaction event, final User user,
             final User.Profile profile, final Color effectiveColor) {
 
@@ -162,7 +155,6 @@ public final class WhoIsCommand extends SlashCommandAdapter {
      * @param member the {@link Member} to take the booster properties from
      * @return user readable {@link String}
      */
-    @Nonnull
     private static String possibleBoosterToStringItem(final Member member) {
         OffsetDateTime timeBoosted = member.getTimeBoosted();
 
@@ -180,7 +172,6 @@ public final class WhoIsCommand extends SlashCommandAdapter {
      * @param user the {@link User} to take the identifiers from
      * @return user readable {@link String}
      */
-    @Nonnull
     private static String userIdentificationToStringItem(final User user) {
         return "**Mention:** " + user.getAsMention() + "\n**Tag:** " + user.getAsTag()
                 + "\n**ID:** " + user.getId();
@@ -192,7 +183,6 @@ public final class WhoIsCommand extends SlashCommandAdapter {
      * @param member member to take the Roles from
      * @return user readable {@link String} of the roles
      */
-    @Nonnull
     private static String formatRoles(final Member member) {
         return member.getRoles().stream().map(Role::getAsMention).collect(Collectors.joining(", "));
     }
@@ -204,7 +194,6 @@ public final class WhoIsCommand extends SlashCommandAdapter {
      *        (recommend {@link java.util.EnumSet}
      * @return user readable {@link StringBuilder}
      */
-    @Nonnull
     private static StringBuilder userFlagsToStringItem(final Collection<User.UserFlag> flags) {
         String formattedFlags = formatUserFlags(flags);
         StringBuilder result = hypeSquadToStringItem(flags);
@@ -223,7 +212,6 @@ public final class WhoIsCommand extends SlashCommandAdapter {
      *        (recommend {@link java.util.EnumSet}
      * @return user readable {@link StringBuilder}
      */
-    @Nonnull
     private static StringBuilder hypeSquadToStringItem(final Collection<User.UserFlag> flags) {
         StringBuilder stringBuilder = new StringBuilder("**\nHypesquad:** ");
 
@@ -247,7 +235,6 @@ public final class WhoIsCommand extends SlashCommandAdapter {
      *        (recommend {@link java.util.EnumSet}
      * @return the user readable string
      */
-    @Nonnull
     private static String formatUserFlags(final Collection<User.UserFlag> flags) {
         return flags.stream()
             .map(User.UserFlag::getName)

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/package-info.java
@@ -2,7 +2,10 @@
  * This package offers all the moderation commands from the application such as banning and kicking
  * users.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.moderation;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/scam/ScamBlocker.java
@@ -26,7 +26,6 @@ import org.togetherjava.tjbot.commands.utils.MessageUtils;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.config.ScamBlockerConfig;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.awt.Color;
 import java.util.*;
@@ -84,7 +83,6 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
     }
 
     @Override
-    @Nonnull
     public String getName() {
         return "scam-blocker";
     }
@@ -250,12 +248,10 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
             .queue();
     }
 
-    @Nonnull
     private Optional<TextChannel> getReportChannel(Guild guild) {
         return guild.getTextChannelCache().stream().filter(isReportChannel).findAny();
     }
 
-    @Nonnull
     private ActionRow createConfirmDialog(MessageReceivedEvent event) {
         ComponentIdArguments args = new ComponentIdArguments(mode, event.getGuild().getIdLong(),
                 event.getChannel().getIdLong(), event.getMessageIdLong(),
@@ -266,7 +262,6 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
                 Button.danger(generateComponentId(args), "No"));
     }
 
-    @Nonnull
     private String generateComponentId(ComponentIdArguments args) {
         return Objects.requireNonNull(componentIdGenerator)
             .generate(new ComponentId(getName(), args.toList()), Lifespan.REGULAR);
@@ -334,11 +329,9 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
             .queue(onRetrieveAuthorSuccess, onRetrieveAuthorFailure);
     }
 
-
     private record ComponentIdArguments(ScamBlockerConfig.Mode mode, long guildId, long channelId,
             long messageId, long authorId, String contentHash) {
 
-        @Nonnull
         static ComponentIdArguments fromList(List<String> args) {
             ScamBlockerConfig.Mode mode = ScamBlockerConfig.Mode.valueOf(args.get(0));
             long guildId = Long.parseLong(args.get(1));
@@ -350,7 +343,6 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
                     contentHash);
         }
 
-        @Nonnull
         List<String> toList() {
             return List.of(mode.name(), Long.toString(guildId), Long.toString(channelId),
                     Long.toString(messageId), Long.toString(authorId), contentHash);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/scam/ScamHistoryPurgeRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/scam/ScamHistoryPurgeRoutine.java
@@ -3,7 +3,6 @@ package org.togetherjava.tjbot.commands.moderation.scam;
 import net.dv8tion.jda.api.JDA;
 import org.togetherjava.tjbot.commands.Routine;
 
-import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.time.Period;
 import java.util.concurrent.TimeUnit;
@@ -25,7 +24,6 @@ public final class ScamHistoryPurgeRoutine implements Routine {
     }
 
     @Override
-    @Nonnull
     public Schedule createSchedule() {
         return new Schedule(ScheduleMode.FIXED_RATE, 0, 1, TimeUnit.DAYS);
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/scam/ScamHistoryStore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/scam/ScamHistoryStore.java
@@ -6,7 +6,6 @@ import org.togetherjava.tjbot.commands.utils.Hashing;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.records.ScamHistoryRecord;
 
-import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -71,7 +70,6 @@ public final class ScamHistoryStore {
      * @return identifications of all scam messages that have just been marked deleted, which
      *         previously have not been marked accordingly yet
      */
-    @Nonnull
     public Collection<ScamIdentification> markScamDuplicatesDeleted(Message scam) {
         return markScamDuplicatesDeleted(scam.getGuild().getIdLong(), scam.getAuthor().getIdLong(),
                 hashMessageContent(scam));
@@ -87,7 +85,6 @@ public final class ScamHistoryStore {
      * @return identifications of all scam messages that have just been marked deleted, which
      *         previously have not been marked accordingly yet
      */
-    @Nonnull
     public Collection<ScamIdentification> markScamDuplicatesDeleted(long guildId, long authorId,
             String contentHash) {
         return database.writeAndProvide(context -> {
@@ -139,7 +136,6 @@ public final class ScamHistoryStore {
      * @param message the message to hash
      * @return a text representation of the hash
      */
-    @Nonnull
     public static String hashMessageContent(Message message) {
         return Hashing.bytesToHex(Hashing.hash(HASH_METHOD,
                 message.getContentRaw().getBytes(StandardCharsets.UTF_8)));
@@ -156,7 +152,6 @@ public final class ScamHistoryStore {
      */
     public record ScamIdentification(long guildId, long channelId, long messageId, long authorId,
             String contentHash) {
-        @Nonnull
         private static ScamIdentification ofDatabaseRecord(ScamHistoryRecord scamHistoryRecord) {
             return new ScamIdentification(scamHistoryRecord.getGuildId(),
                     scamHistoryRecord.getChannelId(), scamHistoryRecord.getMessageId(),

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/scam/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/scam/package-info.java
@@ -2,7 +2,10 @@
  * This package offers classes dealing with detecting scam messages and taking appropriate action,
  * see {@link org.togetherjava.tjbot.commands.moderation.scam.ScamBlocker} as main entry point.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.moderation.scam;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/RevocableModerationAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/RevocableModerationAction.java
@@ -5,8 +5,6 @@ import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.requests.RestAction;
 import org.togetherjava.tjbot.commands.moderation.ModerationAction;
 
-import javax.annotation.Nonnull;
-
 /**
  * Represents revocable moderation actions, such as temporary bans. Primarily used by
  * {@link TemporaryModerationRoutine} to identify and revoke such actions.
@@ -35,7 +33,6 @@ interface RevocableModerationAction {
      * 
      * @return the type to apply the temporary action
      */
-    @Nonnull
     ModerationAction getApplyType();
 
     /**
@@ -44,7 +41,6 @@ interface RevocableModerationAction {
      * 
      * @return the type to revoke the temporary action
      */
-    @Nonnull
     ModerationAction getRevokeType();
 
     /**
@@ -55,7 +51,6 @@ interface RevocableModerationAction {
      * @param reason why the action is revoked
      * @return the unsubmitted revocation action
      */
-    @Nonnull
     RestAction<Void> revokeAction(Guild guild, User target, String reason);
 
     /**
@@ -67,6 +62,5 @@ interface RevocableModerationAction {
      * @return a classification of the failure, decides whether the surrounding flow will continue
      *         to handle the error further or not
      */
-    @Nonnull
     FailureIdentification handleRevokeFailure(Throwable failure, long targetId);
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/RevocableRoleBasedAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/RevocableRoleBasedAction.java
@@ -4,8 +4,6 @@ import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-
 /**
  * Role based moderation actions that can be revoked, for example a {@link TemporaryMuteAction} or a
  * {@link TemporaryBanAction}, which are applied implicitly purely by the presence of a role.
@@ -26,7 +24,6 @@ abstract class RevocableRoleBasedAction implements RevocableModerationAction {
     }
 
     @Override
-    @Nonnull
     public FailureIdentification handleRevokeFailure(Throwable failure, long targetId) {
 
         if (failure instanceof ErrorResponseException errorResponseException) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryBanAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryBanAction.java
@@ -9,8 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.moderation.ModerationAction;
 
-import javax.annotation.Nonnull;
-
 /**
  * Action to revoke temporary bans, as applied by
  * {@link org.togetherjava.tjbot.commands.moderation.BanCommand} and executed by
@@ -20,25 +18,21 @@ final class TemporaryBanAction implements RevocableModerationAction {
     private static final Logger logger = LoggerFactory.getLogger(TemporaryBanAction.class);
 
     @Override
-    @Nonnull
     public ModerationAction getApplyType() {
         return ModerationAction.BAN;
     }
 
     @Override
-    @Nonnull
     public ModerationAction getRevokeType() {
         return ModerationAction.UNBAN;
     }
 
     @Override
-    @Nonnull
     public RestAction<Void> revokeAction(Guild guild, User target, String reason) {
         return guild.unban(target).reason(reason);
     }
 
     @Override
-    @Nonnull
     public FailureIdentification handleRevokeFailure(Throwable failure, long targetId) {
         if (failure instanceof ErrorResponseException errorResponseException) {
             if (errorResponseException.getErrorResponse() == ErrorResponse.UNKNOWN_USER) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryModerationRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryModerationRoutine.java
@@ -12,7 +12,6 @@ import org.togetherjava.tjbot.commands.moderation.ModerationAction;
 import org.togetherjava.tjbot.commands.moderation.ModerationActionsStore;
 import org.togetherjava.tjbot.config.Config;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -60,7 +59,6 @@ public final class TemporaryModerationRoutine implements Routine {
     }
 
     @Override
-    @Nonnull
     public Schedule createSchedule() {
         return new Schedule(ScheduleMode.FIXED_DELAY, 5, 5, TimeUnit.MINUTES);
     }
@@ -123,7 +121,6 @@ public final class TemporaryModerationRoutine implements Routine {
             }, failure -> handleFailure(failure, groupIdentifier));
     }
 
-    @Nonnull
     private RestAction<Void> executeRevocation(Guild guild, User target,
             ModerationAction actionType) {
         logger.info("Revoked temporary action {} against user '{}' ({}).", actionType,
@@ -148,7 +145,6 @@ public final class TemporaryModerationRoutine implements Routine {
                 groupIdentifier.targetId, failure);
     }
 
-    @Nonnull
     private RevocableModerationAction getRevocableActionByType(ModerationAction type) {
         return Objects.requireNonNull(typeToRevocableAction.get(type),
                 "Action type is not revocable: " + type);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryMuteAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryMuteAction.java
@@ -7,8 +7,6 @@ import org.togetherjava.tjbot.commands.moderation.ModerationAction;
 import org.togetherjava.tjbot.commands.moderation.ModerationUtils;
 import org.togetherjava.tjbot.config.Config;
 
-import javax.annotation.Nonnull;
-
 /**
  * Action to revoke temporary mutes, as applied by
  * {@link org.togetherjava.tjbot.commands.moderation.MuteCommand} and executed by
@@ -29,19 +27,16 @@ final class TemporaryMuteAction extends RevocableRoleBasedAction {
     }
 
     @Override
-    @Nonnull
     public ModerationAction getApplyType() {
         return ModerationAction.MUTE;
     }
 
     @Override
-    @Nonnull
     public ModerationAction getRevokeType() {
         return ModerationAction.UNMUTE;
     }
 
     @Override
-    @Nonnull
     public RestAction<Void> revokeAction(Guild guild, User target, String reason) {
         return guild
             .removeRoleFromMember(target.getIdLong(),

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryQuarantineAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/TemporaryQuarantineAction.java
@@ -7,8 +7,6 @@ import org.togetherjava.tjbot.commands.moderation.ModerationAction;
 import org.togetherjava.tjbot.commands.moderation.ModerationUtils;
 import org.togetherjava.tjbot.config.Config;
 
-import javax.annotation.Nonnull;
-
 /**
  * Action to revoke temporary quarantines, as applied by
  * {@link org.togetherjava.tjbot.commands.moderation.QuarantineCommand} and executed by
@@ -29,19 +27,16 @@ final class TemporaryQuarantineAction extends RevocableRoleBasedAction {
     }
 
     @Override
-    @Nonnull
     public ModerationAction getApplyType() {
         return ModerationAction.QUARANTINE;
     }
 
     @Override
-    @Nonnull
     public ModerationAction getRevokeType() {
         return ModerationAction.UNQUARANTINE;
     }
 
     @Override
-    @Nonnull
     public RestAction<Void> revokeAction(Guild guild, User target, String reason) {
         return guild
             .removeRoleFromMember(target.getIdLong(),

--- a/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/moderation/temp/package-info.java
@@ -1,7 +1,10 @@
 /**
  * This package offers classes dealing with temporary moderation actions, such as temporary bans.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.moderation.temp;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/package-info.java
@@ -9,7 +9,10 @@
  * {@link org.togetherjava.tjbot.commands.SlashCommand} or using the adapter
  * {@link org.togetherjava.tjbot.commands.SlashCommandAdapter} for convenience.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/reminder/RemindCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/reminder/RemindCommand.java
@@ -11,7 +11,6 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.db.Database;
 
-import javax.annotation.Nonnull;
 import java.time.*;
 import java.time.temporal.TemporalAmount;
 import java.util.List;
@@ -102,7 +101,6 @@ public final class RemindCommand extends SlashCommandAdapter {
             .insert());
     }
 
-    @Nonnull
     private static Instant parseWhen(int whenAmount, String whenUnit) {
         TemporalAmount period = switch (whenUnit) {
             case "second", "seconds" -> Duration.ofSeconds(whenAmount);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/reminder/RemindRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/reminder/RemindRoutine.java
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.Routine;
 import org.togetherjava.tjbot.db.Database;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.awt.Color;
 import java.time.Instant;
@@ -45,7 +44,6 @@ public final class RemindRoutine implements Routine {
     }
 
     @Override
-    @Nonnull
     public Schedule createSchedule() {
         return new Schedule(ScheduleMode.FIXED_RATE, 0, SCHEDULE_INTERVAL_SECONDS,
                 TimeUnit.SECONDS);
@@ -84,7 +82,6 @@ public final class RemindRoutine implements Routine {
         return createDmReminderRoute(jda, authorId);
     }
 
-    @Nonnull
     private static RestAction<ReminderRoute> createGuildReminderRoute(JDA jda, long authorId,
             MessageChannel channel) {
         return jda.retrieveUserById(authorId)
@@ -92,7 +89,6 @@ public final class RemindRoutine implements Routine {
             .map(author -> ReminderRoute.toPublic(channel, author));
     }
 
-    @Nonnull
     private static RestAction<ReminderRoute> createDmReminderRoute(JDA jda, long authorId) {
         return jda.openPrivateChannelById(authorId).map(ReminderRoute::toPrivate);
     }
@@ -113,7 +109,6 @@ public final class RemindRoutine implements Routine {
         routeAction.flatMap(sendMessage).queue(doNothing(), logFailure);
     }
 
-    @Nonnull
     private static MessageEmbed createReminderEmbed(CharSequence content,
             TemporalAccessor createdAt, @Nullable User author) {
         String authorName = author == null ? "Unknown user" : author.getAsTag();
@@ -127,7 +122,6 @@ public final class RemindRoutine implements Routine {
             .build();
     }
 
-    @Nonnull
     private static <T> Consumer<T> doNothing() {
         return a -> {
         };
@@ -135,13 +129,11 @@ public final class RemindRoutine implements Routine {
 
     private record ReminderRoute(MessageChannel channel, @Nullable User target,
             @Nullable String description) {
-        @Nonnull
         static ReminderRoute toPublic(MessageChannel channel, @Nullable User target) {
             return new ReminderRoute(channel, target,
                     target == null ? null : target.getAsMention());
         }
 
-        @Nonnull
         static ReminderRoute toPrivate(PrivateChannel channel) {
             return new ReminderRoute(channel, channel.getUser(),
                     "(Sending your reminder directly, because I was unable to locate"

--- a/application/src/main/java/org/togetherjava/tjbot/commands/reminder/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/reminder/package-info.java
@@ -2,7 +2,10 @@
  * This packages offers all the functionality for the remind-command. The core class is
  * {@link org.togetherjava.tjbot.commands.reminder.RemindCommand}.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.reminder;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
@@ -25,7 +25,6 @@ import org.togetherjava.tjbot.commands.componentids.InvalidComponentIdFormatExce
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.db.Database;
 
-import javax.annotation.Nonnull;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -125,7 +124,6 @@ public final class BotCore extends ListenerAdapter implements SlashCommandProvid
     }
 
     @Override
-    @Nonnull
     public Collection<SlashCommand> getSlashCommands() {
         return nameToInteractor.values()
             .stream()
@@ -135,7 +133,6 @@ public final class BotCore extends ListenerAdapter implements SlashCommandProvid
     }
 
     @Override
-    @Nonnull
     public Optional<SlashCommand> getSlashCommand(String name) {
         return Optional.ofNullable(nameToInteractor.get(name))
             .filter(SlashCommand.class::isInstance)
@@ -204,7 +201,6 @@ public final class BotCore extends ListenerAdapter implements SlashCommandProvid
         }
     }
 
-    @Nonnull
     private Stream<MessageReceiver> getMessageReceiversSubscribedTo(Channel channel) {
         String channelName = channel.getName();
         return channelNameToMessageReceiver.entrySet()
@@ -308,7 +304,6 @@ public final class BotCore extends ListenerAdapter implements SlashCommandProvid
      * @return the command with the given name
      * @throws NullPointerException if the command with the given name was not registered
      */
-    @Nonnull
     private SlashCommand requireSlashCommand(String name) {
         return getSlashCommand(name).orElseThrow(
                 () -> new NullPointerException("There is no slash command with name " + name));
@@ -321,7 +316,6 @@ public final class BotCore extends ListenerAdapter implements SlashCommandProvid
      * @return the user interactor with the given name
      * @throws NullPointerException if the user interactor with the given name was not registered
      */
-    @Nonnull
     private UserInteractor requireUserInteractor(String name) {
         return Objects.requireNonNull(nameToInteractor.get(name));
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/ReloadCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/ReloadCommand.java
@@ -17,7 +17,6 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.commands.utils.MessageUtils;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -132,7 +131,6 @@ public final class ReloadCommand extends SlashCommandAdapter {
      * @param updateAction the upstream to update commands
      * @return the given upstream for chaining
      */
-    @Nonnull
     private CommandListUpdateAction updateCommandsIf(Predicate<? super SlashCommand> commandFilter,
             CommandListUpdateAction updateAction) {
         return commandProvider.getSlashCommands()
@@ -142,12 +140,10 @@ public final class ReloadCommand extends SlashCommandAdapter {
             .reduce(updateAction, CommandListUpdateAction::addCommands, (x, y) -> x);
     }
 
-    @Nonnull
     private static CommandListUpdateAction getGlobalUpdateAction(JDA jda) {
         return jda.updateCommands();
     }
 
-    @Nonnull
     private static Stream<CommandListUpdateAction> getGuildUpdateActions(JDA jda) {
         return jda.getGuildCache().stream().map(Guild::updateCommands);
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/SlashCommandProvider.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/SlashCommandProvider.java
@@ -2,7 +2,6 @@ package org.togetherjava.tjbot.commands.system;
 
 import org.togetherjava.tjbot.commands.SlashCommand;
 
-import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -15,7 +14,6 @@ public interface SlashCommandProvider {
      *
      * @return all slash commands
      */
-    @Nonnull
     Collection<SlashCommand> getSlashCommands();
 
     /**
@@ -24,6 +22,5 @@ public interface SlashCommandProvider {
      * @param name the name of the command
      * @return the command registered under this name, if any
      */
-    @Nonnull
     Optional<SlashCommand> getSlashCommand(String name);
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/package-info.java
@@ -2,7 +2,10 @@
  * This package represents the core of the command system. The entry point is
  * {@link org.togetherjava.tjbot.commands.system.BotCore}.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.system;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagManageCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagManageCommand.java
@@ -16,7 +16,6 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.moderation.ModAuditLogWriter;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -123,7 +122,6 @@ public final class TagManageCommand extends SlashCommandAdapter {
      * @param event the event to send messages with
      * @return the parsed message id, if successful
      */
-    @Nonnull
     private static OptionalLong parseMessageIdAndHandle(String messageId, IReplyCallback event) {
         try {
             return OptionalLong.of(Long.parseLong(messageId));
@@ -289,7 +287,6 @@ public final class TagManageCommand extends SlashCommandAdapter {
      * @param id the id of the tag to get its content
      * @return the content of the tag, if present
      */
-    @Nonnull
     private Optional<String> getTagContent(Subcommand subcommand, String id) {
         if (Subcommand.SUBCOMMANDS_WITH_PREVIOUS_CONTENT.contains(subcommand)) {
             try {
@@ -383,7 +380,6 @@ public final class TagManageCommand extends SlashCommandAdapter {
         NOT_EXISTS
     }
 
-
     enum Subcommand {
         RAW("raw", ""),
         CREATE("create", "created"),
@@ -397,7 +393,6 @@ public final class TagManageCommand extends SlashCommandAdapter {
         private static final Set<Subcommand> SUBCOMMANDS_WITH_PREVIOUS_CONTENT =
                 EnumSet.of(EDIT, EDIT_WITH_MESSAGE, DELETE);
 
-
         private final String name;
         private final String actionVerb;
 
@@ -406,12 +401,10 @@ public final class TagManageCommand extends SlashCommandAdapter {
             this.actionVerb = actionVerb;
         }
 
-        @Nonnull
         String getName() {
             return name;
         }
 
-        @Nonnull
         static Subcommand fromName(String name) {
             for (Subcommand subcommand : Subcommand.values()) {
                 if (subcommand.name.equals(name)) {
@@ -422,7 +415,6 @@ public final class TagManageCommand extends SlashCommandAdapter {
                     "Subcommand with name '%s' is unknown".formatted(name));
         }
 
-        @Nonnull
         String getActionVerb() {
             return actionVerb;
         }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagSystem.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagSystem.java
@@ -9,7 +9,6 @@ import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.Tags;
 import org.togetherjava.tjbot.db.generated.tables.records.TagsRecord;
 
-import javax.annotation.Nonnull;
 import java.awt.Color;
 import java.util.Optional;
 import java.util.Set;
@@ -122,7 +121,6 @@ public final class TagSystem {
      * @param id the id of the tag to get
      * @return the content of the tag, if the tag is known to the system
      */
-    @Nonnull
     Optional<String> getTag(String id) {
         return database.readTransaction(context -> Optional
             .ofNullable(context.selectFrom(Tags.TAGS).where(Tags.TAGS.ID.eq(id)).fetchOne())
@@ -134,7 +132,6 @@ public final class TagSystem {
      *
      * @return a set of all ids known to the system, not backed
      */
-    @Nonnull
     Set<String> getAllIds() {
         return database.readTransaction(context -> context.select(Tags.TAGS.ID)
             .from(Tags.TAGS)

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/package-info.java
@@ -4,7 +4,10 @@
  * like {@link org.togetherjava.tjbot.commands.tags.TagCommand} as entry point to the package's
  * offered functionality.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.tags;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersCommand.java
@@ -18,7 +18,6 @@ import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.SlashCommandVisibility;
 import org.togetherjava.tjbot.db.Database;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.time.*;
@@ -88,7 +87,6 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
             .onSuccess(members -> handleTopHelpers(topHelpers, members, timeRange, event));
     }
 
-    @Nonnull
     private static Month computeMonth(@Nullable OptionMapping atMonthData) {
         if (atMonthData != null) {
             return Month.valueOf(atMonthData.getAsString());
@@ -98,7 +96,6 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
         return Instant.now().atZone(ZoneOffset.UTC).minusMonths(1).getMonth();
     }
 
-    @Nonnull
     private static TimeRange computeTimeRange(Month atMonth) {
         ZonedDateTime now = Instant.now().atZone(ZoneOffset.UTC);
 
@@ -117,7 +114,6 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
         return new TimeRange(start, end, description);
     }
 
-    @Nonnull
     private List<TopHelperResult> computeTopHelpersDescending(long guildId, TimeRange timeRange) {
         return database.read(context -> context
             .select(HELP_CHANNEL_MESSAGES.AUTHOR_ID, DSL.sum(HELP_CHANNEL_MESSAGES.MESSAGE_LENGTH))
@@ -151,7 +147,6 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
         event.getHook().editOriginal(message).queue();
     }
 
-    @Nonnull
     private static List<String> topHelperToDataRow(TopHelperResult topHelper,
             @Nullable Member member) {
         String id = Long.toString(topHelper.authorId());
@@ -161,7 +156,6 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
         return List.of(id, name, messageLengths);
     }
 
-    @Nonnull
     private static String dataTableToString(Collection<List<String>> dataTable,
             TimeRange timeRange) {
         return dataTableToAsciiTable(dataTable,
@@ -172,7 +166,6 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
                                 HorizontalAlign.RIGHT)));
     }
 
-    @Nonnull
     private static String dataTableToAsciiTable(Collection<List<String>> dataTable,
             List<ColumnSetting> columnSettings) {
         IntFunction<String> headerToAlignment = i -> columnSettings.get(i).headerName();
@@ -192,10 +185,8 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
     private record TimeRange(Instant start, Instant end, String description) {
     }
 
-
     private record TopHelperResult(long authorId, BigDecimal messageLengths) {
     }
-
 
     private record ColumnSetting(String headerName, HorizontalAlign alignment) {
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersPurgeMessagesRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersPurgeMessagesRoutine.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.Routine;
 import org.togetherjava.tjbot.db.Database;
 
-import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.time.Period;
 import java.util.concurrent.TimeUnit;
@@ -33,7 +32,6 @@ public final class TopHelpersPurgeMessagesRoutine implements Routine {
     }
 
     @Override
-    @Nonnull
     public Schedule createSchedule() {
         return new Schedule(ScheduleMode.FIXED_RATE, 0, 4, TimeUnit.HOURS);
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/package-info.java
@@ -2,7 +2,10 @@
  * This packages offers all the functionality for the top-helpers command system. The core class is
  * {@link org.togetherjava.tjbot.commands.tophelper.TopHelpersCommand}.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.tophelper;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/DiscordClientAction.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/DiscordClientAction.java
@@ -4,7 +4,6 @@ import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 import org.jetbrains.annotations.Contract;
 
-import javax.annotation.Nonnull;
 import java.util.regex.Pattern;
 
 /**
@@ -81,7 +80,6 @@ public final class DiscordClientAction {
                 new DiscordClientAction("discord://-/guild-discovery");
         public static final DiscordClientAction GUILDS_CREATE =
                 new DiscordClientAction("discord://-/guilds/create");
-
 
         public static final DiscordClientAction GUILD_EVENT =
                 new DiscordClientAction("discord://-/events/{GUILD-ID}/{EVENT-ID}");
@@ -261,7 +259,6 @@ public final class DiscordClientAction {
      * @return The formatted URL as an {@link String}
      * @throws IllegalArgumentException When missing arguments
      */
-    @Nonnull
     public String formatUrl(final String... arguments) {
         String localUrl = url;
 
@@ -285,13 +282,11 @@ public final class DiscordClientAction {
      * @return A {@link Button} of {@link ButtonStyle#LINK} with the given label
      * @throws IllegalArgumentException When missing arguments
      */
-    @Nonnull
     public Button asLinkButton(final String label, final String... arguments) {
         return Button.link(formatUrl(arguments), label);
     }
 
     @Override
-    @Nonnull
     public String toString() {
         return "DiscordClientAction{" + "url='" + url + '\'' + '}';
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/Hashing.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/Hashing.java
@@ -1,6 +1,5 @@
 package org.togetherjava.tjbot.commands.utils;
 
-import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -25,7 +24,6 @@ public class Hashing {
      * @param bytes the binary data to convert
      * @return a hexadecimal representation
      */
-    @Nonnull
     public static String bytesToHex(byte[] bytes) {
         Objects.requireNonNull(bytes);
         // See https://stackoverflow.com/a/9855338/2411243
@@ -50,7 +48,6 @@ public class Hashing {
      * @param data the data to hash
      * @return the computed hash
      */
-    @Nonnull
     public static byte[] hash(String method, byte[] data) {
         Objects.requireNonNull(method);
         Objects.requireNonNull(data);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
@@ -5,7 +5,6 @@ import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.utils.MarkdownSanitizer;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -39,7 +38,6 @@ public class MessageUtils {
             .queue();
     }
 
-
     /**
      * Escapes every markdown content in the given string.
      *
@@ -48,7 +46,6 @@ public class MessageUtils {
      * @param text the text to escape
      * @return the escaped text
      */
-    @Nonnull
     public static String escapeMarkdown(String text) {
         // NOTE Unfortunately the utility does not escape backslashes '\', so we have to do it
         // ourselves

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/StringDistances.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/StringDistances.java
@@ -1,6 +1,5 @@
 package org.togetherjava.tjbot.commands.utils;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
@@ -27,7 +26,6 @@ public class StringDistances {
      * @param <S> the type of the candidates
      * @return the best matching candidate, or empty iff the candidates are empty
      */
-    @Nonnull
     public static <S extends CharSequence> Optional<S> closestMatch(CharSequence query,
             Collection<S> candidates) {
         return candidates.stream()
@@ -47,7 +45,6 @@ public class StringDistances {
      * @param <S> the type of the candidates
      * @return the best matching candidate, or empty iff the candidates are empty
      */
-    @Nonnull
     public static <S extends CharSequence> Optional<S> autocomplete(CharSequence prefix,
             Collection<S> candidates) {
         return candidates.stream()
@@ -110,7 +107,6 @@ public class StringDistances {
      * @param destination the destination string to receive by editing the source
      * @return the levenshtein distance table
      */
-    @Nonnull
     private static int[][] computeLevenshteinDistanceTable(CharSequence source,
             CharSequence destination) {
         int rows = source.length() + 1;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/package-info.java
@@ -1,7 +1,10 @@
 /**
  * This package contains general utility used by commands.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.commands.utils;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -181,7 +180,6 @@ public final class Config {
      *
      * @return the suggestion system config
      */
-    @Nonnull
     public SuggestionsConfig getSuggestions() {
         return suggestions;
     }
@@ -191,7 +189,6 @@ public final class Config {
      *
      * @return the role name pattern
      */
-    @Nonnull
     public String getQuarantinedRolePattern() {
         return quarantinedRolePattern;
     }
@@ -201,7 +198,6 @@ public final class Config {
      *
      * @return the scam blocker system config
      */
-    @Nonnull
     public ScamBlockerConfig getScamBlocker() {
         return scamBlocker;
     }
@@ -211,7 +207,6 @@ public final class Config {
      *
      * @return the application ID for the WolframAlpha API
      */
-    @Nonnull
     public String getWolframAlphaAppId() {
         return wolframAlphaAppId;
     }
@@ -221,7 +216,6 @@ public final class Config {
      *
      * @return the help system config
      */
-    @Nonnull
     public HelpSystemConfig getHelpSystem() {
         return helpSystem;
     }
@@ -231,7 +225,6 @@ public final class Config {
      *
      * @return the channel name pattern
      */
-    @Nonnull
     public String getMediaOnlyChannelPattern() {
         return mediaOnlyChannelPattern;
     }

--- a/application/src/main/java/org/togetherjava/tjbot/config/HelpSystemConfig.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/HelpSystemConfig.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -37,7 +36,6 @@ public final class HelpSystemConfig {
      *
      * @return the channel name pattern
      */
-    @Nonnull
     public String getStagingChannelPattern() {
         return stagingChannelPattern;
     }
@@ -48,7 +46,6 @@ public final class HelpSystemConfig {
      *
      * @return the channel name pattern
      */
-    @Nonnull
     public String getOverviewChannelPattern() {
         return overviewChannelPattern;
     }
@@ -58,7 +55,6 @@ public final class HelpSystemConfig {
      *
      * @return a list of all categories
      */
-    @Nonnull
     public List<String> getCategories() {
         return Collections.unmodifiableList(categories);
     }
@@ -73,7 +69,6 @@ public final class HelpSystemConfig {
      *
      * @return the suffix
      */
-    @Nonnull
     public String getCategoryRoleSuffix() {
         return categoryRoleSuffix;
     }

--- a/application/src/main/java/org/togetherjava/tjbot/config/ScamBlockerConfig.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/ScamBlockerConfig.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -53,7 +52,6 @@ public final class ScamBlockerConfig {
      *
      * @return the channel name pattern
      */
-    @Nonnull
     public String getReportChannelPattern() {
         return reportChannelPattern;
     }
@@ -63,7 +61,6 @@ public final class ScamBlockerConfig {
      *
      * @return the whitelist of hosts
      */
-    @Nonnull
     public Set<String> getHostWhitelist() {
         return Collections.unmodifiableSet(hostWhitelist);
     }
@@ -73,7 +70,6 @@ public final class ScamBlockerConfig {
      *
      * @return the blacklist of hosts
      */
-    @Nonnull
     public Set<String> getHostBlacklist() {
         return Collections.unmodifiableSet(hostBlacklist);
     }
@@ -84,7 +80,6 @@ public final class ScamBlockerConfig {
      *
      * @return the set of suspicious host keywords
      */
-    @Nonnull
     public Set<String> getSuspiciousHostKeywords() {
         return Collections.unmodifiableSet(suspiciousHostKeywords);
     }

--- a/application/src/main/java/org/togetherjava/tjbot/config/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/package-info.java
@@ -2,7 +2,10 @@
  * This package contains the configuration of the application. It revolves around the class
  * {@link org.togetherjava.tjbot.config.Config}.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.config;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/logging/FlaggedFilter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/logging/FlaggedFilter.java
@@ -8,9 +8,6 @@ import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.filter.AbstractFilter;
 
-import javax.annotation.Nonnull;
-
-
 /**
  * A custom Filter for Log4j2, which only lets an event pass through if a Logging Flag is set in the
  * environment. Intended to be used for local development for devs do not want to also run the
@@ -44,7 +41,6 @@ public class FlaggedFilter extends AbstractFilter {
      * @return {@link Result#DENY} if the Flag is not set, else {@link Result#NEUTRAL}
      */
     @Override
-    @Nonnull
     public Result filter(LogEvent event) {
         return isLoggingEnabled() ? Result.NEUTRAL : Result.DENY;
     }
@@ -61,7 +57,6 @@ public class FlaggedFilter extends AbstractFilter {
      * @return The created FlaggedFilter.
      */
     @PluginFactory
-    @Nonnull
     public static FlaggedFilter createFilter(
             @PluginAttribute(value = "onMatch", defaultString = "NEUTRAL") Result onMatch,
 

--- a/application/src/main/java/org/togetherjava/tjbot/logging/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/logging/package-info.java
@@ -1,7 +1,10 @@
 /**
  * This package is for custom logging plugins of the bot.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.logging;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/misc/MethodsReturnNonnullByDefault.java
+++ b/application/src/main/java/org/togetherjava/tjbot/misc/MethodsReturnNonnullByDefault.java
@@ -1,0 +1,28 @@
+package org.togetherjava.tjbot.misc;
+
+import javax.annotation.Nonnull;
+import javax.annotation.meta.TypeQualifierDefault;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * This annotation can be applied to a package, class or method to indicate that the methods return
+ * value is nonnull by default unless there is:
+ * <ul>
+ * <li>An explicit nullness annotation
+ * <li>The method overrides a method in a superclass (in which case the annotation of the
+ * corresponding method in the superclass applies)
+ * <li>There is a default parameter annotation (like {@link MethodsReturnNonnullByDefault}) applied
+ * to a more tightly nested element.
+ * </ul>
+ *
+ * @see Nonnull
+ */
+@Documented
+@Nonnull
+@TypeQualifierDefault(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MethodsReturnNonnullByDefault {
+}

--- a/application/src/main/java/org/togetherjava/tjbot/misc/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/misc/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Package for all miscellaneous topics, such as general purpose utilities.
+ */
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package org.togetherjava.tjbot.misc;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/moderation/ModAuditLogWriter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/moderation/ModAuditLogWriter.java
@@ -10,7 +10,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.config.Config;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.awt.Color;
 import java.io.File;
@@ -88,7 +87,6 @@ public final class ModAuditLogWriter {
      * @param guild the guild to look for the channel in
      * @return the channel used for moderation audit logs, if present
      */
-    @Nonnull
     public Optional<TextChannel> getAndHandleModAuditLogChannel(Guild guild) {
         Optional<TextChannel> auditLogChannel = guild.getTextChannelCache()
             .stream()
@@ -116,7 +114,6 @@ public final class ModAuditLogWriter {
          *
          * @return the raw content of the attachment
          */
-        @Nonnull
         public byte[] getContentRaw() {
             return content.getBytes(StandardCharsets.UTF_8);
         }

--- a/application/src/main/java/org/togetherjava/tjbot/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/package-info.java
@@ -1,7 +1,10 @@
 /**
  * Entry package for the TJ-Bot. See {@link org.togetherjava.tjbot.Application} to get started.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/routines/ModAuditLogRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/routines/ModAuditLogRoutine.java
@@ -20,7 +20,6 @@ import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.ModAuditLogGuildProcess;
 import org.togetherjava.tjbot.moderation.ModAuditLogWriter;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.awt.Color;
 import java.time.*;
@@ -65,7 +64,6 @@ public final class ModAuditLogRoutine implements Routine {
         this.modAuditLogWriter = modAuditLogWriter;
     }
 
-    @Nonnull
     private static RestAction<AuditLogMessage> handleAction(Action action, AuditLogEntry entry) {
         User author = Objects.requireNonNull(entry.getUser());
         return getTargetFromEntryOrNull(entry).map(target -> new AuditLogMessage(author, action,
@@ -99,7 +97,6 @@ public final class ModAuditLogRoutine implements Routine {
      * @param periodHours the scheduling period in hours
      * @return the according schedule representing the planned execution
      */
-    @Nonnull
     private static Schedule scheduleAtFixedRateFromNextFixedTime(int periodStartHour,
             int periodHours) {
         // NOTE This scheduler could be improved, for example supporting arbitrary periods (not just
@@ -129,7 +126,6 @@ public final class ModAuditLogRoutine implements Routine {
                 TimeUnit.HOURS.toSeconds(periodHours), TimeUnit.SECONDS);
     }
 
-    @Nonnull
     private static Instant computeClosestNextScheduleDate(Instant instant,
             List<Integer> scheduleHours, int periodHours) {
         OffsetDateTime offsetDateTime = instant.atOffset(ZoneOffset.UTC);
@@ -151,36 +147,30 @@ public final class ModAuditLogRoutine implements Routine {
             .orElseThrow();
     }
 
-    @Nonnull
     private static Optional<RestAction<MessageEmbed>> handleBanEntry(AuditLogEntry entry) {
         // NOTE Temporary bans are realized as permanent bans with automated unban,
         // hence we can not differentiate a permanent or a temporary ban here
         return Optional.of(handleAction(Action.BAN, entry).map(AuditLogMessage::toEmbed));
     }
 
-    @Nonnull
     private static Optional<RestAction<MessageEmbed>> handleUnbanEntry(AuditLogEntry entry) {
         return Optional.of(handleAction(Action.UNBAN, entry).map(AuditLogMessage::toEmbed));
     }
 
-    @Nonnull
     private static Optional<RestAction<MessageEmbed>> handleKickEntry(AuditLogEntry entry) {
         return Optional.of(handleAction(Action.KICK, entry).map(AuditLogMessage::toEmbed));
     }
 
-    @Nonnull
     private static Optional<RestAction<MessageEmbed>> handleMuteEntry(AuditLogEntry entry) {
         // NOTE Temporary mutes are realized as permanent mutes with automated unmute,
         // hence we can not differentiate a permanent or a temporary mute here
         return Optional.of(handleAction(Action.MUTE, entry).map(AuditLogMessage::toEmbed));
     }
 
-    @Nonnull
     private static Optional<RestAction<MessageEmbed>> handleUnmuteEntry(AuditLogEntry entry) {
         return Optional.of(handleAction(Action.UNMUTE, entry).map(AuditLogMessage::toEmbed));
     }
 
-    @Nonnull
     private static Optional<RestAction<MessageEmbed>> handleMessageDeleteEntry(
             AuditLogEntry entry) {
         return Optional.of(handleAction(Action.MESSAGE_DELETION, entry).map(message -> {
@@ -198,7 +188,6 @@ public final class ModAuditLogRoutine implements Routine {
     }
 
     @Override
-    @Nonnull
     public Schedule createSchedule() {
         Schedule schedule = scheduleAtFixedRateFromNextFixedTime(CHECK_AUDIT_LOG_START_HOUR,
                 CHECK_AUDIT_LOG_EVERY_HOURS);
@@ -270,7 +259,6 @@ public final class ModAuditLogRoutine implements Routine {
         });
     }
 
-    @Nonnull
     private Optional<RestAction<Message>> handleAuditLog(MessageChannel auditLogChannel,
             AuditLogEntry entry) {
         Optional<RestAction<MessageEmbed>> maybeMessage = switch (entry.getType()) {
@@ -290,7 +278,6 @@ public final class ModAuditLogRoutine implements Routine {
             .map(message -> message.flatMap(Objects::nonNull, auditLogChannel::sendMessageEmbeds));
     }
 
-    @Nonnull
     private Optional<RestAction<MessageEmbed>> handleRoleUpdateEntry(AuditLogEntry entry) {
         if (containsMutedRole(entry, AuditLogKey.MEMBER_ROLES_ADD)) {
             return handleMuteEntry(entry);
@@ -329,12 +316,10 @@ public final class ModAuditLogRoutine implements Routine {
             this.verb = verb;
         }
 
-        @Nonnull
         String getTitle() {
             return title;
         }
 
-        @Nonnull
         String getVerb() {
             return verb;
         }
@@ -342,7 +327,6 @@ public final class ModAuditLogRoutine implements Routine {
 
     private record AuditLogMessage(User author, Action action, @Nullable User target,
             @Nullable String reason, TemporalAccessor timestamp) {
-        @Nonnull
         MessageEmbed toEmbed() {
             String targetTag = target == null ? "(user unknown)" : target.getAsTag();
             String description = "%s **%s**.".formatted(action.getVerb(), targetTag);

--- a/application/src/main/java/org/togetherjava/tjbot/routines/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/routines/package-info.java
@@ -5,7 +5,10 @@
  * Routines are actions that are executed periodically on a schedule. They are added to the system
  * in {@link org.togetherjava.tjbot.commands.Features}.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.routines;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/test/java/org/togetherjava/tjbot/commands/basic/PingCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/basic/PingCommandTest.java
@@ -7,15 +7,12 @@ import org.junit.jupiter.api.Test;
 import org.togetherjava.tjbot.commands.SlashCommand;
 import org.togetherjava.tjbot.jda.JdaTester;
 
-import javax.annotation.Nonnull;
-
 import static org.mockito.Mockito.verify;
 
 final class PingCommandTest {
     private JdaTester jdaTester;
     private SlashCommand command;
 
-    @Nonnull
     private SlashCommandInteractionEvent triggerSlashCommand() {
         SlashCommandInteractionEvent event =
                 jdaTester.createSlashCommandInteractionEvent(command).build();

--- a/application/src/test/java/org/togetherjava/tjbot/commands/mathcommands/TeXCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/mathcommands/TeXCommandTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.togetherjava.tjbot.commands.SlashCommand;
 import org.togetherjava.tjbot.jda.JdaTester;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,7 +25,6 @@ final class TeXCommandTest {
         command = jdaTester.spySlashCommand(new TeXCommand());
     }
 
-    @Nonnull
     private SlashCommandInteractionEvent triggerSlashCommand(String latex) {
         SlashCommandInteractionEvent event = jdaTester.createSlashCommandInteractionEvent(command)
             .setOption(TeXCommand.LATEX_OPTION, latex)

--- a/application/src/test/java/org/togetherjava/tjbot/commands/mediaonly/MediaOnlyChannelListenerTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/mediaonly/MediaOnlyChannelListenerTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.jda.JdaTester;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 import static org.mockito.Mockito.*;
@@ -94,12 +93,10 @@ final class MediaOnlyChannelListenerTest {
         verify(jdaTester.getPrivateChannelSpy()).sendMessage(any(Message.class));
     }
 
-    @Nonnull
     private MessageReceivedEvent sendMessage(Message message) {
         return sendMessage(message, List.of());
     }
 
-    @Nonnull
     private MessageReceivedEvent sendMessage(Message message,
             List<Message.Attachment> attachments) {
         MessageReceivedEvent event = jdaTester.createMessageReceiveEvent(message, attachments);

--- a/application/src/test/java/org/togetherjava/tjbot/commands/moderation/scam/ScamDetectorTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/moderation/scam/ScamDetectorTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.config.ScamBlockerConfig;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Set;
 
@@ -103,7 +102,6 @@ final class ScamDetectorTest {
         assertFalse(isScamResult);
     }
 
-    @Nonnull
     private static List<String> provideRealScamMessages() {
         return List.of("""
                 🤩bro steam gived nitro - https://nitro-ds.online/LfgUfMzqYyx12""",

--- a/application/src/test/java/org/togetherjava/tjbot/commands/reminder/RawReminderTestHelper.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/reminder/RawReminderTestHelper.java
@@ -7,7 +7,6 @@ import org.togetherjava.tjbot.db.generated.Tables;
 import org.togetherjava.tjbot.db.generated.tables.records.PendingRemindersRecord;
 import org.togetherjava.tjbot.jda.JdaTester;
 
-import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.util.List;
 
@@ -45,12 +44,10 @@ final class RawReminderTestHelper {
             .insert());
     }
 
-    @Nonnull
     List<String> readReminders() {
         return readReminders(jdaTester.getMemberSpy());
     }
 
-    @Nonnull
     List<String> readReminders(Member author) {
         long guildId = jdaTester.getTextChannelSpy().getGuild().getIdLong();
         long authorId = author.getIdLong();

--- a/application/src/test/java/org/togetherjava/tjbot/commands/reminder/RemindCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/reminder/RemindCommandTest.java
@@ -11,7 +11,6 @@ import org.togetherjava.tjbot.commands.SlashCommand;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.jda.JdaTester;
 
-import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -35,13 +34,11 @@ final class RemindCommandTest {
         rawReminders = new RawReminderTestHelper(database, jdaTester);
     }
 
-    @Nonnull
     private SlashCommandInteractionEvent triggerSlashCommand(int timeAmount, String timeUnit,
             String content) {
         return triggerSlashCommand(timeAmount, timeUnit, content, jdaTester.getMemberSpy());
     }
 
-    @Nonnull
     private SlashCommandInteractionEvent triggerSlashCommand(int timeAmount, String timeUnit,
             String content, Member author) {
         SlashCommandInteractionEvent event = jdaTester.createSlashCommandInteractionEvent(command)

--- a/application/src/test/java/org/togetherjava/tjbot/commands/reminder/RemindRoutineTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/reminder/RemindRoutineTest.java
@@ -12,7 +12,6 @@ import org.togetherjava.tjbot.commands.Routine;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.jda.JdaTester;
 
-import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
@@ -39,14 +38,12 @@ final class RemindRoutineTest {
         routine.runRoutine(jdaTester.getJdaMock());
     }
 
-    @Nonnull
     private static MessageEmbed getLastMessageFrom(MessageChannel channel) {
         ArgumentCaptor<MessageEmbed> responseCaptor = ArgumentCaptor.forClass(MessageEmbed.class);
         verify(channel).sendMessageEmbeds(responseCaptor.capture());
         return responseCaptor.getValue();
     }
 
-    @Nonnull
     private Member createAndSetupUnknownMember() {
         int unknownMemberId = 2;
 
@@ -67,7 +64,6 @@ final class RemindRoutineTest {
         return member;
     }
 
-    @Nonnull
     private TextChannel createAndSetupUnknownChannel() {
         long unknownChannelId = 2;
 

--- a/application/src/test/java/org/togetherjava/tjbot/commands/system/ReloadCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/system/ReloadCommandTest.java
@@ -3,7 +3,6 @@ package org.togetherjava.tjbot.commands.system;
 import org.junit.jupiter.api.Test;
 import org.togetherjava.tjbot.commands.SlashCommand;
 
-import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -17,13 +16,11 @@ final class ReloadCommandTest {
                 "AnonymousInnerClassMayBeStatic"})
         SlashCommandProvider slashCommandProvider = new SlashCommandProvider() {
             @Override
-            @Nonnull
             public Collection<SlashCommand> getSlashCommands() {
                 return List.of();
             }
 
             @Override
-            @Nonnull
             public Optional<SlashCommand> getSlashCommand(String name) {
                 return Optional.empty();
             }

--- a/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagCommandTest.java
@@ -12,7 +12,6 @@ import org.togetherjava.tjbot.db.generated.tables.Tags;
 import org.togetherjava.tjbot.jda.JdaTester;
 import org.togetherjava.tjbot.jda.SlashCommandInteractionEventBuilder;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static org.mockito.Mockito.*;
@@ -30,7 +29,6 @@ final class TagCommandTest {
         command = new TagCommand(system);
     }
 
-    @Nonnull
     private SlashCommandInteractionEvent triggerSlashCommand(String id,
             @Nullable Member userToReplyTo) {
         SlashCommandInteractionEventBuilder builder =

--- a/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagManageCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagManageCommandTest.java
@@ -19,7 +19,6 @@ import org.togetherjava.tjbot.db.generated.tables.Tags;
 import org.togetherjava.tjbot.jda.JdaTester;
 import org.togetherjava.tjbot.moderation.ModAuditLogWriter;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -36,7 +35,6 @@ final class TagManageCommandTest {
     private Member moderator;
     private ModAuditLogWriter modAuditLogWriter;
 
-    @Nonnull
     private static MessageEmbed getResponse(SlashCommandInteractionEvent event) {
         ArgumentCaptor<MessageEmbed> responseCaptor = ArgumentCaptor.forClass(MessageEmbed.class);
         verify(event).replyEmbeds(responseCaptor.capture());
@@ -62,12 +60,10 @@ final class TagManageCommandTest {
         when(moderatorRole.getName()).thenReturn(moderatorRoleName);
     }
 
-    @Nonnull
     private SlashCommandInteractionEvent triggerRawCommand(String tagId) {
         return triggerRawCommandWithUser(tagId, moderator);
     }
 
-    @Nonnull
     private SlashCommandInteractionEvent triggerRawCommandWithUser(String tagId, Member user) {
         SlashCommandInteractionEvent event = jdaTester.createSlashCommandInteractionEvent(command)
             .setSubcommand(TagManageCommand.Subcommand.RAW.getName())
@@ -79,17 +75,14 @@ final class TagManageCommandTest {
         return event;
     }
 
-    @Nonnull
     private SlashCommandInteractionEvent triggerCreateCommand(String tagId, String content) {
         return triggerTagContentCommand(TagManageCommand.Subcommand.CREATE, tagId, content);
     }
 
-    @Nonnull
     private SlashCommandInteractionEvent triggerEditCommand(String tagId, String content) {
         return triggerTagContentCommand(TagManageCommand.Subcommand.EDIT, tagId, content);
     }
 
-    @Nonnull
     private SlashCommandInteractionEvent triggerTagContentCommand(
             TagManageCommand.Subcommand subcommand, String tagId, String content) {
         SlashCommandInteractionEvent event = jdaTester.createSlashCommandInteractionEvent(command)
@@ -103,21 +96,18 @@ final class TagManageCommandTest {
         return event;
     }
 
-    @Nonnull
     private SlashCommandInteractionEvent triggerCreateWithMessageCommand(String tagId,
             String messageId) {
         return triggerTagMessageCommand(TagManageCommand.Subcommand.CREATE_WITH_MESSAGE, tagId,
                 messageId);
     }
 
-    @Nonnull
     private SlashCommandInteractionEvent triggerEditWithMessageCommand(String tagId,
             String messageId) {
         return triggerTagMessageCommand(TagManageCommand.Subcommand.EDIT_WITH_MESSAGE, tagId,
                 messageId);
     }
 
-    @Nonnull
     private SlashCommandInteractionEvent triggerTagMessageCommand(
             TagManageCommand.Subcommand subcommand, String tagId, String messageId) {
         SlashCommandInteractionEvent event = jdaTester.createSlashCommandInteractionEvent(command)
@@ -131,7 +121,6 @@ final class TagManageCommandTest {
         return event;
     }
 
-    @Nonnull
     private SlashCommandInteractionEvent triggerDeleteCommand(String tagId) {
         SlashCommandInteractionEvent event = jdaTester.createSlashCommandInteractionEvent(command)
             .setSubcommand(TagManageCommand.Subcommand.DELETE.getName())

--- a/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagsCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/tags/TagsCommandTest.java
@@ -15,7 +15,6 @@ import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.Tags;
 import org.togetherjava.tjbot.jda.JdaTester;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 
@@ -35,7 +34,6 @@ final class TagsCommandTest {
         return responseCaptor.getValue().getDescription();
     }
 
-    @Nonnull
     private SlashCommandInteractionEvent triggerSlashCommand() {
         SlashCommandInteractionEvent event =
                 jdaTester.createSlashCommandInteractionEvent(command).build();
@@ -43,7 +41,6 @@ final class TagsCommandTest {
         return event;
     }
 
-    @Nonnull
     private ButtonInteractionEvent triggerButtonClick(Member userWhoClicked, long idOfAuthor) {
         ButtonInteractionEvent event = jdaTester.createButtonInteractionEvent()
             .setUserWhoClicked(userWhoClicked)

--- a/application/src/test/java/org/togetherjava/tjbot/jda/ButtonClickEventBuilder.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/ButtonClickEventBuilder.java
@@ -11,7 +11,6 @@ import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import org.togetherjava.tjbot.commands.SlashCommand;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.function.Function;
@@ -94,7 +93,6 @@ public final class ButtonClickEventBuilder {
      * @param message the message to set
      * @return this builder instance for chaining
      */
-    @Nonnull
     public ButtonClickEventBuilder setMessage(Message message) {
         messageBuilder = new MessageBuilder(message);
         return this;
@@ -107,7 +105,6 @@ public final class ButtonClickEventBuilder {
      * @param content the content of the message
      * @return this builder instance for chaining
      */
-    @Nonnull
     public ButtonClickEventBuilder setContent(String content) {
         messageBuilder.setContent(content);
         return this;
@@ -120,7 +117,6 @@ public final class ButtonClickEventBuilder {
      * @param embeds the embeds of the message
      * @return this builder instance for chaining
      */
-    @Nonnull
     public ButtonClickEventBuilder setEmbeds(MessageEmbed... embeds) {
         messageBuilder.setEmbeds(embeds);
         return this;
@@ -135,7 +131,6 @@ public final class ButtonClickEventBuilder {
      * @param rows the action rows of the message
      * @return this builder instance for chaining
      */
-    @Nonnull
     public ButtonClickEventBuilder setActionRows(ActionRow... rows) {
         messageBuilder.setActionRows(rows);
         return this;
@@ -147,7 +142,6 @@ public final class ButtonClickEventBuilder {
      * @param userWhoClicked the user who clicked the button
      * @return this builder instance for chaining
      */
-    @Nonnull
     public ButtonClickEventBuilder setUserWhoClicked(Member userWhoClicked) {
         this.userWhoClicked = userWhoClicked;
         return this;
@@ -162,7 +156,6 @@ public final class ButtonClickEventBuilder {
      *
      * @return the created slash command instance
      */
-    @Nonnull
     public ButtonInteractionEvent buildWithSingleButton() {
         return createEvent(null);
     }
@@ -178,12 +171,10 @@ public final class ButtonClickEventBuilder {
      *        contained in the message.
      * @return the created slash command instance
      */
-    @Nonnull
     public ButtonInteractionEvent build(Button clickedButton) {
         return createEvent(clickedButton);
     }
 
-    @Nonnull
     private ButtonInteractionEvent createEvent(@Nullable Button maybeClickedButton) {
         Message message = mockMessageOperator.apply(messageBuilder.build());
         Button clickedButton = determineClickedButton(maybeClickedButton, message);
@@ -191,7 +182,6 @@ public final class ButtonClickEventBuilder {
         return mockButtonClickEvent(message, clickedButton);
     }
 
-    @Nonnull
     private static Button determineClickedButton(@Nullable Button maybeClickedButton,
             Message message) {
         if (maybeClickedButton != null) {
@@ -203,7 +193,6 @@ public final class ButtonClickEventBuilder {
         return requireSingleButton(getMessageButtons(message));
     }
 
-    @Nonnull
     private static Button requireButtonInMessage(Button clickedButton, Message message) {
         boolean isClickedButtonUnknown =
                 getMessageButtons(message).noneMatch(clickedButton::equals);
@@ -216,7 +205,6 @@ public final class ButtonClickEventBuilder {
         return clickedButton;
     }
 
-    @Nonnull
     private static Button requireSingleButton(Stream<? extends Button> stream) {
         Function<String, ? extends RuntimeException> descriptionToException =
                 IllegalArgumentException::new;
@@ -231,12 +219,10 @@ public final class ButtonClickEventBuilder {
                             + " Add the button to the message first."));
     }
 
-    @Nonnull
     private static Stream<Button> getMessageButtons(Message message) {
         return message.getActionRows().stream().map(ActionRow::getButtons).flatMap(List::stream);
     }
 
-    @Nonnull
     private ButtonInteractionEvent mockButtonClickEvent(Message message, Button clickedButton) {
         ButtonInteractionEvent event = mockEventSupplier.get();
 

--- a/application/src/test/java/org/togetherjava/tjbot/jda/JdaTester.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/JdaTester.java
@@ -31,7 +31,6 @@ import org.mockito.stubbing.Answer;
 import org.togetherjava.tjbot.commands.SlashCommand;
 import org.togetherjava.tjbot.commands.componentids.ComponentIdGenerator;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.EnumSet;
 import java.util.List;
@@ -207,7 +206,6 @@ public final class JdaTester {
      * @param command the command to create an event for
      * @return a builder used to create a Mockito mocked slash command event
      */
-    @Nonnull
     public SlashCommandInteractionEventBuilder createSlashCommandInteractionEvent(
             SlashCommand command) {
         UnaryOperator<SlashCommandInteractionEvent> mockOperator = event -> {
@@ -234,7 +232,6 @@ public final class JdaTester {
      *
      * @return a builder used to create a Mockito mocked slash command event
      */
-    @Nonnull
     public ButtonClickEventBuilder createButtonInteractionEvent() {
         Supplier<ButtonInteractionEvent> mockEventSupplier = () -> {
             ButtonInteractionEvent event = mock(ButtonInteractionEvent.class);
@@ -262,7 +259,6 @@ public final class JdaTester {
      * @param <T> the type of the command to spy on
      * @return the created spy
      */
-    @Nonnull
     public <T extends SlashCommand> T spySlashCommand(T command) {
         T spiedCommand = spy(command);
         spiedCommand
@@ -278,7 +274,6 @@ public final class JdaTester {
      * @param userId the id of the member to create
      * @return the created spy
      */
-    @Nonnull
     public Member createMemberSpy(long userId) {
         UserImpl user = spy(new UserImpl(userId, jda));
         return spy(new MemberImpl(guild, user));
@@ -292,7 +287,6 @@ public final class JdaTester {
      * @param channelId the id of the text channel to create
      * @return the created spy
      */
-    @Nonnull
     public TextChannel createTextChannelSpy(long channelId) {
         return spy(new TextChannelImpl(channelId, guild));
     }
@@ -306,7 +300,6 @@ public final class JdaTester {
      *
      * @return the reply action mock used by this tester
      */
-    @Nonnull
     public ReplyCallbackAction getReplyActionMock() {
         return replyAction;
     }
@@ -320,7 +313,6 @@ public final class JdaTester {
      *
      * @return the interaction hook mock used by this tester
      */
-    @Nonnull
     public InteractionHook getInteractionHookMock() {
         return interactionHook;
     }
@@ -334,7 +326,6 @@ public final class JdaTester {
      *
      * @return the text channel spy used by this tester
      */
-    @Nonnull
     public TextChannel getTextChannelSpy() {
         return textChannel;
     }
@@ -348,7 +339,6 @@ public final class JdaTester {
      *
      * @return the private channel spy used by this tester
      */
-    @Nonnull
     public PrivateChannel getPrivateChannelSpy() {
         return privateChannel;
     }
@@ -363,7 +353,6 @@ public final class JdaTester {
      *
      * @return the member spy used by this tester
      */
-    @Nonnull
     public Member getMemberSpy() {
         return member;
     }
@@ -373,7 +362,6 @@ public final class JdaTester {
      *
      * @return the JDA mock used by this tester
      */
-    @Nonnull
     public JDA getJdaMock() {
         return jda;
     }
@@ -402,7 +390,6 @@ public final class JdaTester {
      * @param <R> the specific type of the Rest Action to return
      * @return the mocked action
      */
-    @Nonnull
     @SuppressWarnings("unchecked")
     public <T, R extends RestAction<T>> R createSucceededActionMock(@Nullable T t,
             Class<R> restActionType) {
@@ -446,7 +433,6 @@ public final class JdaTester {
      * @see #createSucceededActionMock(Object, Class)
      */
     @SuppressWarnings("unchecked")
-    @Nonnull
     public <T> RestAction<T> createSucceededActionMock(@Nullable T t) {
         return createSucceededActionMock(t, RestAction.class);
     }
@@ -476,7 +462,6 @@ public final class JdaTester {
      * @return the mocked action
      */
     @SuppressWarnings("unchecked")
-    @Nonnull
     public <T, R extends RestAction<T>> R createFailedActionMock(Throwable failureReason,
             Class<R> restActionType) {
         R action = mock(restActionType);
@@ -522,7 +507,6 @@ public final class JdaTester {
      * @see #createFailedActionMock(Throwable, Class)
      */
     @SuppressWarnings("unchecked")
-    @Nonnull
     public <T> RestAction<T> createFailedActionMock(Throwable failureReason) {
         return createFailedActionMock(failureReason, RestAction.class);
     }
@@ -536,7 +520,6 @@ public final class JdaTester {
      * @param reason the reason of the error
      * @return the created exception
      */
-    @Nonnull
     public ErrorResponseException createErrorResponseException(ErrorResponse reason) {
         return ErrorResponseException.create(reason, new Response(null, -1, "", -1, Set.of()));
     }
@@ -549,7 +532,6 @@ public final class JdaTester {
      * @param attachments attachments of the message, empty if none
      * @return the event of receiving the given message
      */
-    @Nonnull
     public MessageReceivedEvent createMessageReceiveEvent(Message message,
             List<Message.Attachment> attachments) {
         Message spyMessage = spy(message);

--- a/application/src/test/java/org/togetherjava/tjbot/jda/SlashCommandInteractionEventBuilder.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/SlashCommandInteractionEventBuilder.java
@@ -16,7 +16,6 @@ import org.togetherjava.tjbot.jda.payloads.PayloadMember;
 import org.togetherjava.tjbot.jda.payloads.PayloadUser;
 import org.togetherjava.tjbot.jda.payloads.slashcommand.*;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
@@ -97,7 +96,6 @@ public final class SlashCommandInteractionEventBuilder {
      * @throws IllegalArgumentException if the option does not exist in the corresponding command,
      *         as specified by its {@link SlashCommand#getData()}
      */
-    @Nonnull
     public SlashCommandInteractionEventBuilder setOption(String name, String value) {
         putOptionRaw(name, value, OptionType.STRING);
         return this;
@@ -117,7 +115,6 @@ public final class SlashCommandInteractionEventBuilder {
      * @throws IllegalArgumentException if the option does not exist in the corresponding command,
      *         as specified by its {@link SlashCommand#getData()}
      */
-    @Nonnull
     public SlashCommandInteractionEventBuilder setOption(String name, long value) {
         putOptionRaw(name, value, OptionType.INTEGER);
         return this;
@@ -137,7 +134,6 @@ public final class SlashCommandInteractionEventBuilder {
      * @throws IllegalArgumentException if the option does not exist in the corresponding command,
      *         as specified by its {@link SlashCommand#getData()}
      */
-    @Nonnull
     public SlashCommandInteractionEventBuilder setOption(String name, User value) {
         putOptionRaw(name, value, OptionType.USER);
         return this;
@@ -157,7 +153,6 @@ public final class SlashCommandInteractionEventBuilder {
      * @throws IllegalArgumentException if the option does not exist in the corresponding command,
      *         as specified by its {@link SlashCommand#getData()}
      */
-    @Nonnull
     public SlashCommandInteractionEventBuilder setOption(String name, Member value) {
         putOptionRaw(name, value, OptionType.USER);
         return this;
@@ -168,7 +163,6 @@ public final class SlashCommandInteractionEventBuilder {
      *
      * @return this builder instance for chaining
      */
-    @Nonnull
     public SlashCommandInteractionEventBuilder clearOptions() {
         nameToOption.clear();
         return this;
@@ -185,7 +179,6 @@ public final class SlashCommandInteractionEventBuilder {
      * @throws IllegalArgumentException if the subcommand does not exist in the corresponding
      *         command, as specified by its {@link SlashCommand#getData()}
      */
-    @Nonnull
     public SlashCommandInteractionEventBuilder setSubcommand(@Nullable String subcommand) {
         if (subcommand != null) {
             requireSubcommand(subcommand);
@@ -201,43 +194,36 @@ public final class SlashCommandInteractionEventBuilder {
      * @param userWhoTriggered the user who triggered the slash command
      * @return this builder instance for chaining
      */
-    @Nonnull
     public SlashCommandInteractionEventBuilder setUserWhoTriggered(Member userWhoTriggered) {
         this.userWhoTriggered = userWhoTriggered;
         return this;
     }
 
-    @Nonnull
     SlashCommandInteractionEventBuilder setCommand(SlashCommand command) {
         this.command = command;
         return this;
     }
 
-    @Nonnull
     SlashCommandInteractionEventBuilder setChannelId(String channelId) {
         this.channelId = channelId;
         return this;
     }
 
-    @Nonnull
     SlashCommandInteractionEventBuilder setToken(String token) {
         this.token = token;
         return this;
     }
 
-    @Nonnull
     SlashCommandInteractionEventBuilder setApplicationId(String applicationId) {
         this.applicationId = applicationId;
         return this;
     }
 
-    @Nonnull
     SlashCommandInteractionEventBuilder setGuildId(String guildId) {
         this.guildId = guildId;
         return this;
     }
 
-    @Nonnull
     SlashCommandInteractionEventBuilder setUserId(String userId) {
         this.userId = userId;
         return this;
@@ -249,7 +235,6 @@ public final class SlashCommandInteractionEventBuilder {
      *
      * @return the created slash command instance
      */
-    @Nonnull
     public SlashCommandInteractionEvent build() {
         PayloadSlashCommand event = createEvent();
 
@@ -263,7 +248,6 @@ public final class SlashCommandInteractionEventBuilder {
         return spySlashCommandEvent(json);
     }
 
-    @Nonnull
     private SlashCommandInteractionEvent spySlashCommandEvent(String jsonData) {
         SlashCommandInteractionEvent event = spy(new SlashCommandInteractionEvent(jda, 0,
                 new SlashCommandInteractionImpl(jda, DataObject.fromJson(jsonData))));
@@ -276,7 +260,6 @@ public final class SlashCommandInteractionEventBuilder {
         return event;
     }
 
-    @Nonnull
     private PayloadSlashCommand createEvent() {
         // TODO Validate that required options are set, check that subcommand is given if the
         // command has one
@@ -313,7 +296,6 @@ public final class SlashCommandInteractionEventBuilder {
             .toList();
     }
 
-    @Nonnull
     private static <T> String serializeOptionValue(T value, OptionType type) {
         if (type == OptionType.STRING) {
             return (String) value;
@@ -393,7 +375,6 @@ public final class SlashCommandInteractionEventBuilder {
     }
 
     @SuppressWarnings("UnusedReturnValue")
-    @Nonnull
     private OptionData requireOption(String name, OptionType type) {
         List<OptionData> options = subcommand == null ? command.getData().getOptions()
                 : requireSubcommand(subcommand).getOptions();
@@ -413,7 +394,6 @@ public final class SlashCommandInteractionEventBuilder {
             });
     }
 
-    @Nonnull
     private SubcommandData requireSubcommand(String name) {
         return command.getData()
             .getSubcommands()

--- a/application/src/test/java/org/togetherjava/tjbot/jda/package-info.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/package-info.java
@@ -2,7 +2,10 @@
  * Provides utilities for testing with JDA, such as mocks. See
  * {@link org.togetherjava.tjbot.jda.JdaTester} as entry point.
  */
+@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 package org.togetherjava.tjbot.jda;
+
+import org.togetherjava.tjbot.misc.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/PayloadMember.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/PayloadMember.java
@@ -5,7 +5,6 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,7 +43,6 @@ public final class PayloadMember {
         this.user = user;
     }
 
-    @Nonnull
     public static PayloadMember of(Member member) {
         String permissions = Long
             .toString(Permission.getRaw(member.getPermissions().toArray(Permission[]::new)));
@@ -56,7 +54,6 @@ public final class PayloadMember {
                 member.isPending(), user);
     }
 
-    @Nonnull
     public PayloadUser getUser() {
         return user;
     }
@@ -83,7 +80,6 @@ public final class PayloadMember {
         this.nick = nick;
     }
 
-    @Nonnull
     public String getJoinedAt() {
         return joinedAt;
     }
@@ -92,7 +88,6 @@ public final class PayloadMember {
         this.joinedAt = joinedAt;
     }
 
-    @Nonnull
     public String getPermissions() {
         return permissions;
     }
@@ -101,7 +96,6 @@ public final class PayloadMember {
         this.permissions = permissions;
     }
 
-    @Nonnull
     public List<String> getRoles() {
         return Collections.unmodifiableList(roles);
     }

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/PayloadUser.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/PayloadUser.java
@@ -3,7 +3,6 @@ package org.togetherjava.tjbot.jda.payloads;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import net.dv8tion.jda.api.entities.User;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public final class PayloadUser {
@@ -24,7 +23,6 @@ public final class PayloadUser {
         this.discriminator = discriminator;
     }
 
-    @Nonnull
     public static PayloadUser of(User user) {
         return new PayloadUser(user.isBot(), user.getFlagsRaw(), user.getId(), user.getAvatarId(),
                 user.getName(), user.getDiscriminator());
@@ -46,7 +44,6 @@ public final class PayloadUser {
         this.publicFlags = publicFlags;
     }
 
-    @Nonnull
     public String getId() {
         return id;
     }
@@ -64,7 +61,6 @@ public final class PayloadUser {
         this.avatar = avatar;
     }
 
-    @Nonnull
     public String getUsername() {
         return username;
     }
@@ -73,7 +69,6 @@ public final class PayloadUser {
         this.username = username;
     }
 
-    @Nonnull
     public String getDiscriminator() {
         return discriminator;
     }

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommand.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommand.java
@@ -3,8 +3,6 @@ package org.togetherjava.tjbot.jda.payloads.slashcommand;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.togetherjava.tjbot.jda.payloads.PayloadMember;
 
-import javax.annotation.Nonnull;
-
 public final class PayloadSlashCommand {
     @JsonProperty("guild_id")
     private String guildId;
@@ -33,7 +31,6 @@ public final class PayloadSlashCommand {
         this.data = data;
     }
 
-    @Nonnull
     public String getGuildId() {
         return guildId;
     }
@@ -42,7 +39,6 @@ public final class PayloadSlashCommand {
         this.guildId = guildId;
     }
 
-    @Nonnull
     public String getId() {
         return id;
     }
@@ -67,7 +63,6 @@ public final class PayloadSlashCommand {
         this.version = version;
     }
 
-    @Nonnull
     public String getChannelId() {
         return channelId;
     }
@@ -76,7 +71,6 @@ public final class PayloadSlashCommand {
         this.channelId = channelId;
     }
 
-    @Nonnull
     public String getApplicationId() {
         return applicationId;
     }
@@ -85,7 +79,6 @@ public final class PayloadSlashCommand {
         this.applicationId = applicationId;
     }
 
-    @Nonnull
     public String getToken() {
         return token;
     }
@@ -94,7 +87,6 @@ public final class PayloadSlashCommand {
         this.token = token;
     }
 
-    @Nonnull
     public PayloadMember getMember() {
         return member;
     }
@@ -103,7 +95,6 @@ public final class PayloadSlashCommand {
         this.member = member;
     }
 
-    @Nonnull
     public PayloadSlashCommandData getData() {
         return data;
     }

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandData.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandData.java
@@ -2,7 +2,6 @@ package org.togetherjava.tjbot.jda.payloads.slashcommand;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,7 +26,6 @@ public final class PayloadSlashCommandData {
         this.resolved = resolved;
     }
 
-    @Nonnull
     public String getName() {
         return name;
     }
@@ -36,7 +34,6 @@ public final class PayloadSlashCommandData {
         this.name = name;
     }
 
-    @Nonnull
     public String getId() {
         return id;
     }

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandMembers.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandMembers.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import org.togetherjava.tjbot.jda.payloads.PayloadMember;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,7 +16,6 @@ public final class PayloadSlashCommandMembers {
     }
 
     @JsonAnyGetter
-    @Nonnull
     public Map<String, PayloadMember> getIdToMember() {
         return Collections.unmodifiableMap(idToMember);
     }

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandOption.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandOption.java
@@ -2,7 +2,6 @@ package org.togetherjava.tjbot.jda.payloads.slashcommand;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -23,7 +22,6 @@ public final class PayloadSlashCommandOption {
         this.options = options == null ? null : new ArrayList<>(options);
     }
 
-    @Nonnull
     public String getName() {
         return name;
     }

--- a/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandUsers.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/payloads/slashcommand/PayloadSlashCommandUsers.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import org.togetherjava.tjbot.jda.payloads.PayloadUser;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,7 +16,6 @@ public final class PayloadSlashCommandUsers {
     }
 
     @JsonAnyGetter
-    @Nonnull
     public Map<String, PayloadUser> getIdToUser() {
         return Collections.unmodifiableMap(idToUser);
     }

--- a/application/src/test/java/org/togetherjava/tjbot/logging/FilterTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/logging/FilterTest.java
@@ -26,7 +26,6 @@ final class FilterTest {
         Assertions.assertEquals(Filter.Result.NEUTRAL, spy.filter(this.event));
     }
 
-
     @Test
     void shouldNotPassFilter() {
         FlaggedFilter spy = Mockito.spy(this.filter);


### PR DESCRIPTION
Closes #548. Similar to #541, this adds an annotation `@MethodsReturnNonnullByDefault` to all packages.

Effectively making `@Nonnull` completely obsolete in our code base - hence also removing it everywhere.

The annotation is self-written (idea snacked from Minecraft who has this annotation as well - credits go to Quinteger for raising awareness).

The PR will of course generate a lot of (simple) merge conflicts - again. But I think people will like it 👍 