### PR TITLE
Replaced overview message to embed

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
@@ -1,5 +1,6 @@
 package org.togetherjava.tjbot.commands.help;
 
+import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
@@ -13,6 +14,7 @@ import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
 import net.dv8tion.jda.api.utils.messages.MessageEditData;
 import net.dv8tion.jda.internal.requests.CompletedRestAction;
+import org.jetbrains.annotations.NonNls;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.MessageReceiverAdapter;
@@ -39,7 +41,7 @@ import java.util.stream.Collectors;
 public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter implements Routine {
     private static final Logger logger = LoggerFactory.getLogger(HelpThreadOverviewUpdater.class);
 
-    private static final String STATUS_TITLE = "## __**Active questions**__ ##";
+    private static final @NonNls String STATUS_TITLE = "## Active questions ##";
     private static final int OVERVIEW_QUESTION_LIMIT = 150;
     private static final AtomicInteger FIND_STATUS_MESSAGE_CONSECUTIVE_FAILURES =
             new AtomicInteger(0);
@@ -120,7 +122,9 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
         logger.debug("Found {} active questions", activeThreads.size());
 
         MessageEditData message = new MessageEditBuilder()
-            .setContent(STATUS_TITLE + "\n\n" + createDescription(activeThreads))
+            .setEmbeds(new EmbedBuilder().setTitle(STATUS_TITLE)
+                .setDescription(createDescription(activeThreads))
+                .build())
             .build();
 
         getStatusMessage(overviewChannel)
@@ -163,12 +167,13 @@ public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter impl
     }
 
     private static boolean isStatusMessage(Message message) {
-        if (!message.getAuthor().equals(message.getJDA().getSelfUser())) {
+        if (message.getEmbeds().isEmpty()
+                || !message.getAuthor().equals(message.getJDA().getSelfUser())) {
             return false;
         }
 
-        String content = message.getContentRaw();
-        return content.startsWith(STATUS_TITLE);
+        String messageEmbedTitle = message.getEmbeds().get(0).getTitle();
+        return STATUS_TITLE.equals(messageEmbedTitle);
     }
 
     private RestAction<Message> sendUpdatedOverview(@Nullable Message statusMessage,

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadOverviewUpdater.java
@@ -14,7 +14,6 @@ import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
 import net.dv8tion.jda.api.utils.messages.MessageEditData;
 import net.dv8tion.jda.internal.requests.CompletedRestAction;
-import org.jetbrains.annotations.NonNls;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.commands.MessageReceiverAdapter;
@@ -41,7 +40,7 @@ import java.util.stream.Collectors;
 public final class HelpThreadOverviewUpdater extends MessageReceiverAdapter implements Routine {
     private static final Logger logger = LoggerFactory.getLogger(HelpThreadOverviewUpdater.class);
 
-    private static final @NonNls String STATUS_TITLE = "## Active questions ##";
+    private static final String STATUS_TITLE = "## Active questions ##";
     private static final int OVERVIEW_QUESTION_LIMIT = 150;
     private static final AtomicInteger FIND_STATUS_MESSAGE_CONSECUTIVE_FAILURES =
             new AtomicInteger(0);


### PR DESCRIPTION
Initially the overview was normal message, but this had the downside of having a limit of 2000 characters.
Embeds have a limit of 4096, which is more than double. But there was a reason for it, embeds didn't have click-through channel mentions on phone.

And that's a major issue, as it'd mean you read the thread channels name, then you find the "Discord" overview, type in the title (assuming you haven't forgotten it), and then you finally reach the channel.

Compared to a simple click, this takes a lot of time.


Since phone now has support for this, there's no reason to not use embeds.
So after this we support more than 2x the amount of questions than before!

Closes #533 

This breaks backwards compatibility, the old message has to get deleted.