### PR TITLE
Auto posting advice on uncategorized help threads

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
@@ -64,7 +64,7 @@ public class Features {
         ModerationActionsStore actionsStore = new ModerationActionsStore(database);
         ModAuditLogWriter modAuditLogWriter = new ModAuditLogWriter(config);
         ScamHistoryStore scamHistoryStore = new ScamHistoryStore(database);
-        HelpSystemHelper helpSystemHelper = new HelpSystemHelper(config, database);
+        HelpSystemHelper helpSystemHelper = new HelpSystemHelper(jda, config, database);
 
         // NOTE The system can add special system relevant commands also by itself,
         // hence this list may not necessarily represent the full list of all commands actually

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -1,6 +1,8 @@
 package org.togetherjava.tjbot.commands.help;
 
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
@@ -19,6 +21,9 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -46,20 +51,26 @@ public final class HelpSystemHelper {
     static final int TITLE_COMPACT_LENGTH_MIN = 2;
     static final int TITLE_COMPACT_LENGTH_MAX = 70;
 
+    private static final ScheduledExecutorService SERVICE = Executors.newScheduledThreadPool(3);
+    private static final int SEND_UNCATEGORIZED_ADVICE_AFTER_MINUTES = 5;
+
     private final Predicate<String> isOverviewChannelName;
     private final String overviewChannelPattern;
     private final Predicate<String> isStagingChannelName;
     private final String stagingChannelPattern;
     private final String categoryRoleSuffix;
     private final Database database;
+    private final JDA jda;
 
     /**
      * Creates a new instance.
      *
+     * @param jda the JDA instance to use
      * @param config the config to use
      * @param database the database to store help thread metadata in
      */
-    public HelpSystemHelper(Config config, Database database) {
+    public HelpSystemHelper(JDA jda, Config config, Database database) {
+        this.jda = jda;
         HelpSystemConfig helpConfig = config.getHelpSystem();
         this.database = database;
 
@@ -237,6 +248,50 @@ public final class HelpSystemHelper {
             .stream()
             .filter(Predicate.not(ThreadChannel::isArchived))
             .toList();
+    }
+
+    void scheduleUncategorizedAdviceCheck(long threadChannelId, long authorId) {
+        SERVICE.schedule(() -> {
+            try {
+                executeUncategorizedAdviceCheck(threadChannelId, authorId);
+            } catch (Exception e) {
+                logger.warn(
+                        "Unknown error during an uncategorized advice check on thread {} by author {}.",
+                        threadChannelId, authorId, e);
+            }
+        }, SEND_UNCATEGORIZED_ADVICE_AFTER_MINUTES, TimeUnit.MINUTES);
+    }
+
+    private void executeUncategorizedAdviceCheck(long threadChannelId, long authorId) {
+        logger.debug("Executing uncategorized advice check for thread {} by author {}.",
+                threadChannelId, authorId);
+        jda.retrieveUserById(authorId).flatMap(author -> {
+            ThreadChannel threadChannel = jda.getThreadChannelById(threadChannelId);
+            if (threadChannel == null) {
+                logger.debug(
+                        "Channel for uncategorized advice check seems to be deleted (thread {} by author {}).",
+                        threadChannelId, authorId);
+                return new CompletedRestAction<>(jda, null);
+            }
+
+            Optional<String> category = getCategoryOfChannel(threadChannel);
+            if (category.isPresent()) {
+                logger.debug(
+                        "Channel for uncategorized advice check seems to have a category now (thread {} by author {}).",
+                        threadChannelId, authorId);
+                return new CompletedRestAction<>(jda, null);
+            }
+
+            // Still no category, send advice
+            MessageEmbed embed = HelpSystemHelper.embedWith(
+                    """
+                            Hey there 👋 You have to select a category for your help thread, otherwise nobody can see your question.
+                            Please use the `/change-help-category` slash-command and pick what fits best, thanks 🙂
+                            """);
+            Message message = new MessageBuilder(author.getAsMention()).setEmbeds(embed).build();
+
+            return threadChannel.sendMessage(message);
+        }).queue();
     }
 
     record HelpThreadName(@Nullable ThreadActivity activity, @Nullable String category,

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
@@ -162,7 +162,12 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
         return sendInitialMessage(threadChannel, message, title)
             .flatMap(any -> notifyUser(threadChannel, message))
             .flatMap(any -> message.delete())
-            .flatMap(any -> helper.sendExplanationMessage(threadChannel));
+            .flatMap(any -> helper.sendExplanationMessage(threadChannel))
+            .<Void>map(any -> {
+                helper.scheduleUncategorizedAdviceCheck(threadChannel.getIdLong(),
+                        author.getIdLong());
+                return null;
+            });
     }
 
     private static MessageAction sendInitialMessage(ThreadChannel threadChannel,


### PR DESCRIPTION
## Overview

Closes #487 .

Reminds the user of selecting a category for their help threads if they still dont have one after **5 minutes**:

![example](https://i.imgur.com/pnwpfOb.png)

Technically, its solved with a simple scheduled task - scheduled after creation of threads without categories (`ImplicitAskListener`).

## Notes

I put the code for that into `HelpSystemHelper` since the executor service (with 3 threads) should be reused for #481 and similar issues.

The ping is outside of the embed to ensure it actually pings the author, instead of just a soft-ping. But I still wanted to keep using the embed instead of a raw message for the better UI.

Before someone asks during CR, there is no overload for `retrieveThreadChannelById` or similar. JDAs cache seems to be a reliable source for channels, similar to guilds (i.e. JDA seems to receive all updates to them and keeps the cache up2date - unlike for users).