### PR TITLE
Added cancel feature to reminder command

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/commands/reminder/ReminderCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/reminder/ReminderCommand.java
@@ -59,7 +59,6 @@ public final class ReminderCommand extends SlashCommandAdapter {
     private static final String COMMAND_NAME = "reminder";
     private static final String LIST_SUBCOMMAND = "list";
     private static final String CANCEL_COMMAND = "cancel";
-    private static final String CANCEL_ALL_COMMAND = "cancle-all";
     private static final String CANCEL_REMINDER_OPTION = "reminder";
     static final String CREATE_SUBCOMMAND = "create";
     static final String TIME_AMOUNT_OPTION = "time-amount";
@@ -104,7 +103,6 @@ public final class ReminderCommand extends SlashCommandAdapter {
                 new SubcommandData(CANCEL_COMMAND, "cancels a pending reminder").addOption(
                         OptionType.STRING, CANCEL_REMINDER_OPTION, "reminder to cancel", true,
                         true),
-                new SubcommandData(CANCEL_ALL_COMMAND, "cancels all your pending reminders"),
                 new SubcommandData(LIST_SUBCOMMAND, "shows all your currently pending reminders"));
 
         this.database = database;
@@ -115,7 +113,6 @@ public final class ReminderCommand extends SlashCommandAdapter {
         switch (event.getSubcommandName()) {
             case CREATE_SUBCOMMAND -> handleCreateCommand(event);
             case CANCEL_COMMAND -> handleCancelCommand(event);
-            case CANCEL_ALL_COMMAND -> handleCancelAllCommand(event);
             case LIST_SUBCOMMAND -> handleListCommand(event);
             default -> throw new AssertionError(
                     "Unexpected Subcommand: " + event.getSubcommandName());
@@ -199,14 +196,6 @@ public final class ReminderCommand extends SlashCommandAdapter {
             .execute());
 
         event.reply("Your reminder is canceled").setEphemeral(true).queue();
-    }
-
-    private void handleCancelAllCommand(SlashCommandInteractionEvent event) {
-        database.write(context -> context.delete(PENDING_REMINDERS)
-            .where(PENDING_REMINDERS.AUTHOR_ID.eq(event.getUser().getIdLong()))
-            .execute());
-
-        event.reply("All your reminder are canceled").setEphemeral(true).queue();
     }
 
     private void handleListCommand(SlashCommandInteractionEvent event) {

--- a/application/src/main/java/org/togetherjava/tjbot/commands/reminder/ReminderCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/reminder/ReminderCommand.java
@@ -142,8 +142,7 @@ public final class ReminderCommand extends SlashCommandAdapter {
         AutoCompleteQuery focusedOption = event.getFocusedOption();
 
         if (!focusedOption.getName().equals(CANCEL_REMINDER_OPTION)) {
-            throw new IllegalArgumentException(
-                    "Unexpected option, was : " + focusedOption.getName());
+            throw new AssertionError("Unexpected option, was : " + focusedOption.getName());
         }
 
         List<String> pendingReminders = getPendingReminders(event.getGuild(), event.getUser())

--- a/application/src/main/java/org/togetherjava/tjbot/commands/reminder/ReminderCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/commands/reminder/ReminderCommand.java
@@ -7,9 +7,12 @@ import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.entities.emoji.EmojiUnion;
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.interactions.AutoCompleteQuery;
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
+import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
@@ -24,6 +27,7 @@ import org.togetherjava.tjbot.commands.CommandVisibility;
 import org.togetherjava.tjbot.commands.SlashCommandAdapter;
 import org.togetherjava.tjbot.commands.utils.MessageUtils;
 import org.togetherjava.tjbot.commands.utils.Pagination;
+import org.togetherjava.tjbot.commands.utils.StringDistances;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.records.PendingRemindersRecord;
 
@@ -54,6 +58,9 @@ import static org.togetherjava.tjbot.db.generated.Tables.PENDING_REMINDERS;
 public final class ReminderCommand extends SlashCommandAdapter {
     private static final String COMMAND_NAME = "reminder";
     private static final String LIST_SUBCOMMAND = "list";
+    private static final String CANCEL_COMMAND = "cancel";
+    private static final String CANCEL_ALL_COMMAND = "cancle-all";
+    private static final String CANCEL_REMINDER_OPTION = "reminder";
     static final String CREATE_SUBCOMMAND = "create";
     static final String TIME_AMOUNT_OPTION = "time-amount";
     static final String TIME_UNIT_OPTION = "time-unit";
@@ -94,6 +101,10 @@ public final class ReminderCommand extends SlashCommandAdapter {
         getData().addSubcommands(
                 new SubcommandData(CREATE_SUBCOMMAND, "creates a reminder").addOptions(timeAmount,
                         timeUnit, content),
+                new SubcommandData(CANCEL_COMMAND, "cancels a pending reminder").addOption(
+                        OptionType.STRING, CANCEL_REMINDER_OPTION, "reminder to cancel", true,
+                        true),
+                new SubcommandData(CANCEL_ALL_COMMAND, "cancels all your pending reminders"),
                 new SubcommandData(LIST_SUBCOMMAND, "shows all your currently pending reminders"));
 
         this.database = database;
@@ -103,6 +114,8 @@ public final class ReminderCommand extends SlashCommandAdapter {
     public void onSlashCommand(SlashCommandInteractionEvent event) {
         switch (event.getSubcommandName()) {
             case CREATE_SUBCOMMAND -> handleCreateCommand(event);
+            case CANCEL_COMMAND -> handleCancelCommand(event);
+            case CANCEL_ALL_COMMAND -> handleCancelAllCommand(event);
             case LIST_SUBCOMMAND -> handleListCommand(event);
             default -> throw new AssertionError(
                     "Unexpected Subcommand: " + event.getSubcommandName());
@@ -125,6 +138,26 @@ public final class ReminderCommand extends SlashCommandAdapter {
 
         MessageCreateData message = createPendingRemindersPage(pendingReminders, pageToShow);
         event.editMessage(MessageEditData.fromCreateData(message)).queue();
+    }
+
+    @Override
+    public void onAutoComplete(CommandAutoCompleteInteractionEvent event) {
+        AutoCompleteQuery focusedOption = event.getFocusedOption();
+
+        if (!focusedOption.getName().equals(CANCEL_REMINDER_OPTION)) {
+            throw new IllegalArgumentException(
+                    "Unexpected option, was : " + focusedOption.getName());
+        }
+
+        List<String> pendingReminders = getPendingReminders(event.getGuild(), event.getUser())
+            .map(PendingRemindersRecord::getContent);
+        List<Command.Choice> choices = StringDistances
+            .closeMatches(focusedOption.getValue(), pendingReminders, REMINDERS_PER_PAGE)
+            .stream()
+            .map(content -> new Command.Choice(content, content))
+            .toList();
+
+        event.replyChoices(choices).queue();
     }
 
     private void handleCreateCommand(SlashCommandInteractionEvent event) {
@@ -155,6 +188,25 @@ public final class ReminderCommand extends SlashCommandAdapter {
             .setRemindAt(remindAt)
             .setContent(content)
             .insert());
+    }
+
+    private void handleCancelCommand(SlashCommandInteractionEvent event) {
+        String content = event.getOption(CANCEL_REMINDER_OPTION).getAsString();
+
+        database.write(context -> context.delete(PENDING_REMINDERS)
+            .where(PENDING_REMINDERS.CONTENT.eq(content)
+                .and(PENDING_REMINDERS.AUTHOR_ID.eq(event.getUser().getIdLong())))
+            .execute());
+
+        event.reply("Your reminder is canceled").setEphemeral(true).queue();
+    }
+
+    private void handleCancelAllCommand(SlashCommandInteractionEvent event) {
+        database.write(context -> context.delete(PENDING_REMINDERS)
+            .where(PENDING_REMINDERS.AUTHOR_ID.eq(event.getUser().getIdLong()))
+            .execute());
+
+        event.reply("All your reminder are canceled").setEphemeral(true).queue();
     }
 
     private void handleListCommand(SlashCommandInteractionEvent event) {


### PR DESCRIPTION
closes #674 

this pr adds 2 new subcommand one for canceling a specific reminder and the other to cancel all at once.

![image](https://user-images.githubusercontent.com/73871477/209997597-15fc6a6e-cddc-4cb6-b614-48305de75c8f.png)
![image](https://user-images.githubusercontent.com/73871477/209997512-c435eb3e-8cb3-4891-a2e8-de7b93e4cd6a.png)
