### PR TITLE
Ensure config is present and not null

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -36,7 +36,7 @@ public final class Config {
 
     @SuppressWarnings("ConstructorWithTooManyParameters")
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-    private Config(@JsonProperty("token") String token,
+    private Config(@JsonProperty(value = "token", required = true) String token,
             @JsonProperty(value = "gistApiKey", required = true) String gistApiKey,
             @JsonProperty(value = "databasePath", required = true) String databasePath,
             @JsonProperty(value = "projectWebsite", required = true) String projectWebsite,

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Configuration of the application. Create instances using {@link #load(Path)}.
@@ -36,39 +37,46 @@ public final class Config {
     @SuppressWarnings("ConstructorWithTooManyParameters")
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     private Config(@JsonProperty("token") String token,
-            @JsonProperty("gistApiKey") String gistApiKey,
-            @JsonProperty("databasePath") String databasePath,
-            @JsonProperty("projectWebsite") String projectWebsite,
-            @JsonProperty("discordGuildInvite") String discordGuildInvite,
-            @JsonProperty("modAuditLogChannelPattern") String modAuditLogChannelPattern,
-            @JsonProperty("mutedRolePattern") String mutedRolePattern,
-            @JsonProperty("heavyModerationRolePattern") String heavyModerationRolePattern,
-            @JsonProperty("softModerationRolePattern") String softModerationRolePattern,
-            @JsonProperty("tagManageRolePattern") String tagManageRolePattern,
-            @JsonProperty("suggestions") SuggestionsConfig suggestions,
-            @JsonProperty("quarantinedRolePattern") String quarantinedRolePattern,
-            @JsonProperty("scamBlocker") ScamBlockerConfig scamBlocker,
-            @JsonProperty("wolframAlphaAppId") String wolframAlphaAppId,
-            @JsonProperty("helpSystem") HelpSystemConfig helpSystem,
-            @JsonProperty("mediaOnlyChannelPattern") String mediaOnlyChannelPattern,
-            @JsonProperty("blacklistedFileExtension") List<String> blacklistedFileExtension) {
-        this.token = token;
-        this.gistApiKey = gistApiKey;
-        this.databasePath = databasePath;
-        this.projectWebsite = projectWebsite;
-        this.discordGuildInvite = discordGuildInvite;
-        this.modAuditLogChannelPattern = modAuditLogChannelPattern;
-        this.mutedRolePattern = mutedRolePattern;
-        this.heavyModerationRolePattern = heavyModerationRolePattern;
-        this.softModerationRolePattern = softModerationRolePattern;
-        this.tagManageRolePattern = tagManageRolePattern;
-        this.suggestions = suggestions;
-        this.quarantinedRolePattern = quarantinedRolePattern;
-        this.scamBlocker = scamBlocker;
-        this.wolframAlphaAppId = wolframAlphaAppId;
-        this.helpSystem = helpSystem;
-        this.mediaOnlyChannelPattern = mediaOnlyChannelPattern;
-        this.blacklistedFileExtension = blacklistedFileExtension;
+            @JsonProperty(value = "gistApiKey", required = true) String gistApiKey,
+            @JsonProperty(value = "databasePath", required = true) String databasePath,
+            @JsonProperty(value = "projectWebsite", required = true) String projectWebsite,
+            @JsonProperty(value = "discordGuildInvite", required = true) String discordGuildInvite,
+            @JsonProperty(value = "modAuditLogChannelPattern",
+                    required = true) String modAuditLogChannelPattern,
+            @JsonProperty(value = "mutedRolePattern", required = true) String mutedRolePattern,
+            @JsonProperty(value = "heavyModerationRolePattern",
+                    required = true) String heavyModerationRolePattern,
+            @JsonProperty(value = "softModerationRolePattern",
+                    required = true) String softModerationRolePattern,
+            @JsonProperty(value = "tagManageRolePattern",
+                    required = true) String tagManageRolePattern,
+            @JsonProperty(value = "suggestions", required = true) SuggestionsConfig suggestions,
+            @JsonProperty(value = "quarantinedRolePattern",
+                    required = true) String quarantinedRolePattern,
+            @JsonProperty(value = "scamBlocker", required = true) ScamBlockerConfig scamBlocker,
+            @JsonProperty(value = "wolframAlphaAppId", required = true) String wolframAlphaAppId,
+            @JsonProperty(value = "helpSystem", required = true) HelpSystemConfig helpSystem,
+            @JsonProperty(value = "mediaOnlyChannelPattern",
+                    required = true) String mediaOnlyChannelPattern,
+            @JsonProperty(value = "blacklistedFileExtension",
+                    required = true) List<String> blacklistedFileExtension) {
+        this.token = Objects.requireNonNull(token);
+        this.gistApiKey = Objects.requireNonNull(gistApiKey);
+        this.databasePath = Objects.requireNonNull(databasePath);
+        this.projectWebsite = Objects.requireNonNull(projectWebsite);
+        this.discordGuildInvite = Objects.requireNonNull(discordGuildInvite);
+        this.modAuditLogChannelPattern = Objects.requireNonNull(modAuditLogChannelPattern);
+        this.mutedRolePattern = Objects.requireNonNull(mutedRolePattern);
+        this.heavyModerationRolePattern = Objects.requireNonNull(heavyModerationRolePattern);
+        this.softModerationRolePattern = Objects.requireNonNull(softModerationRolePattern);
+        this.tagManageRolePattern = Objects.requireNonNull(tagManageRolePattern);
+        this.suggestions = Objects.requireNonNull(suggestions);
+        this.quarantinedRolePattern = Objects.requireNonNull(quarantinedRolePattern);
+        this.scamBlocker = Objects.requireNonNull(scamBlocker);
+        this.wolframAlphaAppId = Objects.requireNonNull(wolframAlphaAppId);
+        this.helpSystem = Objects.requireNonNull(helpSystem);
+        this.mediaOnlyChannelPattern = Objects.requireNonNull(mediaOnlyChannelPattern);
+        this.blacklistedFileExtension = Objects.requireNonNull(blacklistedFileExtension);
     }
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/config/HelpSystemConfig.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/HelpSystemConfig.java
@@ -7,11 +7,11 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Configuration for the help system, see {@link org.togetherjava.tjbot.commands.help.AskCommand}.
  */
-@SuppressWarnings("ClassCanBeRecord")
 @JsonRootName("helpSystem")
 public final class HelpSystemConfig {
     private final String stagingChannelPattern;
@@ -20,14 +20,18 @@ public final class HelpSystemConfig {
     private final String categoryRoleSuffix;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-    private HelpSystemConfig(@JsonProperty("stagingChannelPattern") String stagingChannelPattern,
-            @JsonProperty("overviewChannelPattern") String overviewChannelPattern,
-            @JsonProperty("categories") List<String> categories,
-            @JsonProperty("categoryRoleSuffix") String categoryRoleSuffix) {
-        this.stagingChannelPattern = stagingChannelPattern;
-        this.overviewChannelPattern = overviewChannelPattern;
-        this.categories = new ArrayList<>(categories);
-        this.categoryRoleSuffix = categoryRoleSuffix;
+    private HelpSystemConfig(
+            @JsonProperty(value = "stagingChannelPattern",
+                    required = true) String stagingChannelPattern,
+            @JsonProperty(value = "overviewChannelPattern",
+                    required = true) String overviewChannelPattern,
+            @JsonProperty(value = "categories", required = true) List<String> categories,
+            @JsonProperty(value = "categoryRoleSuffix",
+                    required = true) String categoryRoleSuffix) {
+        this.stagingChannelPattern = Objects.requireNonNull(stagingChannelPattern);
+        this.overviewChannelPattern = Objects.requireNonNull(overviewChannelPattern);
+        this.categories = new ArrayList<>(Objects.requireNonNull(categories));
+        this.categoryRoleSuffix = Objects.requireNonNull(categoryRoleSuffix);
     }
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/config/ScamBlockerConfig.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/ScamBlockerConfig.java
@@ -6,13 +6,13 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
  * Configuration for the scam blocker system, see
  * {@link org.togetherjava.tjbot.commands.moderation.scam.ScamBlocker}.
  */
-@SuppressWarnings("ClassCanBeRecord")
 @JsonRootName("scamBlocker")
 public final class ScamBlockerConfig {
     private final Mode mode;
@@ -23,17 +23,20 @@ public final class ScamBlockerConfig {
     private final int isHostSimilarToKeywordDistanceThreshold;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-    private ScamBlockerConfig(@JsonProperty("mode") Mode mode,
-            @JsonProperty("reportChannelPattern") String reportChannelPattern,
-            @JsonProperty("hostWhitelist") Set<String> hostWhitelist,
-            @JsonProperty("hostBlacklist") Set<String> hostBlacklist,
-            @JsonProperty("suspiciousHostKeywords") Set<String> suspiciousHostKeywords,
-            @JsonProperty("isHostSimilarToKeywordDistanceThreshold") int isHostSimilarToKeywordDistanceThreshold) {
-        this.mode = mode;
-        this.reportChannelPattern = reportChannelPattern;
-        this.hostWhitelist = new HashSet<>(hostWhitelist);
-        this.hostBlacklist = new HashSet<>(hostBlacklist);
-        this.suspiciousHostKeywords = new HashSet<>(suspiciousHostKeywords);
+    private ScamBlockerConfig(@JsonProperty(value = "mode", required = true) Mode mode,
+            @JsonProperty(value = "reportChannelPattern",
+                    required = true) String reportChannelPattern,
+            @JsonProperty(value = "hostWhitelist", required = true) Set<String> hostWhitelist,
+            @JsonProperty(value = "hostBlacklist", required = true) Set<String> hostBlacklist,
+            @JsonProperty(value = "suspiciousHostKeywords",
+                    required = true) Set<String> suspiciousHostKeywords,
+            @JsonProperty(value = "isHostSimilarToKeywordDistanceThreshold",
+                    required = true) int isHostSimilarToKeywordDistanceThreshold) {
+        this.mode = Objects.requireNonNull(mode);
+        this.reportChannelPattern = Objects.requireNonNull(reportChannelPattern);
+        this.hostWhitelist = new HashSet<>(Objects.requireNonNull(hostWhitelist));
+        this.hostBlacklist = new HashSet<>(Objects.requireNonNull(hostBlacklist));
+        this.suspiciousHostKeywords = new HashSet<>(Objects.requireNonNull(suspiciousHostKeywords));
         this.isHostSimilarToKeywordDistanceThreshold = isHostSimilarToKeywordDistanceThreshold;
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/config/SuggestionsConfig.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/SuggestionsConfig.java
@@ -4,11 +4,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
+import java.util.Objects;
+
 /**
  * Configuration for the suggestion system, see
  * {@link org.togetherjava.tjbot.commands.basic.SuggestionsUpDownVoter}.
  */
-@SuppressWarnings("ClassCanBeRecord")
 @JsonRootName("suggestions")
 public final class SuggestionsConfig {
     private final String channelPattern;
@@ -16,12 +17,13 @@ public final class SuggestionsConfig {
     private final String downVoteEmoteName;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-    private SuggestionsConfig(@JsonProperty("channelPattern") String channelPattern,
-            @JsonProperty("upVoteEmoteName") String upVoteEmoteName,
-            @JsonProperty("downVoteEmoteName") String downVoteEmoteName) {
-        this.channelPattern = channelPattern;
-        this.upVoteEmoteName = upVoteEmoteName;
-        this.downVoteEmoteName = downVoteEmoteName;
+    private SuggestionsConfig(
+            @JsonProperty(value = "channelPattern", required = true) String channelPattern,
+            @JsonProperty(value = "upVoteEmoteName", required = true) String upVoteEmoteName,
+            @JsonProperty(value = "downVoteEmoteName", required = true) String downVoteEmoteName) {
+        this.channelPattern = Objects.requireNonNull(channelPattern);
+        this.upVoteEmoteName = Objects.requireNonNull(upVoteEmoteName);
+        this.downVoteEmoteName = Objects.requireNonNull(downVoteEmoteName);
     }
 
     /**


### PR DESCRIPTION
## Overview

Our code incorrectly allowed missing config properties. Such as just leaving out an entry, for example `gistApiKey`. Or even explicitly setting it to `null`:

```json
"gistApiKey": null,
```

both lead to Jackson constructing our `Config` with `null` for this field.

This is a problem, because our code implicitly assumes `@Nonnull` on all these fields and getter methods, in the whole code base. And we obviously also never accounted for this situation in our code, nor do we want to.

## Fix

This approaches the problem by correctly documenting and enforcing that all properties of configs are required. The code now throws for both those situations:

![exception](https://i.imgur.com/LgYh61A.png)

This is achieved by two mechanisms:

* `this.foo = Objects.requireNonNull(foo)` for explicit nulls like `"foo" = null,`
* `@JsonProperty(value = "foo", required = true)` for leaving it out alltogether

Unfortunately, this makes the already ugly config files even uglier. Doesnt seem like there is a better or more automatic way of applying this everywhere in the config.