### PR TITLE
Fixed issue with jooq version

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 
     implementation 'club.minnced:discord-webhooks:0.8.2'
 
-    implementation 'org.jooq:jooq:3.17.2'
+    implementation "org.jooq:jooq:$jooqVersion"
 
     implementation 'io.mikael:urlbuilder:2.0.9'
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,10 @@ plugins {
 group 'org.togetherjava'
 version '1.0-SNAPSHOT'
 
+ext {
+    jooqVersion = '3.17.2'
+}
+
 // Skips sonarlint during the build, useful for testing purposes.
 Boolean skipSonarlint = false
 

--- a/buildSrc/src/main/groovy/database-settings.gradle
+++ b/buildSrc/src/main/groovy/database-settings.gradle
@@ -28,7 +28,7 @@ tasks.flywayMigrate {
 }
 
 jooq {
-    version = "3.16.0"
+    version = "3.17.2"
 
     configurations {
         main {
@@ -73,7 +73,7 @@ var sqliteVersion = "3.36.0.3"
 dependencies {
     implementation "org.xerial:sqlite-jdbc:${sqliteVersion}"
     implementation 'org.flywaydb:flyway-core:8.0.0'
-    implementation 'org.jooq:jooq:3.15.3'
+    implementation 'org.jooq:jooq:3.17.2'
 
     jooqGenerator "org.xerial:sqlite-jdbc:${sqliteVersion}"
 }

--- a/buildSrc/src/main/groovy/database-settings.gradle
+++ b/buildSrc/src/main/groovy/database-settings.gradle
@@ -28,7 +28,7 @@ tasks.flywayMigrate {
 }
 
 jooq {
-    version = "3.17.2"
+    version = jooqVersion
 
     configurations {
         main {
@@ -73,7 +73,7 @@ var sqliteVersion = "3.36.0.3"
 dependencies {
     implementation "org.xerial:sqlite-jdbc:${sqliteVersion}"
     implementation 'org.flywaydb:flyway-core:8.0.0'
-    implementation 'org.jooq:jooq:3.17.2'
+    implementation "org.jooq:jooq:$jooqVersion"
 
     jooqGenerator "org.xerial:sqlite-jdbc:${sqliteVersion}"
 }

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     implementation "org.xerial:sqlite-jdbc:${sqliteVersion}"
     implementation 'org.flywaydb:flyway-core:9.5.0'
-    implementation 'org.jooq:jooq:3.17.2'
+    implementation "org.jooq:jooq:$jooqVersion"
 
     implementation project(':utils')
 }


### PR DESCRIPTION
We defined the jooq version at multiple points. This lead to multiple mismatches in the past and also confuses dependabot.

Now, we moved it to a single point. That way, issues like that wont happen anymore.