### PR TITLE
Fixed bug with MediaOnlyChannelListener when user closed DMs

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/mediaonly/MediaOnlyChannelListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/mediaonly/MediaOnlyChannelListener.java
@@ -13,6 +13,7 @@ import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.features.MessageReceiverAdapter;
 
 import java.awt.Color;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -48,8 +49,7 @@ public final class MediaOnlyChannelListener extends MessageReceiverAdapter {
         if (messageHasNoMediaAttached(message)) {
             message.delete().flatMap(any -> dmUser(message)).queue(any -> {
             }, failure -> tempNotifyUserInChannel(message)
-                .queue(notificationMessage -> notificationMessage.delete()
-                    .queueAfter(1, TimeUnit.MINUTES)));
+            );
         }
     }
 
@@ -78,8 +78,8 @@ public final class MediaOnlyChannelListener extends MessageReceiverAdapter {
             .flatMap(channel -> channel.sendMessage(createNotificationMessage(message)));
     }
 
-    private RestAction<Message> tempNotifyUserInChannel(Message message) {
-        return message.getChannel().sendMessage(createNotificationMessage(message));
-
+    private void tempNotifyUserInChannel(Message message) {
+        message.getChannel().sendMessage(createNotificationMessage(message))
+                .queue(notificationMessage -> notificationMessage.delete().queueAfter(1, TimeUnit.MINUTES));
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/mediaonly/MediaOnlyChannelListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/mediaonly/MediaOnlyChannelListener.java
@@ -13,7 +13,6 @@ import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.features.MessageReceiverAdapter;
 
 import java.awt.Color;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -48,8 +47,7 @@ public final class MediaOnlyChannelListener extends MessageReceiverAdapter {
 
         if (messageHasNoMediaAttached(message)) {
             message.delete().flatMap(any -> dmUser(message)).queue(any -> {
-            }, failure -> tempNotifyUserInChannel(message)
-            );
+            }, failure -> tempNotifyUserInChannel(message));
         }
     }
 
@@ -79,7 +77,9 @@ public final class MediaOnlyChannelListener extends MessageReceiverAdapter {
     }
 
     private void tempNotifyUserInChannel(Message message) {
-        message.getChannel().sendMessage(createNotificationMessage(message))
-                .queue(notificationMessage -> notificationMessage.delete().queueAfter(1, TimeUnit.MINUTES));
+        message.getChannel()
+            .sendMessage(createNotificationMessage(message))
+            .queue(notificationMessage -> notificationMessage.delete()
+                .queueAfter(1, TimeUnit.MINUTES));
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/mediaonly/MediaOnlyChannelListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/mediaonly/MediaOnlyChannelListener.java
@@ -70,12 +70,10 @@ public final class MediaOnlyChannelListener extends MessageReceiverAdapter {
                     .setColor(Color.ORANGE)
                     .build();
 
-        MessageCreateData pingMessage = new MessageCreateBuilder().setContent("Hey there, you "
+        return new MessageCreateBuilder().setContent("Hey there, you "
                 + message.getAuthor().getAsMention()
                 + " posted a message without media (image, video, link) in a media-only channel. Please see the description of the channel for details and then repost with media attached, thanks 😀")
             .setEmbeds(originalMessageEmbed)
             .build();
-
-        return pingMessage;
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/mediaonly/MediaOnlyChannelListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/mediaonly/MediaOnlyChannelListener.java
@@ -48,10 +48,10 @@ public final class MediaOnlyChannelListener extends MessageReceiverAdapter {
             message.delete()
                 .flatMap(any -> message.getAuthor()
                     .openPrivateChannel()
-                    .flatMap(channel -> channel.sendMessage(warningMessage(message))))
+                    .flatMap(channel -> channel.sendMessage(createNotificationMessage(message))))
                 .queue(any -> {
                 }, failure -> message.getChannel()
-                    .sendMessage(warningMessage(message))
+                    .sendMessage(createNotificationMessage(message))
                     .queue(notificationMessage -> notificationMessage.delete()
                         .queueAfter(1, TimeUnit.MINUTES)));
         }
@@ -62,7 +62,7 @@ public final class MediaOnlyChannelListener extends MessageReceiverAdapter {
                 && !message.getContentRaw().contains("http");
     }
 
-    private MessageCreateData warningMessage(Message message) {
+    private MessageCreateData createNotificationMessage(Message message) {
         String originalMessageContent = message.getContentRaw();
 
         MessageEmbed originalMessageEmbed =
@@ -70,9 +70,8 @@ public final class MediaOnlyChannelListener extends MessageReceiverAdapter {
                     .setColor(Color.ORANGE)
                     .build();
 
-        return new MessageCreateBuilder().setContent("Hey there, you "
-                + message.getAuthor().getAsMention()
-                + " posted a message without media (image, video, link) in a media-only channel. Please see the description of the channel for details and then repost with media attached, thanks 😀")
+        return new MessageCreateBuilder().setContent(message.getAuthor().getAsMention()
+                + "Hey there, you posted a message without media (image, video, link) in a media-only channel. Please see the description of the channel for details and then repost with media attached, thanks 😀")
             .setEmbeds(originalMessageEmbed)
             .build();
     }

--- a/application/src/main/java/org/togetherjava/tjbot/features/mediaonly/MediaOnlyChannelListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/mediaonly/MediaOnlyChannelListener.java
@@ -5,8 +5,6 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.MessageType;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
-import net.dv8tion.jda.api.exceptions.ErrorHandler;
-import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
@@ -48,12 +46,11 @@ public final class MediaOnlyChannelListener extends MessageReceiverAdapter {
         }
 
         if (messageHasNoMediaAttached(message)) {
-            message.delete().flatMap(any -> dmUser(message)).queue(res -> {
-            }, new ErrorHandler().handle(ErrorResponse.CANNOT_SEND_TO_USER, err -> {
-                warnUser(message).queue((res) -> {
-                    res.delete().queueAfter(1, TimeUnit.MINUTES);
-                });
-            }));
+            message.delete().flatMap(any -> dmUser(message)).queue(any -> {
+            }, err -> {
+                pingUserAobutMedia(message)
+                    .queue(res -> res.delete().queueAfter(1, TimeUnit.MINUTES));
+            });
         }
     }
 
@@ -65,20 +62,20 @@ public final class MediaOnlyChannelListener extends MessageReceiverAdapter {
     private MessageEmbed originalMessageEmbed(Message message) {
         String originalMessageContent = message.getContentRaw();
         return new EmbedBuilder().setDescription(originalMessageContent)
-                .setColor(Color.ORANGE)
-                .build();
+            .setColor(Color.ORANGE)
+            .build();
     }
 
-    private RestAction<Message> warnUser(Message message) {
+    private RestAction<Message> pingUserAobutMedia(Message message) {
         MessageEmbed originalMessageEmbed = originalMessageEmbed(message);
 
         long authorId = message.getAuthor().getIdLong();
 
         MessageCreateData pingMessage = new MessageCreateBuilder().setContent("Hey there, you <@"
-                        + authorId
-                        + "> posted a message without media (image, video, link) in a media-only channel. Please see the description of the channel for details and then repost with media attached, thanks 😀")
-                .setEmbeds(originalMessageEmbed)
-                .build();
+                + authorId
+                + "> posted a message without media (image, video, link) in a media-only channel. Please see the description of the channel for details and then repost with media attached, thanks 😀")
+            .setEmbeds(originalMessageEmbed)
+            .build();
 
         return message.getChannel().sendMessage(pingMessage);
     }
@@ -87,12 +84,12 @@ public final class MediaOnlyChannelListener extends MessageReceiverAdapter {
         MessageEmbed originalMessageEmbed = originalMessageEmbed(message);
 
         MessageCreateData dmMessage = new MessageCreateBuilder().setContent(
-                        "Hey there, you posted a message without media (image, video, link) in a media-only channel. Please see the description of the channel for details and then repost with media attached, thanks 😀")
-                .setEmbeds(originalMessageEmbed)
-                .build();
+                "Hey there, you posted a message without media (image, video, link) in a media-only channel. Please see the description of the channel for details and then repost with media attached, thanks 😀")
+            .setEmbeds(originalMessageEmbed)
+            .build();
 
         return message.getAuthor()
-                .openPrivateChannel()
-                .flatMap(channel -> channel.sendMessage(dmMessage));
+            .openPrivateChannel()
+            .flatMap(channel -> channel.sendMessage(dmMessage));
     }
 }


### PR DESCRIPTION
Fixes and closes #748 by sending a temporary message in the channel if DMs fail (the message is deleted after 1min)