### PR TITLE
Prefer uncommon categories first

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/help/HelpSystemHelper.java
@@ -32,9 +32,11 @@ import java.awt.Color;
 import java.io.InputStream;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Helper class offering certain methods used by the help system.
@@ -48,6 +50,11 @@ public final class HelpSystemHelper {
 
     private final Predicate<String> isHelpForumName;
     private final String helpForumPattern;
+    /**
+     * Compares categories by how common they are, ascending. I.e., the most uncommon or specific
+     * category comes first.
+     */
+    private final Comparator<ForumTag> byCategoryCommonnessAsc;
     private final Set<String> categories;
     private final Set<String> threadActivityTagNames;
     private final String categoryRoleSuffix;
@@ -66,8 +73,17 @@ public final class HelpSystemHelper {
         helpForumPattern = helpConfig.getHelpForumPattern();
         isHelpForumName = Pattern.compile(helpForumPattern).asMatchPredicate();
 
-        categories = new HashSet<>(helpConfig.getCategories());
+        List<String> categoriesList = helpConfig.getCategories();
+        categories = new HashSet<>(categoriesList);
         categoryRoleSuffix = helpConfig.getCategoryRoleSuffix();
+
+        Map<String, Integer> categoryToCommonDesc = IntStream.range(0, categoriesList.size())
+            .boxed()
+            .collect(Collectors.toMap(categoriesList::get, Function.identity()));
+        byCategoryCommonnessAsc = Comparator
+            .<ForumTag>comparingInt(
+                    tag -> categoryToCommonDesc.getOrDefault(tag.getName(), categories.size()))
+            .reversed();
 
         threadActivityTagNames = Arrays.stream(ThreadActivity.values())
             .map(ThreadActivity::getTagName)
@@ -171,12 +187,12 @@ public final class HelpSystemHelper {
         return getFirstMatchingTagOfChannel(threadActivityTagNames, channel);
     }
 
-    private static Optional<ForumTag> getFirstMatchingTagOfChannel(Set<String> tagNamesToMatch,
+    private Optional<ForumTag> getFirstMatchingTagOfChannel(Set<String> tagNamesToMatch,
             ThreadChannel channel) {
         return channel.getAppliedTags()
             .stream()
             .filter(tag -> tagNamesToMatch.contains(tag.getName()))
-            .findFirst();
+            .min(byCategoryCommonnessAsc);
     }
 
     RestAction<Void> changeChannelCategory(ThreadChannel channel, String category) {
@@ -187,8 +203,8 @@ public final class HelpSystemHelper {
         return changeMatchingTagOfChannel(activity.getTagName(), threadActivityTagNames, channel);
     }
 
-    private static RestAction<Void> changeMatchingTagOfChannel(String tagName,
-            Set<String> tagNamesToMatch, ThreadChannel channel) {
+    private RestAction<Void> changeMatchingTagOfChannel(String tagName, Set<String> tagNamesToMatch,
+            ThreadChannel channel) {
         List<ForumTag> tags = new ArrayList<>(channel.getAppliedTags());
 
         Optional<ForumTag> currentTag = getFirstMatchingTagOfChannel(tagNamesToMatch, channel);


### PR DESCRIPTION
## Overview

Implements and closes #725.

Fixes the problem that often users tend to select Java as the first category, just because it has to do with Java.

This leads to the Java helpers often being pinged, despite the question is about something more specific. And the actual helpers for this topic not being alerted at all.

## Solution

The categories are now selected in reverse-order of the config. Assuming that the config lists them in commonness descending (in particular, Java first).

Now, when an user picks multiple categories:

![example](https://i.imgur.com/lnLHFM4.png)

It will sort the categories by commonness ascending (uncommon first) and pick the first, i.e. the most uncommon, pinging the most specific category:

![pings correct](https://i.imgur.com/4An44gR.png)