### PR TITLE
Bugfix command completion not working

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
@@ -2,6 +2,7 @@ package org.togetherjava.tjbot.commands.system;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Channel;
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.UserContextInteractionEvent;
@@ -239,6 +240,18 @@ public final class BotCore extends ListenerAdapter implements CommandProvider {
         COMMAND_SERVICE.execute(() -> requireUserInteractor(
                 UserInteractorPrefix.SLASH_COMMAND.getPrefixedName(name), SlashCommand.class)
                     .onSlashCommand(event));
+    }
+
+    @Override
+    public void onCommandAutoCompleteInteraction(
+            @NotNull final CommandAutoCompleteInteractionEvent event) {
+        String name = event.getName();
+
+        logger.debug("Received auto completion from command-subcommand '{}-{}' (#{}) on guild '{}'",
+                name, event.getSubcommandName(), event.getId(), event.getGuild());
+        COMMAND_SERVICE.execute(() -> requireUserInteractor(
+                UserInteractorPrefix.SLASH_COMMAND.getPrefixedName(name), SlashCommand.class)
+                    .onAutoComplete(event));
     }
 
     @Override

--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
@@ -243,12 +243,11 @@ public final class BotCore extends ListenerAdapter implements CommandProvider {
     }
 
     @Override
-    public void onCommandAutoCompleteInteraction(
-            final CommandAutoCompleteInteractionEvent event) {
+    public void onCommandAutoCompleteInteraction(final CommandAutoCompleteInteractionEvent event) {
         String name = event.getName();
 
-        logger.debug("Received auto completion from command-subcommand '{}-{}' (#{}) on guild '{}'",
-                name, event.getSubcommandName(), event.getId(), event.getGuild());
+        logger.debug("Received auto completion from command '{}' (#{}) on guild '{}'",
+                event.getCommandPath(), event.getId(), event.getGuild());
         COMMAND_SERVICE.execute(() -> requireUserInteractor(
                 UserInteractorPrefix.SLASH_COMMAND.getPrefixedName(name), SlashCommand.class)
                     .onAutoComplete(event));

--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
@@ -244,7 +244,7 @@ public final class BotCore extends ListenerAdapter implements CommandProvider {
 
     @Override
     public void onCommandAutoCompleteInteraction(
-            @NotNull final CommandAutoCompleteInteractionEvent event) {
+            final CommandAutoCompleteInteractionEvent event) {
         String name = event.getName();
 
         logger.debug("Received auto completion from command-subcommand '{}-{}' (#{}) on guild '{}'",


### PR DESCRIPTION
In BotCore:
Added onCommandAutoCompleteInteraction listener, this way autocompletion events will actually get forwarded.

Funny, didnt think of this during the previous PR, was probably too hasty.

(maybe this was all planned for free commits \s