### PR TITLE
Fixed bug with help thread creation actions being send too fast

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadCreatedListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpThreadCreatedListener.java
@@ -9,6 +9,8 @@ import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
 import net.dv8tion.jda.api.events.channel.ChannelCreateEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.requests.RestAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.togetherjava.tjbot.commands.EventReceiver;
 
@@ -16,6 +18,8 @@ import javax.annotation.Nonnull;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -25,6 +29,9 @@ import java.util.concurrent.TimeUnit;
  * user.
  */
 public final class HelpThreadCreatedListener extends ListenerAdapter implements EventReceiver {
+    private static final Logger logger = LoggerFactory.getLogger(HelpThreadCreatedListener.class);
+    private static final ScheduledExecutorService SERVICE = Executors.newScheduledThreadPool(2);
+
     private final HelpSystemHelper helper;
     private final Cache<Long, Instant> threadIdToCreatedAtCache = Caffeine.newBuilder()
         .maximumSize(1_000)
@@ -69,7 +76,20 @@ public final class HelpThreadCreatedListener extends ListenerAdapter implements 
     private void handleHelpThreadCreated(ThreadChannel threadChannel) {
         helper.writeHelpThreadToDatabase(threadChannel.getOwnerIdLong(), threadChannel);
 
-        createMessages(threadChannel).queue();
+        Runnable createMessages = () -> {
+            try {
+                createMessages(threadChannel).queue();
+            } catch (Exception e) {
+                logger.error(
+                        "Unknown error while creating messages after help-thread ({}) creation",
+                        threadChannel.getId(), e);
+            }
+        };
+
+        // The creation is delayed, because otherwise it could be too fast and be executed
+        // after Discord created the thread, but before Discord send OPs initial message.
+        // Sending messages at that moment is not allowed.
+        SERVICE.schedule(createMessages, 5, TimeUnit.SECONDS);
     }
 
     private RestAction<Message> createMessages(ThreadChannel threadChannel) {


### PR DESCRIPTION
## Overview

Fixes and closes #723.

This is about a bug happening when our "on-help-thread-created"-actions are executed too fast, after Discord created the thread, but before it send OPs first message. It seems that the whole process does not happen atomic on Discords side, so our actions can slip in-between.

When that happens, we get an exception, cause the first message has to be from OP.

This fixes the issue by delaying sending the messages by 5 seconds, easy.