### PR TITLE
Fix and speed up top helper anticheat

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersMessageListener.java
@@ -24,7 +24,7 @@ public final class TopHelpersMessageListener extends MessageReceiverAdapter {
      * @see <a href="https://www.regular-expressions.info/unicode.html#category">Unicode
      *      Categories</a>
      */
-    private static final String UNCOUNTED_CHARS = "\\P{C}";
+    private static final String UNCOUNTED_CHARS = "\\p{C}";
 
     private final Database database;
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/tophelper/TopHelpersMessageListener.java
@@ -24,7 +24,7 @@ public final class TopHelpersMessageListener extends MessageReceiverAdapter {
      * @see <a href="https://www.regular-expressions.info/unicode.html#category">Unicode
      *      Categories</a>
      */
-    private static final String UNCOUNTED_CHARS = "\\p{C}";
+    private static final Pattern UNCOUNTED_CHARS = Pattern.compile("\\p{C}");
 
     private final Database database;
 
@@ -74,7 +74,7 @@ public final class TopHelpersMessageListener extends MessageReceiverAdapter {
 
     private void addMessageRecord(MessageReceivedEvent event) {
         String messageContent = event.getMessage().getContentRaw();
-        long messageLength = messageContent.replaceAll(UNCOUNTED_CHARS, "").length();
+        long messageLength = UNCOUNTED_CHARS.matcher(messageContent).replaceAll("").length();
 
         database.write(context -> context.newRecord(HELP_CHANNEL_MESSAGES)
             .setMessageId(event.getMessage().getIdLong())


### PR DESCRIPTION
Fixes top helper anticheat not counting visible charachters instead of invisible ones. This was caused by me using a capital `P` for matching invisible charachters which selects all characters not being invisible. Everything now works as intended.

This also includes [Zabuzard's suggestion](https://github.com/Together-Java/TJ-Bot/pull/649#issuecomment-1288495927) of using a Pattern directly to replace the invisible chars which avoids String#replaceAll compiling a new pattern every time.