### PR TITLE
SlashCommandEducator should check length

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/basic/SlashCommandEducator.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/basic/SlashCommandEducator.java
@@ -19,7 +19,7 @@ import java.util.regex.Pattern;
  * then educates the user about using slash commands, such as {@code /foo} instead.
  */
 public final class SlashCommandEducator extends MessageReceiverAdapter {
-    private static final int MAX_CONTENT_LENGTH = 30;
+    private static final int MAX_COMMAND_LENGTH = 30;
     private static final String SLASH_COMMAND_POPUP_ADVICE_PATH = "slashCommandPopupAdvice.png";
     private static final Predicate<String> IS_MESSAGE_COMMAND = Pattern.compile("""
             [.!?] #Start of message command
@@ -35,7 +35,7 @@ public final class SlashCommandEducator extends MessageReceiverAdapter {
 
         String content = event.getMessage().getContentRaw();
 
-        if (IS_MESSAGE_COMMAND.test(content) && content.length() < MAX_CONTENT_LENGTH) {
+        if (IS_MESSAGE_COMMAND.test(content) && content.length() < MAX_COMMAND_LENGTH) {
             sendAdvice(event.getMessage());
         }
     }

--- a/application/src/main/java/org/togetherjava/tjbot/features/basic/SlashCommandEducator.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/basic/SlashCommandEducator.java
@@ -33,7 +33,8 @@ public final class SlashCommandEducator extends MessageReceiverAdapter {
         }
 
         String content = event.getMessage().getContentRaw();
-        if (IS_MESSAGE_COMMAND.test(content)) {
+        int MAX_COMMAND_LENGTH = 30;
+        if (IS_MESSAGE_COMMAND.test(content) && content.length() < MAX_COMMAND_LENGTH) {
             sendAdvice(event.getMessage());
         }
     }

--- a/application/src/main/java/org/togetherjava/tjbot/features/basic/SlashCommandEducator.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/basic/SlashCommandEducator.java
@@ -19,6 +19,7 @@ import java.util.regex.Pattern;
  * then educates the user about using slash commands, such as {@code /foo} instead.
  */
 public final class SlashCommandEducator extends MessageReceiverAdapter {
+    private static final int MAX_CONTENT_LENGTH = 30;
     private static final String SLASH_COMMAND_POPUP_ADVICE_PATH = "slashCommandPopupAdvice.png";
     private static final Predicate<String> IS_MESSAGE_COMMAND = Pattern.compile("""
             [.!?] #Start of message command
@@ -33,8 +34,8 @@ public final class SlashCommandEducator extends MessageReceiverAdapter {
         }
 
         String content = event.getMessage().getContentRaw();
-        int MAX_COMMAND_LENGTH = 30;
-        if (IS_MESSAGE_COMMAND.test(content) && content.length() < MAX_COMMAND_LENGTH) {
+
+        if (IS_MESSAGE_COMMAND.test(content) && content.length() < MAX_CONTENT_LENGTH) {
             sendAdvice(event.getMessage());
         }
     }

--- a/application/src/test/java/org/togetherjava/tjbot/features/basic/SlashCommandEducatorTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/features/basic/SlashCommandEducatorTest.java
@@ -61,7 +61,7 @@ final class SlashCommandEducatorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("provideOtherCommands")
+    @MethodSource("provideOtherMessages")
     void ignoresMessagesWhereLengthIsGreaterThanThirty(String message) {
         // GIVEN a message's length is more than Thirty
         // WHEN the message is sent
@@ -76,11 +76,9 @@ final class SlashCommandEducatorTest {
     }
 
     private static Stream<String> provideOtherMessages() {
-        return Stream.of("  a  ", "foo", "#foo", "/foo", "!!!", "?!?!?", "?", ".,-", "!f", "! foo");
-    }
+        return Stream.of("  a  ", "foo", "#foo", "/foo", "!!!", "?!?!?", "?", ".,-", "!f", "! foo",
+                "thisIsAWordWhichLengthIsMoreThanThirtyLetterSoItShouldNotReply",
+                ".isLetter and .isNumber are available");
 
-    private static Stream<String> provideOtherCommands() {
-        return Stream.of("thisIsAWordWhichLengthIsMoreThanThirtyLetterSoItShouldNotReply",
-                "abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde");
     }
 }

--- a/application/src/test/java/org/togetherjava/tjbot/features/basic/SlashCommandEducatorTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/features/basic/SlashCommandEducatorTest.java
@@ -60,17 +60,6 @@ final class SlashCommandEducatorTest {
         verify(event.getMessage(), never()).replyEmbeds(any(MessageEmbed.class));
     }
 
-    @ParameterizedTest
-    @MethodSource("provideOtherMessages")
-    void ignoresMessagesWhereLengthIsGreaterThanThirty(String message) {
-        // GIVEN a message's length is more than Thirty
-        // WHEN the message is sent
-        MessageReceivedEvent event = sendMessage(message);
-
-        // THEN the system ignores the message and does not reply to it
-        verify(event.getMessage(), never()).replyEmbeds(any(MessageEmbed.class));
-    }
-
     private static Stream<String> provideMessageCommands() {
         return Stream.of("!foo", ".foo", "?foo", ".test", "!whatever", "!this is a test");
     }

--- a/application/src/test/java/org/togetherjava/tjbot/features/basic/SlashCommandEducatorTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/features/basic/SlashCommandEducatorTest.java
@@ -65,6 +65,6 @@ final class SlashCommandEducatorTest {
     }
 
     private static Stream<String> provideOtherMessages() {
-        return Stream.of("  a  ", "foo", "#foo", "/foo", "!!!", "?!?!?", "?", ".,-", "!f", "! foo");
+        return Stream.of("  a  ", "foo", "#foo", "/foo", "!!!", "?!?!?", "?", ".,-", "!f", "! foo","thisIsAWordWhichLengthIsMoreThanThrityLetterSoItShouldNotReply");
     }
 }

--- a/application/src/test/java/org/togetherjava/tjbot/features/basic/SlashCommandEducatorTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/features/basic/SlashCommandEducatorTest.java
@@ -60,11 +60,27 @@ final class SlashCommandEducatorTest {
         verify(event.getMessage(), never()).replyEmbeds(any(MessageEmbed.class));
     }
 
+    @ParameterizedTest
+    @MethodSource("provideOtherCommands")
+    void ignoresMessagesWhereLengthIsGreaterThanThirty(String message) {
+        // GIVEN a message's length is more than Thirty
+        // WHEN the message is sent
+        MessageReceivedEvent event = sendMessage(message);
+
+        // THEN the system ignores the message and does not reply to it
+        verify(event.getMessage(), never()).replyEmbeds(any(MessageEmbed.class));
+    }
+
     private static Stream<String> provideMessageCommands() {
         return Stream.of("!foo", ".foo", "?foo", ".test", "!whatever", "!this is a test");
     }
 
     private static Stream<String> provideOtherMessages() {
-        return Stream.of("  a  ", "foo", "#foo", "/foo", "!!!", "?!?!?", "?", ".,-", "!f", "! foo","thisIsAWordWhichLengthIsMoreThanThrityLetterSoItShouldNotReply");
+        return Stream.of("  a  ", "foo", "#foo", "/foo", "!!!", "?!?!?", "?", ".,-", "!f", "! foo");
+    }
+
+    private static Stream<String> provideOtherCommands() {
+        return Stream.of("thisIsAWordWhichLengthIsMoreThanThirtyLetterSoItShouldNotReply",
+                "abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde");
     }
 }


### PR DESCRIPTION
Closes and fixes #782, lets `SlashCommandEducator` additionally check the length to prevent false positives. Long messages are not considered a command.