### PR TITLE
Fix website bug with widget on mobile

### DIFF
--- a/website/src/main/resources/public/index.html
+++ b/website/src/main/resources/public/index.html
@@ -74,7 +74,7 @@
                 Lots of friendly volunteers to help you learn Java or chat about everyday
                 things.</small></p>
             <ul>
-                <li>24.000 members</li>
+                <li>25.000 members</li>
                 <li>300 questions answered weekly</li>
                 <li>50.000 messages per month</li>
                 <li>monthly giveaways</li>

--- a/website/src/main/resources/public/index.html
+++ b/website/src/main/resources/public/index.html
@@ -74,7 +74,7 @@
                 Lots of friendly volunteers to help you learn Java or chat about everyday
                 things.</small></p>
             <ul>
-                <li>20.000 members</li>
+                <li>24.000 members</li>
                 <li>300 questions answered weekly</li>
                 <li>50.000 messages per month</li>
                 <li>monthly giveaways</li>
@@ -82,8 +82,8 @@
             <widgetbot
                     server="272761734820003841"
                     channel="272761734820003841"
-                    width="800"
-                    height="400"
+                    width="100%"
+                    height="500"
             ></widgetbot>
         </div>
     </section>


### PR DESCRIPTION
Closes and fixes #721, the problem was that the size for the widget was hardcoded. Now its made relative `100%` and by that scales properly.