### PR TITLE
Upgrade java to 19 for website subproject

### DIFF
--- a/website/build.gradle
+++ b/website/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 var outputImage = 'togetherjava.org:5001/togetherjava/website:' + System.getenv('BRANCH_NAME') ?: 'latest'
 
 jib {
-    from.image = 'eclipse-temurin:18'
+    from.image = 'eclipse-temurin:19'
     to {
         image = outputImage
         auth {


### PR DESCRIPTION
Currently website container crashes with:

```java
Error: LinkageError occurred while loading main class org.togetherjava.tjbot.website.Application
    java.lang.UnsupportedClassVersionError: org/togetherjava/tjbot/website/Application has been compiled by a more recent version of the Java Runtime (class file version 63.0), this version of the Java Runtime only recognizes class file versions up to 62.0
```