### PR TITLE
Disabled JOOQ startup spam

### DIFF
--- a/database/src/main/java/org/togetherjava/tjbot/db/Database.java
+++ b/database/src/main/java/org/togetherjava/tjbot/db/Database.java
@@ -26,6 +26,11 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public final class Database {
 
+    static {
+        System.setProperty("org.jooq.no-logo", "true");
+        System.setProperty("org.jooq.no-tips", "true");
+    }
+
     private final DSLContext dslContext;
     /**
      * Lock used to implement thread-safety across this class. Any database modifying method must


### PR DESCRIPTION
Nothing ground breaking. It just removes this JOOQ logo and tips that take up console space and two extra webhook messages:
![image](https://user-images.githubusercontent.com/54677650/195927240-073622fc-e2c8-45ad-afa4-575bf51fbeda.png)
