### PR TITLE
Use slash-command mentions (#559)

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
@@ -48,7 +48,7 @@ import static org.togetherjava.tjbot.commands.help.HelpSystemHelper.TITLE_COMPAC
  */
 public final class AskCommand extends SlashCommandAdapter {
     private static final Logger logger = LoggerFactory.getLogger(AskCommand.class);
-
+    public static final String COMMAND_NAME = "ask";
     private static final String TITLE_OPTION = "title";
     private static final String CATEGORY_OPTION = "category";
     private final HelpSystemHelper helper;
@@ -128,7 +128,7 @@ public final class AskCommand extends SlashCommandAdapter {
         helper.writeHelpThreadToDatabase(author, threadChannel);
         return sendInitialMessage(guild, threadChannel, author, title, category)
             .flatMap(any -> notifyUser(eventHook, threadChannel))
-            .flatMap(any -> helper.sendExplanationMessage(guild, threadChannel));
+            .flatMap(any -> helper.sendExplanationMessage(threadChannel));
     }
 
     private RestAction<Message> sendInitialMessage(Guild guild, ThreadChannel threadChannel,

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
@@ -128,7 +128,7 @@ public final class AskCommand extends SlashCommandAdapter {
         helper.writeHelpThreadToDatabase(author, threadChannel);
         return sendInitialMessage(guild, threadChannel, author, title, category)
             .flatMap(any -> notifyUser(eventHook, threadChannel))
-            .flatMap(any -> helper.sendExplanationMessage(threadChannel));
+            .flatMap(any -> helper.sendExplanationMessage(guild, threadChannel));
     }
 
     private RestAction<Message> sendInitialMessage(Guild guild, ThreadChannel threadChannel,

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -314,7 +314,7 @@ public final class HelpSystemHelper {
 
             // Still no category, send advice
             return MessageUtils.mentionSlashCommand(threadChannel.getGuild(),
-                    String.join(HelpThreadCommand.COMMAND_NAME, HelpThreadCommand.CHANGE_SUBCOMMAND,
+                    String.join(" ", HelpThreadCommand.COMMAND_NAME, HelpThreadCommand.CHANGE_SUBCOMMAND,
                             HelpThreadCommand.Subcommand.CHANGE_CATEGORY.getCommandName()))
                 .flatMap(command -> {
                     MessageEmbed embed = HelpSystemHelper.embedWith(

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -92,7 +92,7 @@ public final class HelpSystemHelper {
         categoryRoleSuffix = helpConfig.getCategoryRoleSuffix();
     }
 
-    RestAction<Message> sendExplanationMessage(Guild guild, MessageChannel threadChannel) {
+    RestAction<Message> sendExplanationMessage(GuildMessageChannel threadChannel) {
         boolean useCodeSyntaxExampleImage = true;
         InputStream codeSyntaxExampleData =
                 AskCommand.class.getResourceAsStream("/" + CODE_SYNTAX_EXAMPLE_PATH);
@@ -117,8 +117,11 @@ public final class HelpSystemHelper {
                                     **provide details**, context, more code, examples and maybe some screenshots. \
                                     With enough info, someone knows the answer for sure."""),
                 HelpSystemHelper.embedWith(
-                        "Don't forget to close your thread using the command **%s close** when your question has been answered, thanks."
-                            .formatted(MessageUtils.mentionSlashCommand(guild, "help-thread"))));
+                        "Don't forget to close your thread using the command %s when your question has been answered, thanks."
+                            .formatted(MessageUtils
+                                .mentionSlashCommand(threadChannel.getGuild(),
+                                        CloseCommand.COMMAND_NAME)
+                                .complete())));
 
         MessageCreateAction action = threadChannel.sendMessage(message);
         if (useCodeSyntaxExampleImage) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -17,6 +17,7 @@ import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import net.dv8tion.jda.internal.requests.CompletedRestAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.togetherjava.tjbot.commands.utils.MessageUtils;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.config.HelpSystemConfig;
@@ -95,8 +96,9 @@ public final class HelpSystemHelper {
 
     RestAction<Message> sendExplanationMessage(GuildMessageChannel threadChannel) {
         return MessageUtils
-            .mentionSlashCommand(threadChannel.getGuild(), HelpThreadCommand.COMMAND_NAME,
-                    HelpThreadCommand.Subcommand.CLOSE.getCommandName())
+            .mentionSlashCommand(threadChannel.getGuild(),
+                    String.join(" ", HelpThreadCommand.COMMAND_NAME,
+                            HelpThreadCommand.Subcommand.CLOSE.getCommandName()))
             .flatMap(closeCommandMention -> sendExplanationMessage(threadChannel,
                     closeCommandMention));
     }
@@ -311,10 +313,9 @@ public final class HelpSystemHelper {
             }
 
             // Still no category, send advice
-            return MessageUtils
-                .mentionSlashCommand(threadChannel.getGuild(), HelpThreadCommand.COMMAND_NAME,
-                        HelpThreadCommand.CHANGE_SUBCOMMAND,
-                        HelpThreadCommand.Subcommand.CHANGE_CATEGORY.getCommandName())
+            return MessageUtils.mentionSlashCommand(threadChannel.getGuild(),
+                    String.join(HelpThreadCommand.COMMAND_NAME, HelpThreadCommand.CHANGE_SUBCOMMAND,
+                            HelpThreadCommand.Subcommand.CHANGE_CATEGORY.getCommandName()))
                 .flatMap(command -> {
                     MessageEmbed embed = HelpSystemHelper.embedWith(
                             """

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -93,6 +93,12 @@ public final class HelpSystemHelper {
     }
 
     RestAction<Message> sendExplanationMessage(GuildMessageChannel threadChannel) {
+        return MessageUtils.mentionSlashCommand(threadChannel.getGuild(), CloseCommand.COMMAND_NAME)
+            .flatMap(command -> sendExplanationMessage(threadChannel, command));
+    }
+
+    private RestAction<Message> sendExplanationMessage(GuildMessageChannel threadChannel,
+            String command) {
         boolean useCodeSyntaxExampleImage = true;
         InputStream codeSyntaxExampleData =
                 AskCommand.class.getResourceAsStream("/" + CODE_SYNTAX_EXAMPLE_PATH);
@@ -118,10 +124,7 @@ public final class HelpSystemHelper {
                                     With enough info, someone knows the answer for sure."""),
                 HelpSystemHelper.embedWith(
                         "Don't forget to close your thread using the command %s when your question has been answered, thanks."
-                            .formatted(MessageUtils
-                                .mentionSlashCommand(threadChannel.getGuild(),
-                                        CloseCommand.COMMAND_NAME)
-                                .complete())));
+                            .formatted(command)));
 
         MessageCreateAction action = threadChannel.sendMessage(message);
         if (useCodeSyntaxExampleImage) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -97,8 +97,8 @@ public final class HelpSystemHelper {
     RestAction<Message> sendExplanationMessage(GuildMessageChannel threadChannel) {
         return MessageUtils
             .mentionSlashCommand(threadChannel.getGuild(),
-                    String.join(" ", HelpThreadCommand.COMMAND_NAME,
-                            HelpThreadCommand.Subcommand.CLOSE.getCommandName()))
+                    HelpThreadCommand.COMMAND_NAME,
+                            HelpThreadCommand.Subcommand.CLOSE.getCommandName())
             .flatMap(closeCommandMention -> sendExplanationMessage(threadChannel,
                     closeCommandMention));
     }
@@ -314,8 +314,8 @@ public final class HelpSystemHelper {
 
             // Still no category, send advice
             return MessageUtils.mentionSlashCommand(threadChannel.getGuild(),
-                    String.join(" ", HelpThreadCommand.COMMAND_NAME, HelpThreadCommand.CHANGE_SUBCOMMAND,
-                            HelpThreadCommand.Subcommand.CHANGE_CATEGORY.getCommandName()))
+                    HelpThreadCommand.COMMAND_NAME, HelpThreadCommand.CHANGE_SUBCOMMAND_GROUP,
+                            HelpThreadCommand.Subcommand.CHANGE_CATEGORY.getCommandName())
                 .flatMap(command -> {
                     MessageEmbed embed = HelpSystemHelper.embedWith(
                             """

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -96,9 +96,8 @@ public final class HelpSystemHelper {
 
     RestAction<Message> sendExplanationMessage(GuildMessageChannel threadChannel) {
         return MessageUtils
-            .mentionSlashCommand(threadChannel.getGuild(),
-                    HelpThreadCommand.COMMAND_NAME,
-                            HelpThreadCommand.Subcommand.CLOSE.getCommandName())
+            .mentionSlashCommand(threadChannel.getGuild(), HelpThreadCommand.COMMAND_NAME,
+                    HelpThreadCommand.Subcommand.CLOSE.getCommandName())
             .flatMap(closeCommandMention -> sendExplanationMessage(threadChannel,
                     closeCommandMention));
     }
@@ -313,9 +312,10 @@ public final class HelpSystemHelper {
             }
 
             // Still no category, send advice
-            return MessageUtils.mentionSlashCommand(threadChannel.getGuild(),
-                    HelpThreadCommand.COMMAND_NAME, HelpThreadCommand.CHANGE_SUBCOMMAND_GROUP,
-                            HelpThreadCommand.Subcommand.CHANGE_CATEGORY.getCommandName())
+            return MessageUtils
+                .mentionSlashCommand(threadChannel.getGuild(), HelpThreadCommand.COMMAND_NAME,
+                        HelpThreadCommand.CHANGE_SUBCOMMAND_GROUP,
+                        HelpThreadCommand.Subcommand.CHANGE_CATEGORY.getCommandName())
                 .flatMap(command -> {
                     MessageEmbed embed = HelpSystemHelper.embedWith(
                             """

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -16,7 +16,7 @@ import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import net.dv8tion.jda.internal.requests.CompletedRestAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import org.togetherjava.tjbot.commands.utils.MessageUtils;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.config.HelpSystemConfig;
 import org.togetherjava.tjbot.db.Database;
@@ -92,7 +92,7 @@ public final class HelpSystemHelper {
         categoryRoleSuffix = helpConfig.getCategoryRoleSuffix();
     }
 
-    RestAction<Message> sendExplanationMessage(MessageChannel threadChannel) {
+    RestAction<Message> sendExplanationMessage(Guild guild, MessageChannel threadChannel) {
         boolean useCodeSyntaxExampleImage = true;
         InputStream codeSyntaxExampleData =
                 AskCommand.class.getResourceAsStream("/" + CODE_SYNTAX_EXAMPLE_PATH);
@@ -117,7 +117,8 @@ public final class HelpSystemHelper {
                                     **provide details**, context, more code, examples and maybe some screenshots. \
                                     With enough info, someone knows the answer for sure."""),
                 HelpSystemHelper.embedWith(
-                        "Don't forget to close your thread using the command **/help-thread close** when your question has been answered, thanks."));
+                        "Don't forget to close your thread using the command **%s close** when your question has been answered, thanks."
+                            .formatted(MessageUtils.mentionSlashCommand(guild, "help-thread"))));
 
         MessageCreateAction action = threadChannel.sendMessage(message);
         if (useCodeSyntaxExampleImage) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadCommand.java
@@ -45,7 +45,7 @@ public final class HelpThreadCommand extends SlashCommandAdapter {
     private static final String CHANGE_CATEGORY_OPTION = "category";
     private static final String CHANGE_TITLE_OPTION = "title";
     private static final String CHANGE_TITLE_SUBCOMMAND = "title";
-    public static final String CHANGE_SUBCOMMAND = "change";
+    public static final String CHANGE_SUBCOMMAND_GROUP = "change";
     public static final String COMMAND_NAME = "help-thread";
 
     private final HelpSystemHelper helper;
@@ -75,7 +75,7 @@ public final class HelpThreadCommand extends SlashCommandAdapter {
             .addOption(OptionType.STRING, CHANGE_TITLE_OPTION, "new title", true);
 
         SubcommandGroupData changeCommands =
-                new SubcommandGroupData(CHANGE_SUBCOMMAND, "Change the details of this help thread")
+                new SubcommandGroupData(CHANGE_SUBCOMMAND_GROUP, "Change the details of this help thread")
                     .addSubcommands(changeCategory, changeTitle);
         getData().addSubcommandGroups(changeCommands);
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadCommand.java
@@ -74,9 +74,9 @@ public final class HelpThreadCommand extends SlashCommandAdapter {
         SubcommandData changeTitle = Subcommand.CHANGE_TITLE.toSubcommandData()
             .addOption(OptionType.STRING, CHANGE_TITLE_OPTION, "new title", true);
 
-        SubcommandGroupData changeCommands =
-                new SubcommandGroupData(CHANGE_SUBCOMMAND_GROUP, "Change the details of this help thread")
-                    .addSubcommands(changeCategory, changeTitle);
+        SubcommandGroupData changeCommands = new SubcommandGroupData(CHANGE_SUBCOMMAND_GROUP,
+                "Change the details of this help thread").addSubcommands(changeCategory,
+                        changeTitle);
         getData().addSubcommandGroups(changeCommands);
 
         getData().addSubcommands(Subcommand.CLOSE.toSubcommandData());

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadCommand.java
@@ -45,6 +45,8 @@ public final class HelpThreadCommand extends SlashCommandAdapter {
     private static final String CHANGE_CATEGORY_OPTION = "category";
     private static final String CHANGE_TITLE_OPTION = "title";
     private static final String CHANGE_TITLE_SUBCOMMAND = "title";
+    public static final String CHANGE_SUBCOMMAND = "change";
+    public static final String COMMAND_NAME = "help-thread";
 
     private final HelpSystemHelper helper;
     private final Map<String, Subcommand> nameToSubcommand;
@@ -58,7 +60,7 @@ public final class HelpThreadCommand extends SlashCommandAdapter {
      * @param helper the helper to use
      */
     public HelpThreadCommand(Config config, HelpSystemHelper helper) {
-        super("help-thread", "Help thread specific commands", CommandVisibility.GUILD);
+        super(COMMAND_NAME, "Help thread specific commands", CommandVisibility.GUILD);
 
         OptionData categoryChoices =
                 new OptionData(OptionType.STRING, CHANGE_CATEGORY_OPTION, "new category", true);
@@ -73,7 +75,7 @@ public final class HelpThreadCommand extends SlashCommandAdapter {
             .addOption(OptionType.STRING, CHANGE_TITLE_OPTION, "new title", true);
 
         SubcommandGroupData changeCommands =
-                new SubcommandGroupData("change", "Change the details of this help thread")
+                new SubcommandGroupData(CHANGE_SUBCOMMAND, "Change the details of this help thread")
                     .addSubcommands(changeCategory, changeTitle);
         getData().addSubcommandGroups(changeCommands);
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
@@ -185,9 +185,9 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
             .build();
 
         return MessageUtils
-            .mentionSlashCommand(originalMessage.getGuild(),
-                    HelpThreadCommand.COMMAND_NAME, HelpThreadCommand.CHANGE_SUBCOMMAND_GROUP,
-                            HelpThreadCommand.Subcommand.CHANGE_CATEGORY.getCommandName())
+            .mentionSlashCommand(originalMessage.getGuild(), HelpThreadCommand.COMMAND_NAME,
+                    HelpThreadCommand.CHANGE_SUBCOMMAND_GROUP,
+                    HelpThreadCommand.Subcommand.CHANGE_CATEGORY.getCommandName())
             .flatMap(command -> {
                 MessageCreateData threadMessage = new MessageCreateBuilder()
                     .setContent("""

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
@@ -10,7 +10,6 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.requests.RestAction;
-import net.dv8tion.jda.api.requests.restaction.MessageCreateAction;
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import org.slf4j.Logger;
@@ -120,7 +119,7 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
                 : lastHelpThread.getAsMention();
 
         MessageUtils.mentionSlashCommand(message.getGuild(), AskCommand.COMMAND_NAME)
-            .map(command -> message.getChannel()
+            .flatMap(command -> message.getChannel()
                 .sendMessage("""
                         %s Please use %s to follow up on your question, \
                         or use %s to ask a new questions, thanks."""
@@ -186,14 +185,18 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
             .build();
 
         return MessageUtils
-            .mentionSlashCommand(originalMessage.getGuild(), ChangeHelpCategoryCommand.COMMAND_NAME)
+            .mentionSlashCommand(originalMessage.getGuild(), HelpThreadCommand.COMMAND_NAME,
+                    HelpThreadCommand.CHANGE_SUBCOMMAND,
+                    HelpThreadCommand.Subcommand.CHANGE_CATEGORY.getCommandName())
             .flatMap(command -> {
                 MessageCreateData threadMessage = new MessageCreateBuilder()
-                        .setContent("""
-                        %s has a question about '**%s**' and will send the details now.
+                    .setContent("""
+                            %s has a question about '**%s**' and will send the details now.
 
-                        Please use %s to greatly increase the visibility of the question."""
-                    .formatted(author, title, command)).setEmbeds(embed).build();
+                            Please use %s to greatly increase the visibility of the question."""
+                        .formatted(author, title, command))
+                    .setEmbeds(embed)
+                    .build();
 
                 return threadChannel.sendMessage(threadMessage);
             });

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
@@ -185,9 +185,9 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
             .build();
 
         return MessageUtils
-            .mentionSlashCommand(originalMessage.getGuild(), HelpThreadCommand.COMMAND_NAME,
-                    HelpThreadCommand.CHANGE_SUBCOMMAND,
-                    HelpThreadCommand.Subcommand.CHANGE_CATEGORY.getCommandName())
+            .mentionSlashCommand(originalMessage.getGuild(),
+                    String.join(HelpThreadCommand.COMMAND_NAME, HelpThreadCommand.CHANGE_SUBCOMMAND,
+                            HelpThreadCommand.Subcommand.CHANGE_CATEGORY.getCommandName()))
             .flatMap(command -> {
                 MessageCreateData threadMessage = new MessageCreateBuilder()
                     .setContent("""

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
@@ -186,7 +186,7 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
 
         return MessageUtils
             .mentionSlashCommand(originalMessage.getGuild(),
-                    String.join(HelpThreadCommand.COMMAND_NAME, HelpThreadCommand.CHANGE_SUBCOMMAND,
+                    String.join(" ", HelpThreadCommand.COMMAND_NAME, HelpThreadCommand.CHANGE_SUBCOMMAND,
                             HelpThreadCommand.Subcommand.CHANGE_CATEGORY.getCommandName()))
             .flatMap(command -> {
                 MessageCreateData threadMessage = new MessageCreateBuilder()

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
@@ -186,8 +186,8 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
 
         return MessageUtils
             .mentionSlashCommand(originalMessage.getGuild(),
-                    String.join(" ", HelpThreadCommand.COMMAND_NAME, HelpThreadCommand.CHANGE_SUBCOMMAND,
-                            HelpThreadCommand.Subcommand.CHANGE_CATEGORY.getCommandName()))
+                    HelpThreadCommand.COMMAND_NAME, HelpThreadCommand.CHANGE_SUBCOMMAND_GROUP,
+                            HelpThreadCommand.Subcommand.CHANGE_CATEGORY.getCommandName())
             .flatMap(command -> {
                 MessageCreateData threadMessage = new MessageCreateBuilder()
                     .setContent("""

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/ImplicitAskListener.java
@@ -123,7 +123,9 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
             .sendMessage("""
                     %s Please use %s to follow up on your question, \
                     or use %s to ask a new questions, thanks.""".formatted(author.getAsMention(),
-                    threadDescription, MessageUtils.mentionSlashCommand(message.getGuild(), "ask")))
+                    threadDescription,
+                    MessageUtils.mentionSlashCommand(message.getGuild(), AskCommand.COMMAND_NAME)
+                        .complete()))
             .flatMap(any -> message.delete())
             .queue();
         return false;
@@ -167,7 +169,7 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
         return sendInitialMessage(threadChannel, message, title)
             .flatMap(any -> notifyUser(threadChannel, message))
             .flatMap(any -> message.delete())
-            .flatMap(any -> helper.sendExplanationMessage(message.getGuild(), threadChannel))
+            .flatMap(any -> helper.sendExplanationMessage(threadChannel))
             .onSuccess(any -> helper.scheduleUncategorizedAdviceCheck(threadChannel.getIdLong(),
                     author.getIdLong()));
     }
@@ -187,9 +189,12 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
             .setContent("""
                     %s has a question about '**%s**' and will send the details now.
 
-                Please use **%s change category** to greatly increase the visibility of the question."""
-            .formatted(author, title, MessageUtils.mentionSlashCommand(originalMessage.getGuild(),
-                    "help-thread"))).setEmbeds(embed).build();
+                Please use %s to greatly increase the visibility of the question.""".formatted(
+                author, title,
+                MessageUtils
+                    .mentionSlashCommand(originalMessage.getGuild(),
+                            ChangeHelpCategoryCommand.COMMAND_NAME)
+                    .complete())).setEmbeds(embed).build();
 
         return threadChannel.sendMessage(threadMessage);
     }
@@ -199,7 +204,8 @@ public final class ImplicitAskListener extends MessageReceiverAdapter {
             .sendMessage("""
                     %s Please use %s to ask questions. Don't worry though, I created %s for you. \
                     Please continue there, thanks.""".formatted(message.getAuthor().getAsMention(),
-                    MessageUtils.mentionSlashCommand(message.getGuild(), "ask"),
+                    MessageUtils.mentionSlashCommand(message.getGuild(), AskCommand.COMMAND_NAME)
+                        .complete(),
                     threadChannel.getAsMention()));
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
@@ -64,12 +64,13 @@ public class MessageUtils {
      * in Discord.
      *
      * @param guild the {@link Guild} that contains the command
-     * @param commandPath full command path with subcommand groups and subcommands
+     * @param commandName the command's name
+     * @param subCommands optional subcommands, depending on the base command used
      * @return Formatted string for the mentioned slash command
      * @throws IllegalArgumentException when the command isn't found in the guild
      */
-    public static RestAction<String> mentionSlashCommand(Guild guild, String... commandPath) {
-        String commandName = commandPath[0];
+    public static RestAction<String> mentionSlashCommand(Guild guild, String commandName,
+            String... subCommands) {
         return guild.retrieveCommands().map(guildCommands -> {
             Command guildCommand = guildCommands.stream()
                 .filter(c -> c.getName().equalsIgnoreCase(commandName))
@@ -77,6 +78,10 @@ public class MessageUtils {
                 .orElseThrow(
                         () -> new IllegalArgumentException("Command '%s' does not exist in guild %s"
                             .formatted(commandName, guild.getId())));
+            String commandPath = commandName;
+            if (subCommands.length > 0) {
+                commandPath = commandPath + " " + String.join(" ", subCommands);
+            }
             return String.format("</%s:%s>", String.join(" ", commandPath), guildCommand.getId());
         });
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
@@ -8,6 +8,7 @@ import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.MarkdownSanitizer;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -64,21 +65,25 @@ public class MessageUtils {
      * in Discord.
      *
      * @param guild the {@link Guild} that contains the command
-     * @param commandInput the command's name
+     * @param baseCommandName the command's name
+     * @param subcommands optional subcommands, depending on the base command used
      * @return Formatted string for the mentioned slash command
      * @throws IllegalArgumentException when the command name doesn't match with the guild's
      *         commands
      */
-    public static RestAction<String> mentionSlashCommand(Guild guild, String... commandInput) {
-        String commandWithOptions = String.join(" ", commandInput);
+    public static RestAction<String> mentionSlashCommand(Guild guild, String baseCommandName,
+            String... subcommands) {
+        List<String> fullCommand = new ArrayList<>(List.of(baseCommandName));
+        fullCommand.addAll(List.of(subcommands));
         return guild.retrieveCommands().map(guildCommands -> {
             Command guildCommand = guildCommands.stream()
-                .filter(c -> c.getName().equalsIgnoreCase(commandInput[0]))
+                .filter(c -> c.getName().equalsIgnoreCase(baseCommandName))
                 .findAny()
                 .orElseThrow(
-                        () -> new IllegalArgumentException("Command %s does not exist in guild %s"
-                            .formatted(commandWithOptions, guild.getId())));
-            return String.format("</%s:%d>", commandWithOptions, guildCommand.getIdLong());
+                        () -> new IllegalArgumentException("Command '%s' does not exist in guild %s"
+                            .formatted(String.join(" ", fullCommand), guild.getId())));
+            return String.format("</%s:%d>", String.join(" ", fullCommand),
+                    guildCommand.getIdLong());
         });
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
@@ -2,13 +2,13 @@ package org.togetherjava.tjbot.commands.utils;
 
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.MarkdownSanitizer;
-import org.togetherjava.tjbot.commands.help.CloseCommand;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Utility methods for {@link Message}.
@@ -61,25 +61,23 @@ public class MessageUtils {
 
     /**
      * Converts a slash command text to a mentioned slash command, which you can directly click on
-     * in Discord
+     * in Discord.
      *
-     * @param guild guild that owns the command
-     * @param command command name
-     * @return Formatted string for mentioned slash command
+     * @param guild the {@link Guild} that contains the command
+     * @param command the command's name
+     * @return Formatted string for the mentioned slash command
      * @throws IllegalArgumentException when the command name doesn't match with the guild's
      *         commands
      */
-    public static String mentionSlashCommand(Guild guild, String command) {
-        AtomicLong commandId = new AtomicLong();
-        guild.retrieveCommands()
-            .queue(commands -> commands.stream()
+    public static RestAction<String> mentionSlashCommand(Guild guild, String command) {
+        return guild.retrieveCommands().map(commands -> {
+            Command foundCommand = commands.stream()
                 .filter(c -> c.getName().equalsIgnoreCase(command))
                 .findFirst()
-                .ifPresentOrElse(c -> commandId.set(c.getIdLong()), () -> {
-                    throw new IllegalArgumentException("Command %s does not exist in guild %s"
-                        .formatted(command, guild.getId()));
-                }));
-        return String.format("</%s:%d>", command, commandId.get());
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Command %s does not exist in guild %s".formatted(command, guild.getId())));
+            return String.format("</%s:%d>", command, foundCommand.getIdLong());
+        });
     }
 
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
@@ -69,7 +69,7 @@ public class MessageUtils {
      * @throws IllegalArgumentException when the command isn't found in the guild
      */
     public static RestAction<String> mentionSlashCommand(Guild guild, String commandPath) {
-        String commandName = commandPath.split(" ", 1)[0];
+        String commandName = commandPath.split(" ", 2)[0];
         return guild.retrieveCommands().map(guildCommands -> {
             Command guildCommand = guildCommands.stream()
                 .filter(c -> c.getName().equalsIgnoreCase(commandName))

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
@@ -7,7 +7,6 @@ import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.MarkdownSanitizer;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -65,21 +64,20 @@ public class MessageUtils {
      * in Discord.
      *
      * @param guild the {@link Guild} that contains the command
-     * @param fullCommand the command's name with its optional subcommand
+     * @param commandPath the command's name with its optional subcommand
      * @return Formatted string for the mentioned slash command
      * @throws IllegalArgumentException when the command isn't found in the guild
      */
-    public static RestAction<String> mentionSlashCommand(Guild guild, @NotNull String fullCommand) {
-        List<String> fullCommandSplit = List.of(fullCommand.split(" "));
+    public static RestAction<String> mentionSlashCommand(Guild guild, String commandPath) {
+        String commandName = commandPath.split(" ", 1)[0];
         return guild.retrieveCommands().map(guildCommands -> {
             Command guildCommand = guildCommands.stream()
-                .filter(c -> c.getName().equalsIgnoreCase(fullCommandSplit.get(0)))
+                .filter(c -> c.getName().equalsIgnoreCase(commandName))
                 .findAny()
                 .orElseThrow(
                         () -> new IllegalArgumentException("Command '%s' does not exist in guild %s"
-                            .formatted(fullCommandSplit.get(0), guild.getId())));
-            return String.format("</%s:%d>", String.join(" ", fullCommandSplit),
-                    guildCommand.getIdLong());
+                            .formatted(commandName, guild.getId())));
+            return String.format("</%s:%s>", commandPath, guildCommand.getId());
         });
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
@@ -64,7 +64,7 @@ public class MessageUtils {
      * in Discord.
      *
      * @param guild the {@link Guild} that contains the command
-     * @param commandPath the command's name with its optional subcommand
+     * @param commandPath full command path with subcommand groups and subcommands
      * @return Formatted string for the mentioned slash command
      * @throws IllegalArgumentException when the command isn't found in the guild
      */

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
@@ -64,19 +64,21 @@ public class MessageUtils {
      * in Discord.
      *
      * @param guild the {@link Guild} that contains the command
-     * @param command the command's name
+     * @param commandInput the command's name
      * @return Formatted string for the mentioned slash command
      * @throws IllegalArgumentException when the command name doesn't match with the guild's
      *         commands
      */
-    public static RestAction<String> mentionSlashCommand(Guild guild, String command) {
-        return guild.retrieveCommands().map(commands -> {
-            Command foundCommand = commands.stream()
-                .filter(c -> c.getName().equalsIgnoreCase(command))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Command %s does not exist in guild %s".formatted(command, guild.getId())));
-            return String.format("</%s:%d>", command, foundCommand.getIdLong());
+    public static RestAction<String> mentionSlashCommand(Guild guild, String... commandInput) {
+        String commandWithOptions = String.join(" ", commandInput);
+        return guild.retrieveCommands().map(guildCommands -> {
+            Command guildCommand = guildCommands.stream()
+                .filter(c -> c.getName().equalsIgnoreCase(commandInput[0]))
+                .findAny()
+                .orElseThrow(
+                        () -> new IllegalArgumentException("Command %s does not exist in guild %s"
+                            .formatted(commandWithOptions, guild.getId())));
+            return String.format("</%s:%d>", commandWithOptions, guildCommand.getIdLong());
         });
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
@@ -65,7 +65,7 @@ public class MessageUtils {
      *
      * @param guild the {@link Guild} that contains the command
      * @param commandName the command's name
-     * @param subCommands optional subcommands, depending on the base command used
+     * @param subCommands optional subcommand group & subcommand, depending on the base command used
      * @return Formatted string for the mentioned slash command
      * @throws IllegalArgumentException when the command isn't found in the guild
      */

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
@@ -7,8 +7,8 @@ import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.MarkdownSanitizer;
+import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -65,24 +65,20 @@ public class MessageUtils {
      * in Discord.
      *
      * @param guild the {@link Guild} that contains the command
-     * @param baseCommandName the command's name
-     * @param subcommands optional subcommands, depending on the base command used
+     * @param fullCommand the command's name with its optional subcommand
      * @return Formatted string for the mentioned slash command
-     * @throws IllegalArgumentException when the command name doesn't match with the guild's
-     *         commands
+     * @throws IllegalArgumentException when the command isn't found in the guild
      */
-    public static RestAction<String> mentionSlashCommand(Guild guild, String baseCommandName,
-            String... subcommands) {
-        List<String> fullCommand = new ArrayList<>(List.of(baseCommandName));
-        fullCommand.addAll(List.of(subcommands));
+    public static RestAction<String> mentionSlashCommand(Guild guild, @NotNull String fullCommand) {
+        List<String> fullCommandSplit = List.of(fullCommand.split(" "));
         return guild.retrieveCommands().map(guildCommands -> {
             Command guildCommand = guildCommands.stream()
-                .filter(c -> c.getName().equalsIgnoreCase(baseCommandName))
+                .filter(c -> c.getName().equalsIgnoreCase(fullCommandSplit.get(0)))
                 .findAny()
                 .orElseThrow(
                         () -> new IllegalArgumentException("Command '%s' does not exist in guild %s"
-                            .formatted(String.join(" ", fullCommand), guild.getId())));
-            return String.format("</%s:%d>", String.join(" ", fullCommand),
+                            .formatted(fullCommandSplit.get(0), guild.getId())));
+            return String.format("</%s:%d>", String.join(" ", fullCommandSplit),
                     guildCommand.getIdLong());
         });
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
@@ -68,8 +68,8 @@ public class MessageUtils {
      * @return Formatted string for the mentioned slash command
      * @throws IllegalArgumentException when the command isn't found in the guild
      */
-    public static RestAction<String> mentionSlashCommand(Guild guild, String commandPath) {
-        String commandName = commandPath.split(" ", 2)[0];
+    public static RestAction<String> mentionSlashCommand(Guild guild, String... commandPath) {
+        String commandName = commandPath[0];
         return guild.retrieveCommands().map(guildCommands -> {
             Command guildCommand = guildCommands.stream()
                 .filter(c -> c.getName().equalsIgnoreCase(commandName))
@@ -77,7 +77,7 @@ public class MessageUtils {
                 .orElseThrow(
                         () -> new IllegalArgumentException("Command '%s' does not exist in guild %s"
                             .formatted(commandName, guild.getId())));
-            return String.format("</%s:%s>", commandPath, guildCommand.getId());
+            return String.format("</%s:%s>", String.join(" ", commandPath), guildCommand.getId());
         });
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
@@ -80,7 +80,7 @@ public class MessageUtils {
                             .formatted(commandName, guild.getId())));
             String commandPath = commandName;
             if (subCommands.length > 0) {
-                commandPath = commandPath + " " + String.join(" ", subCommands);
+                commandPath += " " + String.join(" ", subCommands);
             }
             return String.format("</%s:%s>", String.join(" ", commandPath), guildCommand.getId());
         });

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
@@ -1,11 +1,14 @@
 package org.togetherjava.tjbot.commands.utils;
 
+import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.utils.MarkdownSanitizer;
+import org.togetherjava.tjbot.commands.help.CloseCommand;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Utility methods for {@link Message}.
@@ -54,6 +57,29 @@ public class MessageUtils {
         String beforeEscape = text.replace("\\", "\\\\");
         String afterEscape = MarkdownSanitizer.escape(beforeEscape);
         return afterEscape.replace("\\```", "\\`\\`\\`");
+    }
+
+    /**
+     * Converts a slash command text to a mentioned slash command, which you can directly click on
+     * in Discord
+     *
+     * @param guild guild that owns the command
+     * @param command command name
+     * @return Formatted string for mentioned slash command
+     * @throws IllegalArgumentException when the command name doesn't match with the guild's
+     *         commands
+     */
+    public static String mentionSlashCommand(Guild guild, String command) {
+        AtomicLong commandId = new AtomicLong();
+        guild.retrieveCommands()
+            .queue(commands -> commands.stream()
+                .filter(c -> c.getName().equalsIgnoreCase(command))
+                .findFirst()
+                .ifPresentOrElse(c -> commandId.set(c.getIdLong()), () -> {
+                    throw new IllegalArgumentException("Command %s does not exist in guild %s"
+                        .formatted(command, guild.getId()));
+                }));
+        return String.format("</%s:%d>", command, commandId.get());
     }
 
 }


### PR DESCRIPTION
# Changes in this PR 

- Added method MessageUtils.mentionSlashCommand to convert a command name to a mentioned command using the Guild's commands list

I have found 5 text slash commands in strings, I replaced them all with mentioned commands

Closes #559 , check it for details

Result : 
![Discord message with mentioned command](https://cdn.discordapp.com/attachments/895717328359153664/1017098052126916660/Discord_RbefVhvraN.png)