### PR TITLE
Changing auto archiving from 24 to 12h

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadAutoArchiver.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 public final class HelpThreadAutoArchiver implements Routine {
     private static final Logger logger = LoggerFactory.getLogger(HelpThreadAutoArchiver.class);
     private static final int SCHEDULE_MINUTES = 60;
-    private static final Duration ARCHIVE_AFTER_INACTIVITY_OF = Duration.ofHours(24);
+    private static final Duration ARCHIVE_AFTER_INACTIVITY_OF = Duration.ofHours(12);
 
     private final HelpSystemHelper helper;
 


### PR DESCRIPTION
Closes #582 .

As proposed in suggestions, we should reduce the auto archive time from 24h of inactivity to 12h.

We expect that this will reduce the amount of actually inactive threads, while hopefully not closing too much of still valid threads. Ideally, this is a better sweetspot than 24h.