### PR TITLE
Fixed a small OOB bug with extracting code

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/MessageUtils.java
@@ -180,7 +180,8 @@ public class MessageUtils {
             return Optional.empty();
         }
 
-        int codeFenceEnd = fullMessage.indexOf(CODE_FENCE_SYMBOL, codeFenceStart + 1);
+        int languageStart = codeFenceStart + CODE_FENCE_SYMBOL.length();
+        int codeFenceEnd = fullMessage.indexOf(CODE_FENCE_SYMBOL, languageStart);
         if (codeFenceEnd == -1) {
             return Optional.empty();
         }
@@ -188,7 +189,6 @@ public class MessageUtils {
         // Language is between ``` and newline, no spaces allowed, like ```java
         // Look for the next newline and then assert no space between
         String language = null;
-        int languageStart = codeFenceStart + CODE_FENCE_SYMBOL.length();
         int languageEnd = fullMessage.indexOf('\n', codeFenceStart);
         if (languageEnd != -1) {
             String languageCandidate = fullMessage.substring(languageStart, languageEnd);


### PR DESCRIPTION
Fix for this bug:

![bug](https://i.imgur.com/1VBQ7Sj.png)

Happens in rare conditions when the message has more than three backticks before the language. Such as:

![issue](https://i.imgur.com/FIUkpAO.png)