### PR TITLE
Bugfix ScamBlocker fails on DM

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -252,7 +252,8 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
 
     private void dmUser(Guild guild, long userId, JDA jda) {
         jda.openPrivateChannelById(userId).flatMap(channel -> dmUser(guild, channel)).queue(any -> {
-        }, failure ->logger.debug("Unable to send dm message to user {} in guild {}", userId, guild.getId()));
+        }, failure -> logger.debug("Unable to send dm message to user {} in guild {}", userId,
+                guild.getId()));
     }
 
     private RestAction<Message> dmUser(Guild guild, PrivateChannel channel) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -252,7 +252,7 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
 
     private void dmUser(Guild guild, long userId, JDA jda) {
         jda.openPrivateChannelById(userId).flatMap(channel -> dmUser(guild, channel)).queue(any -> {
-        }, failure -> logger.debug("failure in Scam blocker dm to user id ->",userId));
+        }, failure ->logger.debug("Unable to send dm message to user {} in guild {}", userId, guild.getId()));
     }
 
     private RestAction<Message> dmUser(Guild guild, PrivateChannel channel) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -253,7 +253,7 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
     private void dmUser(Guild guild, long userId, JDA jda) {
         jda.openPrivateChannelById(userId).flatMap(channel -> dmUser(guild, channel)).queue(any -> {
         }, failure -> {
-            logger.debug("Unable to send message Scam blocker");
+            logger.debug("failure in Scam blocker Dm  \nTo user id ->"+userId);
         });
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -252,8 +252,9 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
 
     private void dmUser(Guild guild, long userId, JDA jda) {
         jda.openPrivateChannelById(userId).flatMap(channel -> dmUser(guild, channel)).queue(any -> {
-        }, failure -> logger.debug("Unable to send dm message to user {} in guild {}", userId,
-                guild.getId()));
+        }, failure -> logger.debug(
+                "Unable to send dm message to user {} in guild {} to inform them about a scam message being blocked",
+                userId, guild.getId(), failure));
     }
 
     private RestAction<Message> dmUser(Guild guild, PrivateChannel channel) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -251,7 +251,10 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
     }
 
     private void dmUser(Guild guild, long userId, JDA jda) {
-        jda.openPrivateChannelById(userId).flatMap(channel -> dmUser(guild, channel)).queue();
+        jda.openPrivateChannelById(userId).flatMap(channel -> dmUser(guild, channel)).queue(any -> {
+        }, failure -> {
+            logger.debug("Unable to send message Scam blocker");
+        });
     }
 
     private RestAction<Message> dmUser(Guild guild, PrivateChannel channel) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -252,7 +252,7 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
 
     private void dmUser(Guild guild, long userId, JDA jda) {
         jda.openPrivateChannelById(userId).flatMap(channel -> dmUser(guild, channel)).queue(any -> {
-        }, failure -> logger.debug("failure in Scam blocker Dm  \nTo user id ->" + userId));
+        }, failure -> logger.debug("failure in Scam blocker dm to user id ->",userId));
     }
 
     private RestAction<Message> dmUser(Guild guild, PrivateChannel channel) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -252,9 +252,7 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
 
     private void dmUser(Guild guild, long userId, JDA jda) {
         jda.openPrivateChannelById(userId).flatMap(channel -> dmUser(guild, channel)).queue(any -> {
-        }, failure -> {
-            logger.debug("failure in Scam blocker Dm  \nTo user id ->"+userId);
-        });
+        }, failure -> logger.debug("failure in Scam blocker Dm  \nTo user id ->" + userId));
     }
 
     private RestAction<Message> dmUser(Guild guild, PrivateChannel channel) {


### PR DESCRIPTION
Fixes and closes #747 where the ScamBlocker would crash if attempting to DM an user who blocked DMs.

It will now instead write a DEBUG log message and otherwise ignore the issue.