### PR TITLE
Fixed bug with linkpreview OG twitter broken

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/utils/LinkPreviews.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/utils/LinkPreviews.java
@@ -176,7 +176,7 @@ public final class LinkPreviews {
         String value = Optional
             .ofNullable(doc.selectFirst("meta[property=og:%s]".formatted(metaProperty)))
             .or(() -> Optional
-                .ofNullable(doc.selectFirst("meta[property=twitter:%s".formatted(metaProperty))))
+                .ofNullable(doc.selectFirst("meta[property=twitter:%s]".formatted(metaProperty))))
             .map(element -> element.attr("content"))
             .orElse(fallback);
         if (value == null) {


### PR DESCRIPTION
Fixed a small syntax issue in the JSoup query selection for the OpenGraph Twitter title property.

Unfortunately, JSoup didnt just crash and gave us a proper exception, but instead searched for the element forever...

This is the reason we did a rollback on the latest release. Once its merged, we can rerelease.