### PR TITLE
Fixed components not working

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/BotCommandAdapter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/BotCommandAdapter.java
@@ -130,7 +130,8 @@ public abstract class BotCommandAdapter implements BotCommand {
      */
     @SuppressWarnings({"OverloadedVarargsMethod", "WeakerAccess"})
     protected final String generateComponentId(Lifespan lifespan, String... args) {
-        return componentIdGenerator.generate(new ComponentId(getName(), Arrays.asList(args)),
-                lifespan);
+        return componentIdGenerator
+            .generate(new ComponentId(UserInteractorPrefix.getPrefixedNameFromInstance(this),
+                    Arrays.asList(args)), lifespan);
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/system/BotCore.java
@@ -104,12 +104,12 @@ public final class BotCore extends ListenerAdapter implements CommandProvider {
         componentIdParser = uuid -> componentIdStore.get(UUID.fromString(uuid));
         Collection<UserInteractor> interactors = getInteractors();
 
-        interactors.forEach(slashCommand -> slashCommand
-            .acceptComponentIdGenerator(((componentId, lifespan) -> {
-                UUID uuid = UUID.randomUUID();
-                componentIdStore.putOrThrow(uuid, componentId, lifespan);
-                return uuid.toString();
-            })));
+        interactors.forEach(
+                interactor -> interactor.acceptComponentIdGenerator(((componentId, lifespan) -> {
+                    UUID uuid = UUID.randomUUID();
+                    componentIdStore.putOrThrow(uuid, componentId, lifespan);
+                    return uuid.toString();
+                })));
 
         if (logger.isInfoEnabled()) {
             logger.info("Available user interactors: {}", interactors);

--- a/application/src/test/java/org/togetherjava/tjbot/commands/SlashCommandAdapterTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/SlashCommandAdapterTest.java
@@ -10,6 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 final class SlashCommandAdapterTest {
     private static final String NAME = "foo";
+    private static final String PREFIXED_NAME =
+            UserInteractorPrefix.SLASH_COMMAND.getPrefix() + NAME;
     private static final String DESCRIPTION = "Foo command";
     private static final CommandVisibility VISIBILITY = CommandVisibility.GUILD;
     private static final int UNIQUE_ID_ITERATIONS = 20;
@@ -71,7 +73,7 @@ final class SlashCommandAdapterTest {
         String[] elements = {"foo", "bar", "baz"};
         String[] componentIdText = adapter.generateComponentId(elements).split(";");
         assertEquals(3, componentIdText.length);
-        assertEquals(NAME, componentIdText[0]);
+        assertEquals(PREFIXED_NAME, componentIdText[0]);
         assertEquals(Integer.toString(elements.length), componentIdText[1]);
         assertEquals(Lifespan.REGULAR.toString(), componentIdText[2]);
 
@@ -79,7 +81,7 @@ final class SlashCommandAdapterTest {
         for (Lifespan lifespan : Lifespan.values()) {
             componentIdText = adapter.generateComponentId(lifespan, elements).split(";");
             assertEquals(3, componentIdText.length);
-            assertEquals(NAME, componentIdText[0]);
+            assertEquals(PREFIXED_NAME, componentIdText[0]);
             assertEquals(Integer.toString(elements.length), componentIdText[1]);
             assertEquals(lifespan.toString(), componentIdText[2]);
         }


### PR DESCRIPTION
In BotCommandAdapter
the Interactor's name was used without prefix, but to forward from the button the prefix is needed.


I promise next time I'll create a better PR! :p