### PR TITLE
MessageUtils#extractCode out of bounds

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/utils/MessageUtils.java
@@ -194,10 +194,6 @@ public class MessageUtils {
         }
 
         int languageStart = codeFenceStart + CODE_FENCE_SYMBOL.length();
-        int codeFenceEnd = fullMessage.indexOf(CODE_FENCE_SYMBOL, languageStart);
-        if (codeFenceEnd == -1) {
-            return Optional.empty();
-        }
 
         // Language is between ``` and newline, no spaces allowed, like ```java
         // Look for the next newline and then assert no space between
@@ -211,6 +207,11 @@ public class MessageUtils {
         }
         if (language == null) {
             languageEnd = languageStart;
+        }
+
+        int codeFenceEnd = fullMessage.indexOf(CODE_FENCE_SYMBOL, languageEnd);
+        if (codeFenceEnd == -1) {
+            return Optional.empty();
         }
 
         String code = fullMessage.substring(languageEnd, codeFenceEnd).strip();

--- a/application/src/test/java/org/togetherjava/tjbot/features/utils/MessageUtilsTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/features/utils/MessageUtilsTest.java
@@ -247,6 +247,19 @@ final class MessageUtilsTest {
 
         tests.add(Arguments.of("small code fence", "Foo `int x = 5` Bar", null));
 
+        tests.add(Arguments.of("six backticks", """
+                ``````test
+                foo```""", new CodeFence("```test", "foo")));
+
+        tests.add(Arguments.of("single line", "```java test```", new CodeFence(null, "java test")));
+
+        tests.add(Arguments.of("space in language", """
+                ```java test
+                test```
+                """, new CodeFence(null, """
+                java test
+                test""")));
+
         return tests;
     }
 


### PR DESCRIPTION
## Overview

Fixes and closes #766 .

Its about a bug in the logic for `MessageUtils#extractCode`, happens when the "end of the code" (indicated by 3 backticks) is _before_ the end of the "language tag", i.e. like `java`.

Essentially, the closing code block should be found **after** the language tag, so `indexOf(3 backticks, languageEnd)` instead of at the start of it.

So I just moved the part down and now it works. Also added unit tests.

## Details

As an example, consider the following message:

![message](https://i.imgur.com/6aJjKq7.png)

* red: start of code fence
* blue: end of code fence
* green: language tag

Blue should only start **after** green, not before.

So the new order is:
* find start of code fence
* find language tag
* find end of code fence