### PR TITLE
fixed bot positing advice on closed uncategorized help threads

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -275,7 +275,7 @@ public final class HelpSystemHelper {
             }
 
             if (threadChannel.isArchived()) {
-                return null;
+                return new CompletedRestAction<>(jda, null);
             }
 
             Optional<String> category = getCategoryOfChannel(threadChannel);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -274,6 +274,10 @@ public final class HelpSystemHelper {
                 return new CompletedRestAction<>(jda, null);
             }
 
+            if (threadChannel.isArchived()) {
+                return null;
+            }
+
             Optional<String> category = getCategoryOfChannel(threadChannel);
             if (category.isPresent()) {
                 logger.debug(

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -275,6 +275,9 @@ public final class HelpSystemHelper {
             }
 
             if (threadChannel.isArchived()) {
+                logger.debug(
+                        "Channel for uncategorized advice check is archived already (thread {} by author {}).",
+                        threadChannelId, authorId);
                 return new CompletedRestAction<>(jda, null);
             }
 


### PR DESCRIPTION
fixes #571 

Currently the bot sends a advice to select a category on help threads with no category.