### PR TITLE
Format injection in help thread titles

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/AskCommand.java
@@ -136,10 +136,11 @@ public final class AskCommand extends SlashCommandAdapter {
             .map(role -> " (%s)".formatted(role.getAsMention()))
             .orElse("");
 
-        String contentPattern = "%s has a question about '**%s**'%%s and will send the details now."
-            .formatted(author.getAsMention(), title);
-        String contentWithoutRole = contentPattern.formatted("");
-        String contentWithRole = contentPattern.formatted(roleMentionDescription);
+        String contentPrefix =
+                "%s has a question about '**%s**'".formatted(author.getAsMention(), title);
+        String contentSuffix = " and will send the details now.";
+        String contentWithoutRole = contentPrefix + contentSuffix;
+        String contentWithRole = contentPrefix + roleMentionDescription + contentSuffix;
 
         // We want to invite all members of a role, but without hard-pinging them. However,
         // manually inviting them is cumbersome and can hit rate limits.


### PR DESCRIPTION
Fixed #561 which is about a bug where its possible for an user to do a format-injection on help thread titles.

The source of this is us doing `.formatted(...)` twice on the same string. The second invocation will then pick up injected `%s` by the user, leading to a crash.

The fix is to split the formatting section into two isolated pieces. The code, while being more verbose and less elegant, is also more readable now.