### PR TITLE
Adding delete button to filesharing response

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -8,8 +8,8 @@
     "modMailChannelPattern": "modmail",
     "mutedRolePattern": "Muted",
     "heavyModerationRolePattern": "Moderator",
-    "softModerationRolePattern": "Moderator|Staff Assistant",
-    "tagManageRolePattern": "Moderator|Staff Assistant|Top Helpers .+",
+    "softModerationRolePattern": "Moderator|Community Ambassador",
+    "tagManageRolePattern": "Moderator|Community Ambassador|Top Helpers .+",
    "suggestions": {
        "channelPattern": "tj_suggestions",
        "upVoteEmoteName": "peepo_yes",

--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
@@ -264,8 +264,10 @@ public class FileSharingMessageListener extends MessageReceiverAdapter implement
     @Override
     public void onButtonClick(ButtonInteractionEvent event, List<String> args) {
         Member user = event.getMember();
+        String authorId = args.get(0);
+        boolean hasSoftModPermissions = user.getRoles().stream().map(Role::getName).noneMatch(softModPattern);
 
-        if (!args.get(0).equals(user.getId()) && user.getRoles().stream().map(Role::getName).noneMatch(softModPattern)) {
+        if (!authorId.equals(user.getId()) && hasSoftModPermissions) {
             event.reply("You do not have permission for this action.")
                     .setEphemeral(true)
                     .queue();

--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
@@ -16,6 +16,7 @@ import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.togetherjava.tjbot.commands.MessageReceiverAdapter;
 import org.togetherjava.tjbot.commands.UserInteractionType;
 import org.togetherjava.tjbot.commands.UserInteractor;
@@ -229,7 +230,8 @@ public class FileSharingMessageListener extends MessageReceiverAdapter implement
 
         Button gist = Button.link(url, "gist");
 
-        Button delete = Button.danger(componentIdInteractor.generateComponentId(message.getAuthor().getId(), gistId),
+        Button delete = Button.danger(
+                componentIdInteractor.generateComponentId(message.getAuthor().getId(), gistId),
                 Emoji.fromUnicode("🗑️"));
 
         message.reply(messageContent).setActionRow(gist, delete).queue();
@@ -265,22 +267,21 @@ public class FileSharingMessageListener extends MessageReceiverAdapter implement
     public void onButtonClick(ButtonInteractionEvent event, List<String> args) {
         Member user = event.getMember();
         String authorId = args.get(0);
-        boolean hasSoftModPermissions = user.getRoles().stream().map(Role::getName).noneMatch(softModPattern);
+        boolean hasSoftModPermissions =
+                user.getRoles().stream().map(Role::getName).noneMatch(softModPattern);
 
         if (!authorId.equals(user.getId()) && hasSoftModPermissions) {
-            event.reply("You do not have permission for this action.")
-                    .setEphemeral(true)
-                    .queue();
+            event.reply("You do not have permission for this action.").setEphemeral(true).queue();
             return;
         }
 
         String gistId = args.get(1);
         HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(SHARE_API + "/" + gistId))
-                .header("Accept", "application/json")
-                .header("Authorization", "token " + gistApiKey)
-                .DELETE()
-                .build();
+            .uri(URI.create(SHARE_API + "/" + gistId))
+            .header("Accept", "application/json")
+            .header("Authorization", "token " + gistApiKey)
+            .DELETE()
+            .build();
 
         HttpResponse<String> apiResponse;
         try {
@@ -297,12 +298,13 @@ public class FileSharingMessageListener extends MessageReceiverAdapter implement
         int status = apiResponse.statusCode();
         if (status == 404) {
             throw new IllegalStateException("Gist API unexpected response while deleting gist: %s."
-                    .formatted(apiResponse.body()));
+                .formatted(apiResponse.body()));
         }
 
         Message message = event.getMessage();
         List<Button> buttons = message.getButtons();
-        event.editComponents(ActionRow.of(buttons.stream().map(Button::asDisabled).toList())).queue();
+        event.editComponents(ActionRow.of(buttons.stream().map(Button::asDisabled).toList()))
+            .queue();
     }
 
     @Override

--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
@@ -271,8 +271,8 @@ public class FileSharingMessageListener extends MessageReceiverAdapter implement
 
         int status = apiResponse.statusCode();
         if (status == 404) {
-            LOGGER.warn("Gist API unexpected response while deleting gist: {}.",
-                    apiResponse.body());
+            String responseBody = apiResponse.body();
+            LOGGER.warn("Gist API unexpected response while deleting gist: {}.", responseBody);
         }
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
@@ -251,11 +251,11 @@ public class FileSharingMessageListener extends MessageReceiverAdapter implement
 
     private void deleteGist(String gistId) {
         HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(SHARE_API + "/" + gistId))
-                .header("Accept", "application/json")
-                .header("Authorization", "token " + gistApiKey)
-                .DELETE()
-                .build();
+            .uri(URI.create(SHARE_API + "/" + gistId))
+            .header("Accept", "application/json")
+            .header("Authorization", "token " + gistApiKey)
+            .DELETE()
+            .build();
 
         HttpResponse<String> apiResponse;
         try {
@@ -271,7 +271,8 @@ public class FileSharingMessageListener extends MessageReceiverAdapter implement
 
         int status = apiResponse.statusCode();
         if (status == 404) {
-            LOGGER.warn("Gist API unexpected response while deleting gist: {}.", apiResponse.body());
+            LOGGER.warn("Gist API unexpected response while deleting gist: {}.",
+                    apiResponse.body());
         }
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/FileSharingMessageListener.java
@@ -268,7 +268,6 @@ public class FileSharingMessageListener extends MessageReceiverAdapter implement
                     "Attempting to delete a gist, but the request got interrupted.", e);
         }
 
-
         int status = apiResponse.statusCode();
         if (status == 404) {
             String responseBody = apiResponse.body();
@@ -303,13 +302,13 @@ public class FileSharingMessageListener extends MessageReceiverAdapter implement
             return;
         }
 
-        String gistId = args.get(1);
-        deleteGist(gistId);
-
         Message message = event.getMessage();
         List<Button> buttons = message.getButtons();
         event.editComponents(ActionRow.of(buttons.stream().map(Button::asDisabled).toList()))
             .queue();
+
+        String gistId = args.get(1);
+        deleteGist(gistId);
     }
 
     @Override

--- a/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/GistResponse.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/filesharing/GistResponse.java
@@ -12,6 +12,17 @@ final class GistResponse {
     @JsonProperty("html_url")
     private String htmlUrl;
 
+    @JsonProperty("id")
+    private String gistId;
+
+    public String getGistId() {
+        return gistId;
+    }
+
+    public void setGistId(String gistId) {
+        this.gistId = gistId;
+    }
+
     public String getHtmlUrl() {
         return htmlUrl;
     }
@@ -19,4 +30,5 @@ final class GistResponse {
     public void setHtmlUrl(String htmlUrl) {
         this.htmlUrl = htmlUrl;
     }
+
 }


### PR DESCRIPTION
# About
This feature adds a delete button to the filesharing response, so soft mods or the author can delete this gist.

## Examples
Before usage:
![image](https://user-images.githubusercontent.com/88111627/199533847-4f656aff-206d-4326-a2e4-0fccf8947f65.png)

After usage:
![image](https://user-images.githubusercontent.com/88111627/199534409-8cefd908-a45f-44c7-9c8d-ecd038e5cc87.png)

Without permission:
![image](https://user-images.githubusercontent.com/88111627/199534316-78ec6600-09e4-489c-a3ca-81f6f78fb5d6.png)
