### PR TITLE
Make code actions autodetection not trigger for top helpers+

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -10,7 +10,7 @@
     "heavyModerationRolePattern": "Moderator",
     "softModerationRolePattern": "Moderator|Community Ambassador",
     "tagManageRolePattern": "Moderator|Community Ambassador|Top Helpers .+",
-    "ignoreCodeAutoDetectionRolePattern": "Top Helpers .+|Moderator|Community Ambassador|Expert",
+    "excludeCodeAutoDetectionRolePattern": "Top Helpers .+|Moderator|Community Ambassador|Expert",
    "suggestions": {
        "channelPattern": "tj_suggestions",
        "upVoteEmoteName": "peepo_yes",

--- a/application/config.json.template
+++ b/application/config.json.template
@@ -10,7 +10,7 @@
     "heavyModerationRolePattern": "Moderator",
     "softModerationRolePattern": "Moderator|Community Ambassador",
     "tagManageRolePattern": "Moderator|Community Ambassador|Top Helpers .+",
-    "ignoreMessageAutoDetectionRolePattern": "Top Helpers .+",
+    "ignoreCodeAutoDetectionRolePattern": "Top Helpers .+|Moderator|Community Ambassador|Expert",
    "suggestions": {
        "channelPattern": "tj_suggestions",
        "upVoteEmoteName": "peepo_yes",

--- a/application/config.json.template
+++ b/application/config.json.template
@@ -10,6 +10,7 @@
     "heavyModerationRolePattern": "Moderator",
     "softModerationRolePattern": "Moderator|Community Ambassador",
     "tagManageRolePattern": "Moderator|Community Ambassador|Top Helpers .+",
+    "ignoreCodeActionsForRolePattern": "Top Helpers .+",
    "suggestions": {
        "channelPattern": "tj_suggestions",
        "upVoteEmoteName": "peepo_yes",

--- a/application/config.json.template
+++ b/application/config.json.template
@@ -10,7 +10,7 @@
     "heavyModerationRolePattern": "Moderator",
     "softModerationRolePattern": "Moderator|Community Ambassador",
     "tagManageRolePattern": "Moderator|Community Ambassador|Top Helpers .+",
-    "ignoreCodeActionsForRolePattern": "Top Helpers .+",
+    "ignoreMessageAutoDetectionRolePattern": "Top Helpers .+",
    "suggestions": {
        "channelPattern": "tj_suggestions",
        "upVoteEmoteName": "peepo_yes",

--- a/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
@@ -11,7 +11,6 @@ import org.togetherjava.tjbot.commands.utils.CodeFence;
 import org.togetherjava.tjbot.commands.utils.MessageUtils;
 import org.togetherjava.tjbot.config.Config;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -26,7 +25,7 @@ public final class CodeMessageAutoDetection extends MessageReceiverAdapter {
 
     private final CodeMessageHandler codeMessageHandler;
     private final Predicate<String> isHelpForumName;
-    private final List<Predicate<String>> isIgnoredRolePattern;
+    private final Predicate<String> isIgnoredRolePattern;
 
     /**
      * Creates a new instance.
@@ -43,9 +42,7 @@ public final class CodeMessageAutoDetection extends MessageReceiverAdapter {
                 Pattern.compile(config.getHelpSystem().getHelpForumPattern()).asMatchPredicate();
 
         isIgnoredRolePattern =
-                Arrays.stream(config.getIgnoreCodeAutoDetectionRolePattern().split("\\|"))
-                    .map(role -> Pattern.compile(role).asMatchPredicate())
-                    .toList();
+                Pattern.compile(config.getIgnoreCodeAutoDetectionRolePattern()).asMatchPredicate();
     }
 
     @Override
@@ -73,10 +70,7 @@ public final class CodeMessageAutoDetection extends MessageReceiverAdapter {
     }
 
     private boolean isSentByExcludedRole(List<Role> roles) {
-        return roles.stream()
-            .map(Role::getName)
-            .anyMatch(role -> isIgnoredRolePattern.stream()
-                .anyMatch(rolePattern -> rolePattern.test(role)));
+        return roles.stream().map(Role::getName).anyMatch(isIgnoredRolePattern);
     }
 
     private boolean isHelpThread(MessageReceivedEvent event) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
@@ -25,7 +25,7 @@ public final class CodeMessageAutoDetection extends MessageReceiverAdapter {
 
     private final CodeMessageHandler codeMessageHandler;
     private final Predicate<String> isHelpForumName;
-    private final Predicate<String> isExcludedRolePattern;
+    private final Predicate<String> isExcludedRole;
 
     /**
      * Creates a new instance.
@@ -41,7 +41,7 @@ public final class CodeMessageAutoDetection extends MessageReceiverAdapter {
         isHelpForumName =
                 Pattern.compile(config.getHelpSystem().getHelpForumPattern()).asMatchPredicate();
 
-        isExcludedRolePattern =
+        isExcludedRole =
                 Pattern.compile(config.getExcludeCodeAutoDetectionRolePattern()).asMatchPredicate();
     }
 
@@ -70,7 +70,7 @@ public final class CodeMessageAutoDetection extends MessageReceiverAdapter {
     }
 
     private boolean isSentByExcludedRole(List<Role> roles) {
-        return roles.stream().map(Role::getName).anyMatch(isExcludedRolePattern);
+        return roles.stream().map(Role::getName).anyMatch(isExcludedRole);
     }
 
     private boolean isHelpThread(MessageReceivedEvent event) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
@@ -11,6 +11,7 @@ import org.togetherjava.tjbot.commands.utils.CodeFence;
 import org.togetherjava.tjbot.commands.utils.MessageUtils;
 import org.togetherjava.tjbot.config.Config;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;

--- a/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
@@ -25,7 +25,7 @@ public final class CodeMessageAutoDetection extends MessageReceiverAdapter {
 
     private final CodeMessageHandler codeMessageHandler;
     private final Predicate<String> isHelpForumName;
-    private final Predicate<String> isIgnoredRolePattern;
+    private final Predicate<String> isExcludedRolePattern;
 
     /**
      * Creates a new instance.
@@ -41,7 +41,7 @@ public final class CodeMessageAutoDetection extends MessageReceiverAdapter {
         isHelpForumName =
                 Pattern.compile(config.getHelpSystem().getHelpForumPattern()).asMatchPredicate();
 
-        isIgnoredRolePattern =
+        isExcludedRolePattern =
                 Pattern.compile(config.getIgnoreCodeAutoDetectionRolePattern()).asMatchPredicate();
     }
 
@@ -70,7 +70,7 @@ public final class CodeMessageAutoDetection extends MessageReceiverAdapter {
     }
 
     private boolean isSentByExcludedRole(List<Role> roles) {
-        return roles.stream().map(Role::getName).anyMatch(isIgnoredRolePattern);
+        return roles.stream().map(Role::getName).anyMatch(isExcludedRolePattern);
     }
 
     private boolean isHelpThread(MessageReceivedEvent event) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
@@ -11,7 +11,7 @@ import org.togetherjava.tjbot.commands.utils.CodeFence;
 import org.togetherjava.tjbot.commands.utils.MessageUtils;
 import org.togetherjava.tjbot.config.Config;
 
-import java.util.*;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 

--- a/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
@@ -42,7 +42,7 @@ public final class CodeMessageAutoDetection extends MessageReceiverAdapter {
                 Pattern.compile(config.getHelpSystem().getHelpForumPattern()).asMatchPredicate();
 
         isExcludedRolePattern =
-                Pattern.compile(config.getIgnoreCodeAutoDetectionRolePattern()).asMatchPredicate();
+                Pattern.compile(config.getExcludeCodeAutoDetectionRolePattern()).asMatchPredicate();
     }
 
     @Override

--- a/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
@@ -1,6 +1,7 @@
 package org.togetherjava.tjbot.commands.code;
 
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -10,7 +11,7 @@ import org.togetherjava.tjbot.commands.utils.CodeFence;
 import org.togetherjava.tjbot.commands.utils.MessageUtils;
 import org.togetherjava.tjbot.config.Config;
 
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -27,7 +28,7 @@ public final class CodeMessageAutoDetection extends MessageReceiverAdapter {
 
     /**
      * Creates a new instance.
-     * 
+     *
      * @param config to figure out whether a message is from a help thread
      * @param codeMessageHandler to register detected code messages at for further handling
      */
@@ -42,7 +43,7 @@ public final class CodeMessageAutoDetection extends MessageReceiverAdapter {
 
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
-        if (event.isWebhookMessage() || event.getAuthor().isBot() || !isHelpThread(event)) {
+        if (event.isWebhookMessage() || event.getAuthor().isBot() || !isHelpThread(event) || isSendByTopHelper(event)) {
             return;
         }
 
@@ -61,6 +62,16 @@ public final class CodeMessageAutoDetection extends MessageReceiverAdapter {
         }
 
         codeMessageHandler.addAndHandleCodeMessage(originalMessage, true);
+    }
+
+    private boolean isSendByTopHelper(MessageReceivedEvent event) {
+        if(Objects.requireNonNull(event.getMember()).getRoles().isEmpty()) {
+            return false;
+        }
+
+        return event.getMember().getRoles().stream()
+            .map(Role::getName)
+            .anyMatch(roleName -> roleName.matches("Top Helpers .+"));
     }
 
     private boolean isHelpThread(MessageReceivedEvent event) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/code/CodeMessageAutoDetection.java
@@ -44,7 +44,8 @@ public final class CodeMessageAutoDetection extends MessageReceiverAdapter {
 
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
-        if (event.isWebhookMessage() || event.getAuthor().isBot() || !isHelpThread(event) || isSendByTopHelper(event)) {
+        if (event.isWebhookMessage() || event.getAuthor().isBot() || !isHelpThread(event)
+                || isSendByTopHelper(event)) {
             return;
         }
 
@@ -66,11 +67,13 @@ public final class CodeMessageAutoDetection extends MessageReceiverAdapter {
     }
 
     private boolean isSendByTopHelper(MessageReceivedEvent event) {
-        if(Objects.requireNonNull(event.getMember()).getRoles().isEmpty()) {
+        if (Objects.requireNonNull(event.getMember()).getRoles().isEmpty()) {
             return false;
         }
 
-        return event.getMember().getRoles().stream()
+        return event.getMember()
+            .getRoles()
+            .stream()
             .map(Role::getName)
             .anyMatch(roleName -> roleName.matches("Top Helpers .+"));
     }

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -26,7 +26,7 @@ public final class Config {
     private final String heavyModerationRolePattern;
     private final String softModerationRolePattern;
     private final String tagManageRolePattern;
-    private final String ignoreCodeAutoDetectionRolePattern;
+    private final String excludeCodeAutoDetectionRolePattern;
     private final SuggestionsConfig suggestions;
     private final String quarantinedRolePattern;
     private final ScamBlockerConfig scamBlocker;
@@ -55,8 +55,8 @@ public final class Config {
                     required = true) String softModerationRolePattern,
             @JsonProperty(value = "tagManageRolePattern",
                     required = true) String tagManageRolePattern,
-            @JsonProperty(value = "ignoreCodeAutoDetectionRolePattern",
-                    required = true) String ignoreCodeAutoDetectionRolePattern,
+            @JsonProperty(value = "excludeCodeAutoDetectionRolePattern",
+                    required = true) String excludeCodeAutoDetectionRolePattern,
             @JsonProperty(value = "suggestions", required = true) SuggestionsConfig suggestions,
             @JsonProperty(value = "quarantinedRolePattern",
                     required = true) String quarantinedRolePattern,
@@ -82,8 +82,8 @@ public final class Config {
         this.heavyModerationRolePattern = Objects.requireNonNull(heavyModerationRolePattern);
         this.softModerationRolePattern = Objects.requireNonNull(softModerationRolePattern);
         this.tagManageRolePattern = Objects.requireNonNull(tagManageRolePattern);
-        this.ignoreCodeAutoDetectionRolePattern =
-                Objects.requireNonNull(ignoreCodeAutoDetectionRolePattern);
+        this.excludeCodeAutoDetectionRolePattern =
+                Objects.requireNonNull(excludeCodeAutoDetectionRolePattern);
         this.suggestions = Objects.requireNonNull(suggestions);
         this.quarantinedRolePattern = Objects.requireNonNull(quarantinedRolePattern);
         this.scamBlocker = Objects.requireNonNull(scamBlocker);
@@ -220,8 +220,8 @@ public final class Config {
      *
      * @return the REGEX pattern
      */
-    public String getIgnoreCodeAutoDetectionRolePattern() {
-        return ignoreCodeAutoDetectionRolePattern;
+    public String getExcludeCodeAutoDetectionRolePattern() {
+        return excludeCodeAutoDetectionRolePattern;
     }
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -26,7 +26,7 @@ public final class Config {
     private final String heavyModerationRolePattern;
     private final String softModerationRolePattern;
     private final String tagManageRolePattern;
-    private final String ignoreMessageAutoDetectionRolePattern;
+    private final String ignoreCodeAutoDetectionRolePattern;
     private final SuggestionsConfig suggestions;
     private final String quarantinedRolePattern;
     private final ScamBlockerConfig scamBlocker;
@@ -55,8 +55,8 @@ public final class Config {
                     required = true) String softModerationRolePattern,
             @JsonProperty(value = "tagManageRolePattern",
                     required = true) String tagManageRolePattern,
-            @JsonProperty(value = "ignoreMessageAutoDetectionRolePattern",
-                    required = true) String ignoreMessageAutoDetectionRolePattern,
+            @JsonProperty(value = "ignoreCodeAutoDetectionRolePattern",
+                    required = true) String ignoreCodeAutoDetectionRolePattern,
             @JsonProperty(value = "suggestions", required = true) SuggestionsConfig suggestions,
             @JsonProperty(value = "quarantinedRolePattern",
                     required = true) String quarantinedRolePattern,
@@ -82,8 +82,8 @@ public final class Config {
         this.heavyModerationRolePattern = Objects.requireNonNull(heavyModerationRolePattern);
         this.softModerationRolePattern = Objects.requireNonNull(softModerationRolePattern);
         this.tagManageRolePattern = Objects.requireNonNull(tagManageRolePattern);
-        this.ignoreMessageAutoDetectionRolePattern =
-                Objects.requireNonNull(ignoreMessageAutoDetectionRolePattern);
+        this.ignoreCodeAutoDetectionRolePattern =
+                Objects.requireNonNull(ignoreCodeAutoDetectionRolePattern);
         this.suggestions = Objects.requireNonNull(suggestions);
         this.quarantinedRolePattern = Objects.requireNonNull(quarantinedRolePattern);
         this.scamBlocker = Objects.requireNonNull(scamBlocker);
@@ -220,8 +220,8 @@ public final class Config {
      *
      * @return the REGEX pattern
      */
-    public String getIgnoreMessageAutoDetectionRolePattern() {
-        return ignoreMessageAutoDetectionRolePattern;
+    public String getIgnoreCodeAutoDetectionRolePattern() {
+        return ignoreCodeAutoDetectionRolePattern;
     }
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -26,6 +26,7 @@ public final class Config {
     private final String heavyModerationRolePattern;
     private final String softModerationRolePattern;
     private final String tagManageRolePattern;
+    private final String ignoreCodeActionsForRolePattern;
     private final SuggestionsConfig suggestions;
     private final String quarantinedRolePattern;
     private final ScamBlockerConfig scamBlocker;
@@ -54,6 +55,8 @@ public final class Config {
                     required = true) String softModerationRolePattern,
             @JsonProperty(value = "tagManageRolePattern",
                     required = true) String tagManageRolePattern,
+            @JsonProperty(value = "ignoreCodeActionsForRolePattern",
+                    required = true) String ignoreCodeActionsForRolePattern,
             @JsonProperty(value = "suggestions", required = true) SuggestionsConfig suggestions,
             @JsonProperty(value = "quarantinedRolePattern",
                     required = true) String quarantinedRolePattern,
@@ -79,6 +82,8 @@ public final class Config {
         this.heavyModerationRolePattern = Objects.requireNonNull(heavyModerationRolePattern);
         this.softModerationRolePattern = Objects.requireNonNull(softModerationRolePattern);
         this.tagManageRolePattern = Objects.requireNonNull(tagManageRolePattern);
+        this.ignoreCodeActionsForRolePattern =
+                Objects.requireNonNull(ignoreCodeActionsForRolePattern);
         this.suggestions = Objects.requireNonNull(suggestions);
         this.quarantinedRolePattern = Objects.requireNonNull(quarantinedRolePattern);
         this.scamBlocker = Objects.requireNonNull(scamBlocker);
@@ -207,6 +212,16 @@ public final class Config {
      */
     public String getTagManageRolePattern() {
         return tagManageRolePattern;
+    }
+
+    /**
+     * Gets the REGEX pattern used to identify roles that will be ignored for code actions
+     * auto-detection
+     *
+     * @return the REGEX pattern
+     */
+    public String getIgnoreCodeActionsForRolePattern() {
+        return ignoreCodeActionsForRolePattern;
     }
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -26,7 +26,7 @@ public final class Config {
     private final String heavyModerationRolePattern;
     private final String softModerationRolePattern;
     private final String tagManageRolePattern;
-    private final String ignoreCodeActionsForRolePattern;
+    private final String ignoreMessageAutoDetectionRolePattern;
     private final SuggestionsConfig suggestions;
     private final String quarantinedRolePattern;
     private final ScamBlockerConfig scamBlocker;
@@ -55,8 +55,8 @@ public final class Config {
                     required = true) String softModerationRolePattern,
             @JsonProperty(value = "tagManageRolePattern",
                     required = true) String tagManageRolePattern,
-            @JsonProperty(value = "ignoreCodeActionsForRolePattern",
-                    required = true) String ignoreCodeActionsForRolePattern,
+            @JsonProperty(value = "ignoreMessageAutoDetectionRolePattern",
+                    required = true) String ignoreMessageAutoDetectionRolePattern,
             @JsonProperty(value = "suggestions", required = true) SuggestionsConfig suggestions,
             @JsonProperty(value = "quarantinedRolePattern",
                     required = true) String quarantinedRolePattern,
@@ -82,8 +82,8 @@ public final class Config {
         this.heavyModerationRolePattern = Objects.requireNonNull(heavyModerationRolePattern);
         this.softModerationRolePattern = Objects.requireNonNull(softModerationRolePattern);
         this.tagManageRolePattern = Objects.requireNonNull(tagManageRolePattern);
-        this.ignoreCodeActionsForRolePattern =
-                Objects.requireNonNull(ignoreCodeActionsForRolePattern);
+        this.ignoreMessageAutoDetectionRolePattern =
+                Objects.requireNonNull(ignoreMessageAutoDetectionRolePattern);
         this.suggestions = Objects.requireNonNull(suggestions);
         this.quarantinedRolePattern = Objects.requireNonNull(quarantinedRolePattern);
         this.scamBlocker = Objects.requireNonNull(scamBlocker);
@@ -220,8 +220,8 @@ public final class Config {
      *
      * @return the REGEX pattern
      */
-    public String getIgnoreCodeActionsForRolePattern() {
-        return ignoreCodeActionsForRolePattern;
+    public String getIgnoreMessageAutoDetectionRolePattern() {
+        return ignoreMessageAutoDetectionRolePattern;
     }
 
     /**


### PR DESCRIPTION
closes #719 

This pull request includes the following changes:

In the application/config.json.template file, a new key called ignoreMessageAutoDetectionRolePattern has been added.

In the CodeMessageAutoDetection.java file, a new method called isSentByIgnoredMember has been added to check if a message was sent by a member with a role that matches the ignoreMessageAutoDetectionRolePattern specified in the configuration.

In the Config.java file, a new field called ignoreMessageAutoDetectionRolePattern has been added to the Config class.

These changes allow for the configuration of a role pattern that will be used to ignore messages from members with matching roles in the CodeMessageAutoDetection feature. This can be useful for preventing certain roles from triggering code message detection and handling.

Screenshots:
"Code action autodetection is triggered by a user without roles (User catlitter)"
"Code action autodetection is not triggered by a user with Top Helpers Role (User mdyingstar)"
![image](https://user-images.githubusercontent.com/70911193/209720050-9ad49371-66a5-4663-bb6d-6964d40c574b.png)

