### PR TITLE
Fix JOOQ version mismatch

### DIFF
--- a/buildSrc/src/main/groovy/database-settings.gradle
+++ b/buildSrc/src/main/groovy/database-settings.gradle
@@ -28,7 +28,7 @@ tasks.flywayMigrate {
 }
 
 jooq {
-    version = "3.15.2"
+    version = "3.16.0"
 
     configurations {
         main {


### PR DESCRIPTION
Fixes #639 

After the bump to JOOQ gradle plugin 7.1.1 the JOOQ version in application/build/tmp/generateJooq/config.xml changed to 3.16.0. This created a version mismatch with database-settings.gradle that were followed by a few warnings. Intellij would recognize these warnings as errors which was very annoying.