### PR TITLE
Increase default ChatGPT response timeout from 10s to 90s

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/chaptgpt/ChatGptService.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chaptgpt/ChatGptService.java
@@ -20,7 +20,7 @@ import java.util.Optional;
  */
 public class ChatGptService {
     private static final Logger logger = LoggerFactory.getLogger(ChatGptService.class);
-    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration TIMEOUT = Duration.ofSeconds(90);
     private static final int MAX_TOKENS = 3_000;
     private boolean isDisabled = false;
     private final OpenAiService openAiService;


### PR DESCRIPTION
Supposed to address https://github.com/Together-Java/TJ-Bot/issues/839, increase the timeout from 10s to 90s for the ChatGPTService. Very quick and small change but figured I could tackle the issue.