### PR TITLE
TopHelpersCommand message is too long

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
@@ -17,6 +17,8 @@ import java.util.List;
  * other commands to avoid similar methods appearing everywhere.
  */
 public class MessageUtils {
+    private static final String ABBREVIATION = "...";
+
     private MessageUtils() {
         throw new UnsupportedOperationException("Utility class, construction not supported");
     }
@@ -43,7 +45,7 @@ public class MessageUtils {
 
     /**
      * Escapes every markdown content in the given string.
-     *
+     * <p>
      * If the escaped message is sent to Discord, it will display the original message.
      * 
      * @param text the text to escape
@@ -84,6 +86,27 @@ public class MessageUtils {
             }
             return String.format("</%s:%s>", String.join(" ", commandPath), guildCommand.getId());
         });
+    }
+
+    /**
+     * Abbreviates the given text if it is too long.
+     * <p>
+     * Abbreviation is done by adding {@value ABBREVIATION}.
+     *
+     * @param text the text to abbreviate
+     * @param maxLength the maximal length of the abbreviated text
+     * @return the abbreviated text, guaranteed to be smaller than the given length
+     */
+    public static String abbreviate(String text, int maxLength) {
+        if (text.length() <= maxLength) {
+            return text;
+        }
+
+        if (maxLength < ABBREVIATION.length()) {
+            return text.substring(0, maxLength);
+        }
+
+        return text.substring(0, maxLength - ABBREVIATION.length()) + ABBREVIATION;
     }
 
 }

--- a/application/src/main/java/org/togetherjava/tjbot/logging/discord/DiscordLogForwarder.java
+++ b/application/src/main/java/org/togetherjava/tjbot/logging/discord/DiscordLogForwarder.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.togetherjava.tjbot.commands.utils.MessageUtils;
 import org.togetherjava.tjbot.logging.LogMarkers;
 
 import java.io.PrintWriter;
@@ -122,7 +123,7 @@ final class DiscordLogForwarder {
             String authorName = event.getLoggerName();
             String title = event.getLevel().name();
             int colorDecimal = Objects.requireNonNull(LEVEL_TO_AMBIENT_COLOR.get(event.getLevel()));
-            String description = abbreviate(describeLogEvent(event), MAX_EMBED_DESCRIPTION);
+            String description = MessageUtils.abbreviate(describeLogEvent(event), MAX_EMBED_DESCRIPTION);
             Instant timestamp = Instant.ofEpochMilli(event.getInstant().getEpochMillisecond());
 
             WebhookEmbed embed = new WebhookEmbedBuilder()
@@ -148,18 +149,6 @@ final class DiscordLogForwarder {
             exception.printStackTrace(new PrintWriter(exceptionWriter));
 
             return logMessage + "\n" + exceptionWriter.toString().replace("\t", "> ");
-        }
-
-        private static String abbreviate(String text, int maxLength) {
-            if (text.length() < maxLength) {
-                return text;
-            }
-
-            if (maxLength < 3) {
-                return text.substring(0, maxLength);
-            }
-
-            return text.substring(0, maxLength - 3) + "...";
         }
 
         @Override

--- a/application/src/main/java/org/togetherjava/tjbot/logging/discord/DiscordLogForwarder.java
+++ b/application/src/main/java/org/togetherjava/tjbot/logging/discord/DiscordLogForwarder.java
@@ -123,7 +123,8 @@ final class DiscordLogForwarder {
             String authorName = event.getLoggerName();
             String title = event.getLevel().name();
             int colorDecimal = Objects.requireNonNull(LEVEL_TO_AMBIENT_COLOR.get(event.getLevel()));
-            String description = MessageUtils.abbreviate(describeLogEvent(event), MAX_EMBED_DESCRIPTION);
+            String description =
+                    MessageUtils.abbreviate(describeLogEvent(event), MAX_EMBED_DESCRIPTION);
             Instant timestamp = Instant.ofEpochMilli(event.getInstant().getEpochMillisecond());
 
             WebhookEmbed embed = new WebhookEmbedBuilder()

--- a/application/src/test/java/org/togetherjava/tjbot/commands/utils/MessageUtilsTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/utils/MessageUtilsTest.java
@@ -10,11 +10,11 @@ final class MessageUtilsTest {
 
     @Test
     void escapeMarkdown() {
-        List<TestCase> tests = List.of(new TestCase("empty", "", ""),
-                new TestCase("no markdown", "hello world", "hello world"),
-                new TestCase(
+        List<TestCaseEscape> tests = List.of(new TestCaseEscape("empty", "", ""),
+                new TestCaseEscape("no markdown", "hello world", "hello world"),
+                new TestCaseEscape(
                         "basic markdown", "\\*\\*hello\\*\\* \\_world\\_", "**hello** _world_"),
-                new TestCase("code block", """
+                new TestCaseEscape("code block", """
                         \\`\\`\\`java
                         int x = 5;
                         \\`\\`\\`
@@ -23,9 +23,9 @@ final class MessageUtilsTest {
                         int x = 5;
                         ```
                         """),
-                new TestCase("escape simple", "hello\\\\\\\\world\\\\\\\\test",
+                new TestCaseEscape("escape simple", "hello\\\\\\\\world\\\\\\\\test",
                         "hello\\\\world\\\\test"),
-                new TestCase("escape complex", """
+                new TestCaseEscape("escape complex", """
                         Hello\\\\\\\\world
                         \\`\\`\\`java
                         Hello\\\\\\\\
@@ -46,7 +46,7 @@ final class MessageUtilsTest {
                         "Hello \\" World\\\\\\"" haha
                         ```
                         """),
-                new TestCase("escape real example",
+                new TestCaseEscape("escape real example",
                         """
                                 Graph traversal can be accomplished easily using \\*\\*BFS\\*\\* or \\*\\*DFS\\*\\*. The algorithms only differ in the order in which nodes are visited: https://i.imgur.com/n9WrkQG.png
 
@@ -158,12 +158,34 @@ final class MessageUtilsTest {
                                 ```
                                 """));
 
-        for (TestCase test : tests) {
+        for (TestCaseEscape test : tests) {
             assertEquals(test.escapedMessage(), MessageUtils.escapeMarkdown(test.originalMessage()),
                     "Test failed: " + test.testName());
         }
     }
 
-    private record TestCase(String testName, String escapedMessage, String originalMessage) {
+    private record TestCaseEscape(String testName, String escapedMessage, String originalMessage) {
+    }
+
+    @Test
+    void abbreviate() {
+        List<TestCaseAbbreviate> tests =
+                List.of(new TestCaseAbbreviate("base case", "hello...", "hello world", 8),
+                        new TestCaseAbbreviate("long enough", "hello world", "hello world", 15),
+                        new TestCaseAbbreviate("exact size", "hello world", "hello world", 11),
+                        new TestCaseAbbreviate("very small limit", "he", "hello world", 2),
+                        new TestCaseAbbreviate("empty input", "", "", 0),
+                        new TestCaseAbbreviate("zero limit", "", "hello world", 0),
+                        new TestCaseAbbreviate("small limit", "h...", "hello world", 4));
+
+        for (TestCaseAbbreviate test : tests) {
+            assertEquals(test.abbreviatedMessage(),
+                    MessageUtils.abbreviate(test.originalMessage(), test.limit()),
+                    "Test failed: " + test.testName());
+        }
+    }
+
+    private record TestCaseAbbreviate(String testName, String abbreviatedMessage,
+            String originalMessage, int limit) {
     }
 }


### PR DESCRIPTION
## Overview

Fixes #603 which describes a bug when using `/top-helpers` resulting in a too long message, not accepted by Discord.

The approach is simple yet effective:
* reduced the rows from 20 to 18
* abbreviate long user names (limit 15)
* move the description out of the column

these factors effectively reduced the message that was too long from 2300 characters down to 1100 characters, which is perfectively within limits.

## Notes

Since this class also needed abbreviation logic, I elevated the `abbreviate` method from within the `DiscordLogForwarder` to `MessageUtils`. And also gave it a unit test.