### PR TITLE
Fixed issue with closing already closed threads on guild leave

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/OnGuildLeaveCloseThreadListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/OnGuildLeaveCloseThreadListener.java
@@ -66,7 +66,6 @@ public final class OnGuildLeaveCloseThreadListener extends ListenerAdapter
             return;
         }
 
-
         MessageEmbed embed = new EmbedBuilder().setTitle("OP left")
             .setDescription("Closing thread...")
             .setColor(HelpSystemHelper.AMBIENT_COLOR)

--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/OnGuildLeaveCloseThreadListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/OnGuildLeaveCloseThreadListener.java
@@ -1,6 +1,7 @@
 package org.togetherjava.tjbot.commands.help;
 
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
@@ -10,15 +11,17 @@ import org.slf4j.LoggerFactory;
 
 import org.togetherjava.tjbot.commands.EventReceiver;
 import org.togetherjava.tjbot.db.Database;
-import org.togetherjava.tjbot.db.generated.tables.HelpThreads;
 
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.togetherjava.tjbot.db.generated.tables.HelpThreads.HELP_THREADS;
+
 /**
  * Remove all thread channels associated to a user when they leave the guild.
  */
-public class OnGuildLeaveCloseThreadListener extends ListenerAdapter implements EventReceiver {
+public final class OnGuildLeaveCloseThreadListener extends ListenerAdapter
+        implements EventReceiver {
     private static final Logger logger =
             LoggerFactory.getLogger(OnGuildLeaveCloseThreadListener.class);
     private final Database database;
@@ -34,28 +37,36 @@ public class OnGuildLeaveCloseThreadListener extends ListenerAdapter implements 
 
     @Override
     public void onGuildMemberRemove(GuildMemberRemoveEvent leaveEvent) {
-        Set<Long> channelIds = getThreadsCreatedByLeaver(leaveEvent.getUser().getIdLong());
+        Set<Long> channelIds = fetchThreadsByLeaver(leaveEvent.getUser().getIdLong());
         for (long channelId : channelIds) {
-            closeThread(channelId, leaveEvent);
+            closeThread(channelId, leaveEvent.getGuild());
         }
     }
 
-    private Set<Long> getThreadsCreatedByLeaver(long leaverId) {
-        return new HashSet<>(database
-            .readTransaction(context -> context.select(HelpThreads.HELP_THREADS.CHANNEL_ID))
-            .from(HelpThreads.HELP_THREADS)
-            .where(HelpThreads.HELP_THREADS.AUTHOR_ID.eq(leaverId))
-            .fetch(databaseMapper -> databaseMapper.getValue(HelpThreads.HELP_THREADS.CHANNEL_ID)));
+    private Set<Long> fetchThreadsByLeaver(long leaverId) {
+        return new HashSet<>(
+                database.readTransaction(context -> context.select(HELP_THREADS.CHANNEL_ID))
+                    .from(HELP_THREADS)
+                    .where(HELP_THREADS.AUTHOR_ID.eq(leaverId))
+                    .fetch(databaseMapper -> databaseMapper.getValue(HELP_THREADS.CHANNEL_ID)));
     }
 
-    private void closeThread(long channelId, GuildMemberRemoveEvent leaveEvent) {
-        ThreadChannel threadChannel = leaveEvent.getGuild().getThreadChannelById(channelId);
+    private void closeThread(long channelId, Guild guild) {
+        ThreadChannel threadChannel = guild.getThreadChannelById(channelId);
         if (threadChannel == null) {
             logger.warn(
                     "Attempted to archive thread id: '{}' but could not find thread in guild: '{}'.",
-                    channelId, leaveEvent.getGuild().getName());
+                    channelId, guild.getName());
             return;
         }
+        if (threadChannel.isArchived()) {
+            logger.debug(
+                    "Attempted to archive thread id: '{}' in guild: '{}' but thread is already closed.",
+                    channelId, guild.getName());
+            return;
+        }
+
+
         MessageEmbed embed = new EmbedBuilder().setTitle("OP left")
             .setDescription("Closing thread...")
             .setColor(HelpSystemHelper.AMBIENT_COLOR)


### PR DESCRIPTION
Bugfix where the bot would attempt to close already closed channels when someone repeadetly leaves and rejoins:

![join](https://i.imgur.com/ftfmLgy.png)

![channel](https://i.imgur.com/10ASpWz.png)