### PR TITLE
Introduced a var for the jackson version

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -60,10 +60,10 @@ dependencies {
     implementation 'org.scilab.forge:jlatexmath-font-greek:1.0.7'
     implementation 'org.scilab.forge:jlatexmath-font-cyrillic:1.0.7'
 
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.14.0'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.0'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:$jacksonVersion"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
 
 	implementation 'com.github.freva:ascii-table:1.8.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ version '1.0-SNAPSHOT'
 
 ext {
     jooqVersion = '3.17.2'
+    jacksonVersion = '2.14.0'
 }
 
 // Skips sonarlint during the build, useful for testing purposes.


### PR DESCRIPTION
Seems that a Jackson update spawns 4 dependabot tasks:

![tasks](https://i.imgur.com/PhE4gps.png)

Thats not really nice. To get rid of the issue, this PR introduces a single variable for the version.