### PR TITLE
Link/Image previews for tags

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -57,6 +57,8 @@ dependencies {
 
     implementation 'io.mikael:urlbuilder:2.0.9'
 
+    implementation 'org.jsoup:jsoup:1.15.3'
+
     implementation 'org.scilab.forge:jlatexmath:1.0.7'
     implementation 'org.scilab.forge:jlatexmath-font-greek:1.0.7'
     implementation 'org.scilab.forge:jlatexmath-font-cyrillic:1.0.7'

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -68,6 +68,8 @@ dependencies {
 
 	implementation 'com.github.freva:ascii-table:1.8.0'
 
+    implementation 'io.github.url-detector:url-detector:0.1.23'
+
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.1'
 
     testImplementation 'org.mockito:mockito-core:4.8.0'

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagCommand.java
@@ -1,7 +1,13 @@
 package org.togetherjava.tjbot.commands.tags;
 
+import com.linkedin.urls.Url;
+import com.linkedin.urls.detection.UrlDetector;
+import com.linkedin.urls.detection.UrlDetectorOptions;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.AutoCompleteQuery;
 import net.dv8tion.jda.api.interactions.commands.Command;
@@ -9,13 +15,24 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+import net.dv8tion.jda.api.utils.FileUpload;
+import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
 
 import org.togetherjava.tjbot.commands.CommandVisibility;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.utils.StringDistances;
 
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.time.Instant;
-import java.util.Collection;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+import java.util.stream.IntStream;
 
 /**
  * Implements the {@code /tag} command which lets the bot respond content of a tag that has been
@@ -25,6 +42,7 @@ import java.util.Collection;
  * {@link TagsCommand}.
  */
 public final class TagCommand extends SlashCommandAdapter {
+    private static final HttpClient CLIENT = HttpClient.newHttpClient();
     private final TagSystem tagSystem;
     private static final int MAX_SUGGESTIONS = 5;
     static final String ID_OPTION = "id";
@@ -56,17 +74,117 @@ public final class TagCommand extends SlashCommandAdapter {
             return;
         }
 
-        ReplyCallbackAction message = event
-            .replyEmbeds(new EmbedBuilder().setDescription(tagSystem.getTag(id).orElseThrow())
-                .setFooter(event.getUser().getName() + " • used " + event.getCommandString())
-                .setTimestamp(Instant.now())
-                .setColor(TagSystem.AMBIENT_COLOR)
-                .build());
+        String tagContent = tagSystem.getTag(id).orElseThrow();
+        MessageEmbed contentEmbed = new EmbedBuilder().setDescription(tagContent)
+            .setFooter(event.getUser().getName() + " • used " + event.getCommandString())
+            .setTimestamp(Instant.now())
+            .setColor(TagSystem.AMBIENT_COLOR)
+            .build();
 
-        if (replyToUserOption != null) {
-            message = message.setContent(replyToUserOption.getAsUser().getAsMention());
+        Optional<String> replyToUserMention = Optional.ofNullable(replyToUserOption)
+            .map(OptionMapping::getAsUser)
+            .map(User::getAsMention);
+
+        List<String> links =
+                extractLinks(tagContent).stream().limit(Message.MAX_EMBED_COUNT - 1L).toList();
+        if (links.isEmpty()) {
+            // No link previews
+            ReplyCallbackAction message = event.replyEmbeds(contentEmbed);
+            replyToUserMention.ifPresent(message::setContent);
+            message.queue();
+            return;
         }
-        message.queue();
+
+        // Compute link previews
+        event.deferReply().queue();
+
+        createLinkPreviews(links).thenAccept(linkPreviews -> {
+            if (linkPreviews.isEmpty()) {
+                // Did not find any previews
+                MessageEditBuilder message = new MessageEditBuilder().setEmbeds(contentEmbed);
+                replyToUserMention.ifPresent(message::setContent);
+                event.getHook().editOriginal(message.build()).queue();
+                return;
+            }
+
+            Collection<MessageEmbed> embeds = new ArrayList<>();
+            embeds.add(contentEmbed);
+            embeds.addAll(linkPreviews.stream().map(LinkPreview::embed).toList());
+
+            List<FileUpload> attachments =
+                    linkPreviews.stream().map(LinkPreview::attachment).toList();
+
+            MessageEditBuilder message =
+                    new MessageEditBuilder().setEmbeds(embeds).setFiles(attachments);
+            replyToUserMention.ifPresent(message::setContent);
+            event.getHook().editOriginal(message.build()).queue();
+        });
+    }
+
+    private static List<String> extractLinks(String content) {
+        return new UrlDetector(content, UrlDetectorOptions.BRACKET_MATCH).detect()
+            .stream()
+            .map(Url::getFullUrl)
+            .toList();
+    }
+
+    private static CompletableFuture<List<LinkPreview>> createLinkPreviews(List<String> links) {
+        List<CompletableFuture<Optional<LinkPreview>>> tasks = IntStream.range(0, links.size())
+            .mapToObj(i -> createLinkPreview(links.get(i), i + ".png"))
+            .toList();
+
+        return CompletableFuture.allOf(tasks.toArray(CompletableFuture[]::new))
+            .thenApply(any -> tasks.stream()
+                .filter(Predicate.not(CompletableFuture::isCompletedExceptionally))
+                .map(CompletableFuture::join)
+                .flatMap(Optional::stream)
+                .toList());
+    }
+
+    private record LinkPreview(FileUpload attachment, MessageEmbed embed) {
+    }
+
+    private static CompletableFuture<Optional<LinkPreview>> createLinkPreview(String link,
+            String name) {
+        URI linkAsUri;
+        try {
+            linkAsUri = URI.create(link);
+        } catch (IllegalArgumentException e) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+
+        HttpRequest request = HttpRequest.newBuilder(linkAsUri).build();
+        CompletableFuture<HttpResponse<InputStream>> task =
+                CLIENT.sendAsync(request, HttpResponse.BodyHandlers.ofInputStream());
+
+        return task.thenApply(response -> {
+            int statusCode = response.statusCode();
+            if (statusCode < HttpURLConnection.HTTP_OK
+                    || statusCode >= HttpURLConnection.HTTP_MULT_CHOICE) {
+                return Optional.empty();
+            }
+            // TODO Add OpenGraph extraction "og:image"
+            if (!isResponseAnImage(response)) {
+                return Optional.empty();
+            }
+
+            FileUpload attachment = FileUpload.fromData(response.body(), name);
+            MessageEmbed embed = new EmbedBuilder()
+                // TODO Add title "og:title" and description "og:description",
+                // fallback to "twitter:title" and "twitter:description" if necessary
+                .setThumbnail("attachment://" + name)
+                .setColor(TagSystem.AMBIENT_COLOR)
+                .build();
+
+            return Optional.of(new LinkPreview(attachment, embed));
+        });
+    }
+
+    private static boolean isResponseAnImage(HttpResponse<?> response) {
+        return response.headers()
+            .firstValue("Content-Type")
+            .filter(contentType -> contentType.startsWith("image"))
+            .isPresent();
     }
 
     @Override

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagCommand.java
@@ -1,8 +1,5 @@
 package org.togetherjava.tjbot.commands.tags;
 
-import com.linkedin.urls.Url;
-import com.linkedin.urls.detection.UrlDetector;
-import com.linkedin.urls.detection.UrlDetectorOptions;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -10,6 +7,7 @@ import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.AutoCompleteQuery;
+import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
@@ -17,30 +15,18 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.dv8tion.jda.api.utils.FileUpload;
 import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
 
 import org.togetherjava.tjbot.commands.CommandVisibility;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
+import org.togetherjava.tjbot.commands.utils.LinkPreview;
+import org.togetherjava.tjbot.commands.utils.LinkPreviews;
 import org.togetherjava.tjbot.commands.utils.StringDistances;
 
-import javax.annotation.Nullable;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Predicate;
-import java.util.stream.IntStream;
 
 /**
  * Implements the {@code /tag} command which lets the bot respond content of a tag that has been
@@ -50,7 +36,6 @@ import java.util.stream.IntStream;
  * {@link TagsCommand}.
  */
 public final class TagCommand extends SlashCommandAdapter {
-    private static final HttpClient CLIENT = HttpClient.newHttpClient();
     private final TagSystem tagSystem;
     private static final int MAX_SUGGESTIONS = 5;
     static final String ID_OPTION = "id";
@@ -111,8 +96,10 @@ public final class TagCommand extends SlashCommandAdapter {
             .map(OptionMapping::getAsUser)
             .map(User::getAsMention);
 
-        List<String> links =
-                extractLinks(tagContent).stream().limit(Message.MAX_EMBED_COUNT - 1L).toList();
+        List<String> links = LinkPreviews.extractLinks(tagContent)
+            .stream()
+            .limit(Message.MAX_EMBED_COUNT - 1L)
+            .toList();
         if (links.isEmpty()) {
             // No link previews
             ReplyCallbackAction message = event.replyEmbeds(contentEmbed);
@@ -121,16 +108,19 @@ public final class TagCommand extends SlashCommandAdapter {
             return;
         }
 
-        // Compute link previews
         event.deferReply().queue();
 
-        // TODO Move all that link preview stuff into some helper
-        createLinkPreviews(links).thenAccept(linkPreviews -> {
+        respondWithLinkPreviews(event.getHook(), links, contentEmbed, replyToUserMention);
+    }
+
+    private void respondWithLinkPreviews(InteractionHook eventHook, List<String> links,
+            MessageEmbed contentEmbed, Optional<String> replyToUserMention) {
+        LinkPreviews.createLinkPreviews(links).thenAccept(linkPreviews -> {
             if (linkPreviews.isEmpty()) {
                 // Did not find any previews
                 MessageEditBuilder message = new MessageEditBuilder().setEmbeds(contentEmbed);
                 replyToUserMention.ifPresent(message::setContent);
-                event.getHook().editOriginal(message.build()).queue();
+                eventHook.editOriginal(message.build()).queue();
                 return;
             }
 
@@ -144,154 +134,7 @@ public final class TagCommand extends SlashCommandAdapter {
             MessageEditBuilder message =
                     new MessageEditBuilder().setEmbeds(embeds).setFiles(attachments);
             replyToUserMention.ifPresent(message::setContent);
-            event.getHook().editOriginal(message.build()).queue();
+            eventHook.editOriginal(message.build()).queue();
         });
-    }
-
-    private static List<String> extractLinks(String content) {
-        return new UrlDetector(content, UrlDetectorOptions.BRACKET_MATCH).detect()
-            .stream()
-            .map(Url::getFullUrl)
-            .toList();
-    }
-
-    private static CompletableFuture<List<LinkPreview>> createLinkPreviews(List<String> links) {
-        // TODO This stuff needs some polishing, barely readable
-        List<CompletableFuture<Optional<LinkPreview>>> tasks = IntStream.range(0, links.size())
-            .mapToObj(i -> createLinkPreview(links.get(i), i + ".png"))
-            .toList();
-
-        return CompletableFuture.allOf(tasks.toArray(CompletableFuture[]::new))
-            .thenApply(any -> tasks.stream()
-                .filter(Predicate.not(CompletableFuture::isCompletedExceptionally))
-                .map(CompletableFuture::join)
-                .flatMap(Optional::stream)
-                .toList());
-    }
-
-    private record LinkPreview(FileUpload attachment, MessageEmbed embed) {
-        static LinkPreview ofContents(@Nullable String title, String url,
-                @Nullable String description, String thumbnailName, InputStream thumbnail) {
-            FileUpload attachment = FileUpload.fromData(thumbnail, thumbnailName);
-            MessageEmbed embed = new EmbedBuilder().setTitle(title, url)
-                .setDescription(description)
-                .setThumbnail("attachment://" + thumbnailName)
-                .setColor(TagSystem.AMBIENT_COLOR)
-                .build();
-
-            return new LinkPreview(attachment, embed);
-        }
-
-        static LinkPreview ofThumbnail(String thumbnailName, InputStream thumbnail) {
-            FileUpload attachment = FileUpload.fromData(thumbnail, thumbnailName);
-            MessageEmbed embed = new EmbedBuilder().setThumbnail("attachment://" + thumbnailName)
-                .setColor(TagSystem.AMBIENT_COLOR)
-                .build();
-
-            return new LinkPreview(attachment, embed);
-        }
-    }
-
-    private static CompletableFuture<Optional<LinkPreview>> createLinkPreview(String link,
-            String attachmentName) {
-        URI linkAsUri;
-        try {
-            linkAsUri = URI.create(link);
-        } catch (IllegalArgumentException e) {
-            return CompletableFuture.completedFuture(Optional.empty());
-        }
-
-        HttpRequest request = HttpRequest.newBuilder(linkAsUri).build();
-        CompletableFuture<HttpResponse<InputStream>> task =
-                CLIENT.sendAsync(request, HttpResponse.BodyHandlers.ofInputStream());
-
-        return task.thenCompose(response -> {
-            int statusCode = response.statusCode();
-            if (statusCode < HttpURLConnection.HTTP_OK
-                    || statusCode >= HttpURLConnection.HTTP_MULT_CHOICE) {
-                return CompletableFuture.completedFuture(Optional.empty());
-            }
-            if (isResponseOfType(response, "image")) {
-                return CompletableFuture.completedFuture(
-                        Optional.of(LinkPreview.ofThumbnail(attachmentName, response.body())));
-            }
-            if (isResponseOfType(response, "text/html")) {
-                return parseWebsite(link, attachmentName, response.body());
-            }
-
-            return CompletableFuture.completedFuture(Optional.empty());
-        });
-    }
-
-    private static boolean isResponseOfType(HttpResponse<?> response, String type) {
-        return response.headers()
-            .firstValue("Content-Type")
-            .filter(contentType -> contentType.startsWith(type))
-            .isPresent();
-    }
-
-    private static CompletableFuture<Optional<LinkPreview>> parseWebsite(String link,
-            String attachmentName, InputStream websiteContent) {
-        Document doc;
-        try {
-            doc = Jsoup.parse(websiteContent, null, link);
-        } catch (IOException e) {
-            return CompletableFuture.completedFuture(Optional.empty());
-        }
-
-        String title = parseOpenGraphTwitterMeta(doc, "title", doc.title()).orElse(null);
-        String description =
-                parseOpenGraphTwitterMeta(doc, "description", doc.title()).orElse(null);
-        String image = parseOpenGraphMeta(doc, "image").orElse(null);
-
-        if (image == null) {
-            // TODO Can still do something
-            return CompletableFuture.completedFuture(Optional.empty());
-        }
-
-        // TODO Massive duplication
-        URI imageAsUri;
-        try {
-            imageAsUri = URI.create(image);
-        } catch (IllegalArgumentException e) {
-            return CompletableFuture.completedFuture(Optional.empty());
-        }
-
-        HttpRequest request = HttpRequest.newBuilder(imageAsUri).build();
-        CompletableFuture<HttpResponse<InputStream>> task =
-                CLIENT.sendAsync(request, HttpResponse.BodyHandlers.ofInputStream());
-
-        return task.thenCompose(response -> {
-            int statusCode = response.statusCode();
-            if (statusCode < HttpURLConnection.HTTP_OK
-                    || statusCode >= HttpURLConnection.HTTP_MULT_CHOICE) {
-                return CompletableFuture.completedFuture(Optional.empty());
-            }
-            if (!isResponseOfType(response, "image")) {
-                return CompletableFuture.completedFuture(Optional.empty());
-            }
-            return CompletableFuture.completedFuture(Optional.of(LinkPreview.ofContents(title, link,
-                    description, attachmentName, response.body())));
-        });
-    }
-
-    private static Optional<String> parseOpenGraphTwitterMeta(Document doc, String metaProperty,
-            @Nullable String fallback) {
-        String value = Optional
-            .ofNullable(doc.selectFirst("meta[property=og:%s]".formatted(metaProperty)))
-            .or(() -> Optional
-                .ofNullable(doc.selectFirst("meta[property=twitter:%s".formatted(metaProperty))))
-            .map(element -> element.attr("content"))
-            .orElse(fallback);
-        if (value == null) {
-            return Optional.empty();
-        }
-        return value.isBlank() ? Optional.empty() : Optional.of(value);
-    }
-
-    private static Optional<String> parseOpenGraphMeta(Document doc, String metaProperty) {
-        return Optional.ofNullable(doc.selectFirst("meta[property=og:%s]".formatted(metaProperty)))
-            .map(element -> element.attr("content"))
-            .filter(Predicate.not(String::isBlank));
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagCommand.java
@@ -129,6 +129,7 @@ public final class TagCommand extends SlashCommandAdapter {
     }
 
     private static CompletableFuture<List<LinkPreview>> createLinkPreviews(List<String> links) {
+        // TODO This stuff needs some polishing, barely readable
         List<CompletableFuture<Optional<LinkPreview>>> tasks = IntStream.range(0, links.size())
             .mapToObj(i -> createLinkPreview(links.get(i), i + ".png"))
             .toList();

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tags/TagCommand.java
@@ -23,10 +23,7 @@ import org.togetherjava.tjbot.commands.utils.LinkPreviews;
 import org.togetherjava.tjbot.commands.utils.StringDistances;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Implements the {@code /tag} command which lets the bot respond content of a tag that has been
@@ -128,8 +125,10 @@ public final class TagCommand extends SlashCommandAdapter {
             embeds.add(contentEmbed);
             embeds.addAll(linkPreviews.stream().map(LinkPreview::embed).toList());
 
-            List<FileUpload> attachments =
-                    linkPreviews.stream().map(LinkPreview::attachment).toList();
+            List<FileUpload> attachments = linkPreviews.stream()
+                .map(LinkPreview::attachment)
+                .filter(Objects::nonNull)
+                .toList();
 
             MessageEditBuilder message =
                     new MessageEditBuilder().setEmbeds(embeds).setFiles(attachments);

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/LinkPreview.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/LinkPreview.java
@@ -8,22 +8,29 @@ import javax.annotation.Nullable;
 
 import java.io.InputStream;
 
-public record LinkPreview(FileUpload attachment, MessageEmbed embed) {
-    static LinkPreview ofContents(@Nullable String title, String url, @Nullable String description,
-            String thumbnailName, InputStream thumbnail) {
-        FileUpload attachment = FileUpload.fromData(thumbnail, thumbnailName);
-        MessageEmbed embed = new EmbedBuilder().setTitle(title, url)
-            .setDescription(description)
-            .setThumbnail("attachment://" + thumbnailName)
-            .build();
-
-        return new LinkPreview(attachment, embed);
+public record LinkPreview(@Nullable FileUpload attachment, MessageEmbed embed) {
+    LinkPreview withThumbnail(String thumbnailName, InputStream thumbnail) {
+        return withThumbnail(embed, thumbnailName, thumbnail);
     }
 
     static LinkPreview ofThumbnail(String thumbnailName, InputStream thumbnail) {
+        return withThumbnail(null, thumbnailName, thumbnail);
+    }
+
+    static LinkPreview ofContents(@Nullable String title, String url,
+            @Nullable String description) {
+        MessageEmbed embed =
+                new EmbedBuilder().setTitle(title, url).setDescription(description).build();
+
+        return new LinkPreview(null, embed);
+    }
+
+    private static LinkPreview withThumbnail(@Nullable MessageEmbed embedToDecorate,
+            String thumbnailName, InputStream thumbnail) {
         FileUpload attachment = FileUpload.fromData(thumbnail, thumbnailName);
         MessageEmbed embed =
-                new EmbedBuilder().setThumbnail("attachment://" + thumbnailName).build();
+                new EmbedBuilder(embedToDecorate).setThumbnail("attachment://" + thumbnailName)
+                    .build();
 
         return new LinkPreview(attachment, embed);
     }

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/LinkPreview.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/LinkPreview.java
@@ -29,7 +29,7 @@ public record LinkPreview(@Nullable FileUpload attachment, MessageEmbed embed) {
      * @return this preview, but with a thumbnail
      */
     LinkPreview withThumbnail(String thumbnailName, InputStream thumbnail) {
-        return withThumbnail(embed, thumbnailName, thumbnail);
+        return createWithThumbnail(embed, thumbnailName, thumbnail);
     }
 
     /**
@@ -40,7 +40,7 @@ public record LinkPreview(@Nullable FileUpload attachment, MessageEmbed embed) {
      * @return the thumbnail as link preview
      */
     static LinkPreview ofThumbnail(String thumbnailName, InputStream thumbnail) {
-        return withThumbnail(null, thumbnailName, thumbnail);
+        return createWithThumbnail(null, thumbnailName, thumbnail);
     }
 
     /**
@@ -61,7 +61,7 @@ public record LinkPreview(@Nullable FileUpload attachment, MessageEmbed embed) {
         return new LinkPreview(null, embed);
     }
 
-    private static LinkPreview withThumbnail(@Nullable MessageEmbed embedToDecorate,
+    private static LinkPreview createWithThumbnail(@Nullable MessageEmbed embedToDecorate,
             String thumbnailName, InputStream thumbnail) {
         FileUpload attachment = FileUpload.fromData(thumbnail, thumbnailName);
         MessageEmbed embed =

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/LinkPreview.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/LinkPreview.java
@@ -1,0 +1,30 @@
+package org.togetherjava.tjbot.commands.utils;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.utils.FileUpload;
+
+import javax.annotation.Nullable;
+
+import java.io.InputStream;
+
+public record LinkPreview(FileUpload attachment, MessageEmbed embed) {
+    static LinkPreview ofContents(@Nullable String title, String url, @Nullable String description,
+            String thumbnailName, InputStream thumbnail) {
+        FileUpload attachment = FileUpload.fromData(thumbnail, thumbnailName);
+        MessageEmbed embed = new EmbedBuilder().setTitle(title, url)
+            .setDescription(description)
+            .setThumbnail("attachment://" + thumbnailName)
+            .build();
+
+        return new LinkPreview(attachment, embed);
+    }
+
+    static LinkPreview ofThumbnail(String thumbnailName, InputStream thumbnail) {
+        FileUpload attachment = FileUpload.fromData(thumbnail, thumbnailName);
+        MessageEmbed embed =
+                new EmbedBuilder().setThumbnail("attachment://" + thumbnailName).build();
+
+        return new LinkPreview(attachment, embed);
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/LinkPreview.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/LinkPreview.java
@@ -8,17 +8,53 @@ import javax.annotation.Nullable;
 
 import java.io.InputStream;
 
+/**
+ * Preview of a URL for display as embed in Discord.
+ * <p>
+ * If the attachment is not {@code null}, it has to be made available to the message as well, for
+ * example
+ * {@code new MessageCreateBuilder().addEmbeds(linkPreview.embed).addFiles(linkPreview.attachment)}.
+ *
+ * @param attachment the thumbnail image of the link, referenced within the embed, if present
+ * @param embed the embed representing the preview of the link
+ */
 public record LinkPreview(@Nullable FileUpload attachment, MessageEmbed embed) {
+    /**
+     * Creates a new instance of this link preview, but with the given thumbnail.
+     * <p>
+     * Any previous thumbnail is overridden and replaced.
+     *
+     * @param thumbnailName the name of the thumbnail, with extension, e.g. {@code foo.png}
+     * @param thumbnail the thumbnails data as raw data stream
+     * @return this preview, but with a thumbnail
+     */
     LinkPreview withThumbnail(String thumbnailName, InputStream thumbnail) {
         return withThumbnail(embed, thumbnailName, thumbnail);
     }
 
+    /**
+     * Creates a link preview that only has a thumbnail and no other text.
+     * 
+     * @param thumbnailName the name of the thumbnail, with extension, e.g. {@code foo.png}
+     * @param thumbnail the thumbnails data as raw data stream
+     * @return the thumbnail as link preview
+     */
     static LinkPreview ofThumbnail(String thumbnailName, InputStream thumbnail) {
         return withThumbnail(null, thumbnailName, thumbnail);
     }
 
-    static LinkPreview ofContents(@Nullable String title, String url,
-            @Nullable String description) {
+    /**
+     * Creates a link preview that consists of the given text.
+     * <p>
+     * Use {@link #withThumbnail(String, InputStream)} to decorate the preview also with a thumbnail
+     * image.
+     *
+     * @param title the title of the preview, if present
+     * @param url the link to the resource this preview represents
+     * @param description the description of the preview, if present
+     * @return the text as link preview
+     */
+    static LinkPreview ofText(@Nullable String title, String url, @Nullable String description) {
         MessageEmbed embed =
                 new EmbedBuilder().setTitle(title, url).setDescription(description).build();
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/LinkPreviews.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/LinkPreviews.java
@@ -1,0 +1,158 @@
+package org.togetherjava.tjbot.commands.utils;
+
+import com.linkedin.urls.Url;
+import com.linkedin.urls.detection.UrlDetector;
+import com.linkedin.urls.detection.UrlDetectorOptions;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+import java.util.stream.IntStream;
+
+public final class LinkPreviews {
+    private static final HttpClient CLIENT = HttpClient.newHttpClient();
+
+    private LinkPreviews() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static List<String> extractLinks(String content) {
+        return new UrlDetector(content, UrlDetectorOptions.BRACKET_MATCH).detect()
+            .stream()
+            .map(Url::getFullUrl)
+            .toList();
+    }
+
+    public static CompletableFuture<List<LinkPreview>> createLinkPreviews(List<String> links) {
+        if (links.isEmpty()) {
+            return CompletableFuture.completedFuture(List.of());
+        }
+
+        // TODO This stuff needs some polishing, barely readable
+        List<CompletableFuture<Optional<LinkPreview>>> tasks = IntStream.range(0, links.size())
+            .mapToObj(i -> createLinkPreview(links.get(i), i + ".png"))
+            .toList();
+
+        return CompletableFuture.allOf(tasks.toArray(CompletableFuture[]::new))
+            .thenApply(any -> tasks.stream()
+                .filter(Predicate.not(CompletableFuture::isCompletedExceptionally))
+                .map(CompletableFuture::join)
+                .flatMap(Optional::stream)
+                .toList());
+    }
+
+    private static CompletableFuture<Optional<LinkPreview>> createLinkPreview(String link,
+            String attachmentName) {
+        URI linkAsUri;
+        try {
+            linkAsUri = URI.create(link);
+        } catch (IllegalArgumentException e) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+
+        HttpRequest request = HttpRequest.newBuilder(linkAsUri).build();
+        CompletableFuture<HttpResponse<InputStream>> task =
+                CLIENT.sendAsync(request, HttpResponse.BodyHandlers.ofInputStream());
+
+        return task.thenCompose(response -> {
+            int statusCode = response.statusCode();
+            if (statusCode < HttpURLConnection.HTTP_OK
+                    || statusCode >= HttpURLConnection.HTTP_MULT_CHOICE) {
+                return CompletableFuture.completedFuture(Optional.empty());
+            }
+            if (isResponseOfType(response, "image")) {
+                return CompletableFuture.completedFuture(
+                        Optional.of(LinkPreview.ofThumbnail(attachmentName, response.body())));
+            }
+            if (isResponseOfType(response, "text/html")) {
+                return parseWebsite(link, attachmentName, response.body());
+            }
+
+            return CompletableFuture.completedFuture(Optional.empty());
+        });
+    }
+
+    private static boolean isResponseOfType(HttpResponse<?> response, String type) {
+        return response.headers()
+            .firstValue("Content-Type")
+            .filter(contentType -> contentType.startsWith(type))
+            .isPresent();
+    }
+
+    private static CompletableFuture<Optional<LinkPreview>> parseWebsite(String link,
+            String attachmentName, InputStream websiteContent) {
+        Document doc;
+        try {
+            doc = Jsoup.parse(websiteContent, null, link);
+        } catch (IOException e) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+
+        String title = parseOpenGraphTwitterMeta(doc, "title", doc.title()).orElse(null);
+        String description =
+                parseOpenGraphTwitterMeta(doc, "description", doc.title()).orElse(null);
+        String image = parseOpenGraphMeta(doc, "image").orElse(null);
+
+        if (image == null) {
+            // TODO Can still do something
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+
+        // TODO Massive duplication
+        URI imageAsUri;
+        try {
+            imageAsUri = URI.create(image);
+        } catch (IllegalArgumentException e) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+
+        HttpRequest request = HttpRequest.newBuilder(imageAsUri).build();
+        CompletableFuture<HttpResponse<InputStream>> task =
+                CLIENT.sendAsync(request, HttpResponse.BodyHandlers.ofInputStream());
+
+        return task.thenCompose(response -> {
+            int statusCode = response.statusCode();
+            if (statusCode < HttpURLConnection.HTTP_OK
+                    || statusCode >= HttpURLConnection.HTTP_MULT_CHOICE) {
+                return CompletableFuture.completedFuture(Optional.empty());
+            }
+            if (!isResponseOfType(response, "image")) {
+                return CompletableFuture.completedFuture(Optional.empty());
+            }
+            return CompletableFuture.completedFuture(Optional.of(LinkPreview.ofContents(title, link,
+                    description, attachmentName, response.body())));
+        });
+    }
+
+    private static Optional<String> parseOpenGraphTwitterMeta(Document doc, String metaProperty,
+            @Nullable String fallback) {
+        String value = Optional
+            .ofNullable(doc.selectFirst("meta[property=og:%s]".formatted(metaProperty)))
+            .or(() -> Optional
+                .ofNullable(doc.selectFirst("meta[property=twitter:%s".formatted(metaProperty))))
+            .map(element -> element.attr("content"))
+            .orElse(fallback);
+        if (value == null) {
+            return Optional.empty();
+        }
+        return value.isBlank() ? Optional.empty() : Optional.of(value);
+    }
+
+    private static Optional<String> parseOpenGraphMeta(Document doc, String metaProperty) {
+        return Optional.ofNullable(doc.selectFirst("meta[property=og:%s]".formatted(metaProperty)))
+            .map(element -> element.attr("content"))
+            .filter(Predicate.not(String::isBlank));
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/StringDistances.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/StringDistances.java
@@ -77,7 +77,7 @@ public class StringDistances {
         bestMatches.addAll(scoredMatches);
 
         return Stream.generate(bestMatches::poll)
-            .limit(limit)
+            .limit(Math.min(limit, bestMatches.size()))
             .takeWhile(matchScore -> isCloseEnough(matchScore, prefix))
             .map(MatchScore::candidate)
             .toList();


### PR DESCRIPTION
## Overview

Fixes #270 by implementing automatic link and image previews to the `/tag` command.

Image only preview:
![example](https://i.imgur.com/tEJpxDR.png)

Link preview:
![link](https://i.imgur.com/bxzbEk8.png)

## Utility

This feature is also available as general purpose utility via the `LinkPreviews` class, yielding records `LinkPreview`.

The utility offers two methods:
* `static List<String> extractLinks(String content)`
* `static CompletableFuture<List<LinkPreview>> createLinkPreviews(List<String> links)`

Features like #637 will likely make use of this as well.

## Dependencies

Adds `io.github.url-detector:url-detector:0.1.23` to the deps. URL regex is not something we want to have in our own code base lol.

Also adds **JSoup** for the OpenGraph/Twitter meta-extraction.

## Checklist

* [x] draft
* [x] opengraph extraction
* [x] add warn logs to all failures
* [x] polish
* [x] javadoc
* [x] ~~possibly unit tests~~ (not today)