### PR TITLE
Added suspicious keywords to scam blocker

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -19,6 +19,7 @@
    "scamBlocker": {
        "mode": "AUTO_DELETE_BUT_APPROVE_QUARANTINE",
        "reportChannelPattern": "commands",
+       "suspiciousKeywords": ["nitro", "boob", "sexy", "sexi", "esex"],
        "hostWhitelist": ["discord.com", "discord.gg", "discord.media", "discordapp.com", "discordapp.net", "discordstatus.com"],
        "hostBlacklist": ["bit.ly"],
        "suspiciousHostKeywords": ["discord", "nitro", "premium"],

--- a/application/src/main/java/org/togetherjava/tjbot/config/ScamBlockerConfig.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/ScamBlockerConfig.java
@@ -17,6 +17,7 @@ import java.util.Set;
 public final class ScamBlockerConfig {
     private final Mode mode;
     private final String reportChannelPattern;
+    private final Set<String> suspiciousKeywords;
     private final Set<String> hostWhitelist;
     private final Set<String> hostBlacklist;
     private final Set<String> suspiciousHostKeywords;
@@ -26,6 +27,8 @@ public final class ScamBlockerConfig {
     private ScamBlockerConfig(@JsonProperty(value = "mode", required = true) Mode mode,
             @JsonProperty(value = "reportChannelPattern",
                     required = true) String reportChannelPattern,
+            @JsonProperty(value = "suspiciousKeywords",
+                    required = true) Set<String> suspiciousKeywords,
             @JsonProperty(value = "hostWhitelist", required = true) Set<String> hostWhitelist,
             @JsonProperty(value = "hostBlacklist", required = true) Set<String> hostBlacklist,
             @JsonProperty(value = "suspiciousHostKeywords",
@@ -34,6 +37,7 @@ public final class ScamBlockerConfig {
                     required = true) int isHostSimilarToKeywordDistanceThreshold) {
         this.mode = Objects.requireNonNull(mode);
         this.reportChannelPattern = Objects.requireNonNull(reportChannelPattern);
+        this.suspiciousKeywords = new HashSet<>(Objects.requireNonNull(suspiciousKeywords));
         this.hostWhitelist = new HashSet<>(Objects.requireNonNull(hostWhitelist));
         this.hostBlacklist = new HashSet<>(Objects.requireNonNull(hostBlacklist));
         this.suspiciousHostKeywords = new HashSet<>(Objects.requireNonNull(suspiciousHostKeywords));
@@ -57,6 +61,15 @@ public final class ScamBlockerConfig {
      */
     public String getReportChannelPattern() {
         return reportChannelPattern;
+    }
+
+    /**
+     * Gets the set of keywords that are considered suspicious if they appear in a message.
+     *
+     * @return the set of suspicious keywords
+     */
+    public Set<String> getSuspiciousKeywords() {
+        return Collections.unmodifiableSet(suspiciousKeywords);
     }
 
     /**

--- a/application/src/test/java/org/togetherjava/tjbot/commands/moderation/scam/ScamDetectorTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/commands/moderation/scam/ScamDetectorTest.java
@@ -26,6 +26,8 @@ final class ScamDetectorTest {
         ScamBlockerConfig scamConfig = mock(ScamBlockerConfig.class);
         when(config.getScamBlocker()).thenReturn(scamConfig);
 
+        when(scamConfig.getSuspiciousKeywords())
+            .thenReturn(Set.of("nitro", "boob", "sexi", "esex"));
         when(scamConfig.getHostWhitelist()).thenReturn(Set.of("discord.com", "discord.gg",
                 "discord.media", "discordapp.com", "discordapp.net", "discordstatus.com"));
         when(scamConfig.getHostBlacklist()).thenReturn(Set.of("bit.ly"));
@@ -139,6 +141,9 @@ final class ScamDetectorTest {
                         Steam is giving away free discord nitro, have time to pick up at my link https://bit.ly/3nlzmUa before the action is over.""",
                 """
                         @everyone, take nitro faster, it's already running out
-                        https://discordu.gift/u1CHEX2sjpDuR3T5""");
+                        https://discordu.gift/u1CHEX2sjpDuR3T5""",
+                "@everyone join now https://discord.gg/boobise",
+                "@everyone join now https://discord.gg/esexiest",
+                "@everyone Join Now | Free All 12-18 y.o. https://discord.gg/eesexe");
     }
 }


### PR DESCRIPTION
## Overview

Closes #656 .

Adds a `suspiciousKeywords` feature to the `ScamBlocker`. If a message contains such a word, pings everyone and has any url, it is considered scam.

Previously, this feature existed as well, but it only checked for the string `"nitro"` hardcoded.

In the past, the `ScamBlocker` was only meant to prevent nitro-scam, but now we also face NSFW-scam. So we simply expand this feature and add words like `boob`, `esex` and similar on top.

The feature is fully unit tested on the recent scam we had.