### PR TITLE
ScamBlocker crashes if given empty list of actions bug

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -240,8 +240,15 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
                     .setColor(AMBIENT_COLOR)
                     .setFooter(author.getId())
                     .build();
-        MessageCreateData message =
-                new MessageCreateBuilder().setEmbeds(embed).setActionRow(confirmDialog).build();
+
+        MessageCreateBuilder messageBuilder = new MessageCreateBuilder().setEmbeds(embed);
+
+        if (!confirmDialog.isEmpty()) {
+            messageBuilder.setActionRow(confirmDialog);
+        }
+
+        MessageCreateData message = messageBuilder.build();
+
 
         reportChannel.orElseThrow().sendMessage(message).queue();
     }

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -242,13 +242,10 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
                     .build();
 
         MessageCreateBuilder messageBuilder = new MessageCreateBuilder().setEmbeds(embed);
-
         if (!confirmDialog.isEmpty()) {
             messageBuilder.setActionRow(confirmDialog);
         }
-
         MessageCreateData message = messageBuilder.build();
-
 
         reportChannel.orElseThrow().sendMessage(message).queue();
     }


### PR DESCRIPTION
Fixes a bug in `ScamBlocker` by skip calling `.setActionRow` if the list is empty.