### PR TITLE
Code-Actions improvements

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
@@ -6,6 +6,7 @@ import org.togetherjava.tjbot.commands.basic.PingCommand;
 import org.togetherjava.tjbot.commands.basic.RoleSelectCommand;
 import org.togetherjava.tjbot.commands.basic.SuggestionsUpDownVoter;
 import org.togetherjava.tjbot.commands.basic.VcActivityCommand;
+import org.togetherjava.tjbot.commands.code.CodeMessageAutoDetection;
 import org.togetherjava.tjbot.commands.code.CodeMessageHandler;
 import org.togetherjava.tjbot.commands.filesharing.FileSharingMessageListener;
 import org.togetherjava.tjbot.commands.help.*;
@@ -68,6 +69,7 @@ public class Features {
         ModAuditLogWriter modAuditLogWriter = new ModAuditLogWriter(config);
         ScamHistoryStore scamHistoryStore = new ScamHistoryStore(database);
         HelpSystemHelper helpSystemHelper = new HelpSystemHelper(jda, config, database);
+        CodeMessageHandler codeMessageHandler = new CodeMessageHandler();
 
         // NOTE The system can add special system relevant commands also by itself,
         // hence this list may not necessarily represent the full list of all commands actually
@@ -95,7 +97,8 @@ public class Features {
         features.add(new MediaOnlyChannelListener(config));
         features.add(new FileSharingMessageListener(config));
         features.add(new BlacklistedAttachmentListener(config, modAuditLogWriter));
-        features.add(new CodeMessageHandler());
+        features.add(codeMessageHandler);
+        features.add(new CodeMessageAutoDetection(config, codeMessageHandler));
 
         // Event receivers
         features.add(new RejoinModerationRoleListener(actionsStore, config));

--- a/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/Features.java
@@ -8,6 +8,7 @@ import org.togetherjava.tjbot.commands.basic.SuggestionsUpDownVoter;
 import org.togetherjava.tjbot.commands.basic.VcActivityCommand;
 import org.togetherjava.tjbot.commands.code.CodeMessageAutoDetection;
 import org.togetherjava.tjbot.commands.code.CodeMessageHandler;
+import org.togetherjava.tjbot.commands.code.CodeMessageManualDetection;
 import org.togetherjava.tjbot.commands.filesharing.FileSharingMessageListener;
 import org.togetherjava.tjbot.commands.help.*;
 import org.togetherjava.tjbot.commands.mathcommands.TeXCommand;
@@ -99,6 +100,7 @@ public class Features {
         features.add(new BlacklistedAttachmentListener(config, modAuditLogWriter));
         features.add(codeMessageHandler);
         features.add(new CodeMessageAutoDetection(config, codeMessageHandler));
+        features.add(new CodeMessageManualDetection(codeMessageHandler));
 
         // Event receivers
         features.add(new RejoinModerationRoleListener(actionsStore, config));

--- a/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
@@ -1,0 +1,80 @@
+package org.togetherjava.tjbot.commands.code;
+
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+
+import org.togetherjava.tjbot.commands.MessageReceiverAdapter;
+import org.togetherjava.tjbot.commands.utils.CodeFence;
+import org.togetherjava.tjbot.commands.utils.MessageUtils;
+import org.togetherjava.tjbot.config.Config;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+/**
+ * Automatically detects messages that contain code and registers them at {@link CodeMessageHandler}
+ * for further processing.
+ */
+public final class CodeMessageAutoDetection extends MessageReceiverAdapter {
+    private static final long MINIMUM_LINES_OF_CODE = 3;
+
+    private final CodeMessageHandler codeMessageHandler;
+
+    private final Predicate<String> isStagingChannelName;
+    private final Predicate<String> isOverviewChannelName;
+
+    /**
+     * Creates a new instance.
+     * 
+     * @param config to figure out whether a message is from a help thread
+     * @param codeMessageHandler to register detected code messages at for further handling
+     */
+    public CodeMessageAutoDetection(Config config, CodeMessageHandler codeMessageHandler) {
+        super(Pattern.compile(".*"));
+
+        this.codeMessageHandler = codeMessageHandler;
+
+        isStagingChannelName = Pattern.compile(config.getHelpSystem().getStagingChannelPattern())
+            .asMatchPredicate();
+        isOverviewChannelName = Pattern.compile(config.getHelpSystem().getOverviewChannelPattern())
+            .asMatchPredicate();
+    }
+
+    @Override
+    public void onMessageReceived(MessageReceivedEvent event) {
+        if (event.isWebhookMessage() || event.getAuthor().isBot() || !isHelpThread(event)) {
+            return;
+        }
+
+        Message originalMessage = event.getMessage();
+        String content = originalMessage.getContentRaw();
+
+        Optional<CodeFence> maybeCode = MessageUtils.extractCode(content);
+        if (maybeCode.isEmpty()) {
+            // There is no code in the message, ignore it
+            return;
+        }
+
+        long amountOfCodeLines =
+                maybeCode.orElseThrow().code().lines().limit(MINIMUM_LINES_OF_CODE + 1).count();
+        if (amountOfCodeLines < MINIMUM_LINES_OF_CODE) {
+            return;
+        }
+
+        codeMessageHandler.addAndHandleCodeMessage(event.getMessage());
+    }
+
+    private boolean isHelpThread(MessageReceivedEvent event) {
+        if (event.getChannelType() != ChannelType.GUILD_PUBLIC_THREAD) {
+            return false;
+        }
+
+        ThreadChannel thread = event.getChannel().asThreadChannel();
+        String rootChannelName = thread.getParentChannel().getName();
+        return isStagingChannelName.test(rootChannelName)
+                || isOverviewChannelName.test(rootChannelName);
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
@@ -50,21 +50,20 @@ public final class CodeMessageAutoDetection extends MessageReceiverAdapter {
         }
 
         Message originalMessage = event.getMessage();
-        String content = originalMessage.getContentRaw();
 
-        Optional<CodeFence> maybeCode = MessageUtils.extractCode(content);
+        Optional<CodeFence> maybeCode = MessageUtils.extractCode(originalMessage.getContentRaw());
         if (maybeCode.isEmpty()) {
             // There is no code in the message, ignore it
             return;
         }
 
         long amountOfCodeLines =
-                maybeCode.orElseThrow().code().lines().limit(MINIMUM_LINES_OF_CODE + 1).count();
+                maybeCode.orElseThrow().code().lines().limit(MINIMUM_LINES_OF_CODE).count();
         if (amountOfCodeLines < MINIMUM_LINES_OF_CODE) {
             return;
         }
 
-        codeMessageHandler.addAndHandleCodeMessage(event.getMessage());
+        codeMessageHandler.addAndHandleCodeMessage(originalMessage);
     }
 
     private boolean isHelpThread(MessageReceivedEvent event) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageHandler.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageHandler.java
@@ -141,8 +141,10 @@ public final class CodeMessageHandler extends MessageReceiverAdapter implements 
     }
 
     private Button createDeleteButton(long originalMessageId) {
-        return Button.danger(componentIdInteractor.generateComponentId(
-                Long.toString(originalMessageId), "", DELETE_CUE), Emoji.fromUnicode("🗑"));
+        String noCodeActionLabel = "";
+        return Button.danger(componentIdInteractor
+            .generateComponentId(Long.toString(originalMessageId), noCodeActionLabel, DELETE_CUE),
+                Emoji.fromUnicode("🗑"));
     }
 
     private Button createButtonForAction(CodeAction action, long originalMessageId) {
@@ -154,6 +156,7 @@ public final class CodeMessageHandler extends MessageReceiverAdapter implements 
     @Override
     public void onButtonClick(ButtonInteractionEvent event, List<String> args) {
         long originalMessageId = Long.parseLong(args.get(0));
+        // The third arg indicates a non-code-action button
         if (args.size() >= 3 && DELETE_CUE.equals(args.get(2))) {
             deleteCodeReply(event, originalMessageId);
             return;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageManualDetection.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageManualDetection.java
@@ -1,0 +1,37 @@
+package org.togetherjava.tjbot.commands.code;
+
+import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+
+import org.togetherjava.tjbot.commands.BotCommandAdapter;
+import org.togetherjava.tjbot.commands.CommandVisibility;
+import org.togetherjava.tjbot.commands.MessageContextCommand;
+
+/**
+ * Context command to allow users to select messages that contain code. They are then registered at
+ * {@link CodeMessageHandler} for further processing.
+ */
+public final class CodeMessageManualDetection extends BotCommandAdapter
+        implements MessageContextCommand {
+    private final CodeMessageHandler codeMessageHandler;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param codeMessageHandler to register selected code messages at for further handling
+     */
+    public CodeMessageManualDetection(CodeMessageHandler codeMessageHandler) {
+        super(Commands.message("code-actions"), CommandVisibility.GUILD);
+
+        this.codeMessageHandler = codeMessageHandler;
+    }
+
+    @Override
+    public void onMessageContext(MessageContextInteractionEvent event) {
+        event.reply("I registered the message as code-message, actions should appear now.")
+            .setEphemeral(true)
+            .queue();
+
+        codeMessageHandler.addAndHandleCodeMessage(event.getTarget());
+    }
+}


### PR DESCRIPTION
## Motivation

We recently added code-actions with auto-detection on all code messages. The feature is cool, but triggers too often and hence annoys.

This PR attempts to fix most of the problems.

## Overview

The PR essentially adds 3 features:

1. the auto-detection is reduced to
    * only detect messages in help threads
    * only detect code with at least 3 lines of code
2. therefore, add a message context command for helpers to manually register code messages
3. add a delete button

### Auto-detection

The changes on the auto-detection are straightforward. To improve the code a bit, it has been moved out into its own class.

### Command

The main advantages of the context command are:
* allows adding messages outside of help-threads if desired
* allows adding messages in help threads with less than 3 lines, if desired
* allows adding messages without any code-block **(this is huge)**

![command](https://i.imgur.com/Hk4UmiY.png)
![response](https://i.imgur.com/wQ1mIoT.png)

### Delete

Further, a delete-button has been added to get rid of the message if it appears albeit not wanted:

![delete](https://i.imgur.com/wW5eJ9o.png)