### PR TITLE
fixed context commands not working

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/Application.java
+++ b/application/src/main/java/org/togetherjava/tjbot/Application.java
@@ -83,7 +83,11 @@ public class Application {
                 .build();
 
             jda.awaitReady();
+
             BotCore core = new BotCore(jda, database, config);
+            CommandReloading.reloadCommands(jda, core);
+            core.scheduleRoutines(jda);
+
             jda.addEventListener(core);
 
             logger.info("Bot is ready");

--- a/application/src/main/java/org/togetherjava/tjbot/commands/UserInteractorPrefix.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/UserInteractorPrefix.java
@@ -37,6 +37,16 @@ public enum UserInteractorPrefix {
     }
 
     /**
+     * Returns the name, attached with the prefix in front of it.
+     *
+     * @param name the name
+     * @return the name, with the prefix in front of it.
+     */
+    public String getPrefixedName(String name) {
+        return prefix + name;
+    }
+
+    /**
      * The class type that should receive the prefix
      *
      * @return a {@link Class} instance of the type

--- a/application/src/main/java/org/togetherjava/tjbot/commands/UserInteractorPrefix.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/UserInteractorPrefix.java
@@ -7,17 +7,23 @@ import org.jetbrains.annotations.Contract;
  * <p>
  * This is used for separate interactors with the same name, by command type (and possibly more in
  * the future). Our system doesn't allow multiple interactors with the same name, while having a
- * slash-command and a message-context-command with the same name can be really useful.
+ * slash-command, and a message-context-command with the same name can be useful.
  */
 public enum UserInteractorPrefix {
-    /*
-     * Implementations that are none of the following have no dedicated prefix
+    // Implementations that are none of the following have no dedicated prefix.
+
+    /**
+     * Prefix for slash commands.
      */
-
     SLASH_COMMAND(SlashCommand.class, "s-"),
+    /**
+     * Prefix for message context commands.
+     */
     MESSAGE_CONTEXT_COMMAND(MessageContextCommand.class, "mc-"),
+    /**
+     * Prefix for user context commands.
+     */
     USER_CONTEXT_COMMAND(UserContextCommand.class, "uc-");
-
 
     private final Class<? extends UserInteractor> classType;
     private final String prefix;


### PR DESCRIPTION
I might forgot to test it properly after copying the initial PR, slash commands worked but forgot to check context commands (stupid, bad example I agree)

So therefor a fix: this also contains minor improvements of BotCore and UserInteractorPrefix


In BotCore:
Removed requireSlashCommand, and added requireUserInteractor. This works based on generics, very useful.

Also added UserInteractorPrefix#getPrefixedName(String)