### PR TITLE
Some tweaks to the helper prune system

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/AutoPruneHelperRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/AutoPruneHelperRoutine.java
@@ -33,9 +33,9 @@ public final class AutoPruneHelperRoutine implements Routine {
 
     private static final int ROLE_FULL_LIMIT = 100;
     private static final int ROLE_FULL_THRESHOLD = 95;
-    private static final int PRUNE_MEMBER_AMOUNT = 10;
+    private static final int PRUNE_MEMBER_AMOUNT = 7;
     private static final Period INACTIVE_AFTER = Period.ofDays(90);
-    private static final int RECENTLY_JOINED_DAYS = 7;
+    private static final int RECENTLY_JOINED_DAYS = 4;
 
     private final HelpSystemHelper helper;
     private final ModAuditLogWriter modAuditLogWriter;


### PR DESCRIPTION
We often get this warning:

![warning](https://i.imgur.com/QedJqZf.png)

Seems that our current settigns are slightly above the sweetspot. This PR adjusts the settings a bit to hopefully reduce this warning.

* pruning earlier, but therefore less

should hopefully lead to being able to prune the desired amount of people each time, getting less warnings.