### PR TITLE
Logging - links logs to source

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -89,5 +89,5 @@
     "logInfoChannelWebhook": "<put_your_webhook_here>",
     "logErrorChannelWebhook": "<put_your_webhook_here>",
     "openaiApiKey": "<check pins in #tjbot_discussion for the key>",
-    "sourceCodeBaseUrl": "<see explanation in https://github.com/Together-Java/TJ-Bot/pull/857>"
+    "sourceCodeBaseUrl": "<https://github.com/<your_account_here>/<your_repo_here>/blob/master/application/src/main/java/>"
 }

--- a/application/config.json.template
+++ b/application/config.json.template
@@ -89,5 +89,5 @@
     "logInfoChannelWebhook": "<put_your_webhook_here>",
     "logErrorChannelWebhook": "<put_your_webhook_here>",
     "openaiApiKey": "<check pins in #tjbot_discussion for the key>",
-    "sourceCodeBaseUrl": "<put_the_source_code_base_url_here>"
+    "sourceCodeBaseUrl": "<see explanation in https://github.com/Together-Java/TJ-Bot/pull/857>"
 }

--- a/application/config.json.template
+++ b/application/config.json.template
@@ -87,6 +87,7 @@
         "wsh"
     ],
     "logInfoChannelWebhook": "<put_your_webhook_here>",
-    "logErrorChannelWebhook": "<put_your_webhook_here>"
-    "openaiApiKey": "<check pins in #tjbot_discussion for the key>"
+    "logErrorChannelWebhook": "<put_your_webhook_here>",
+    "openaiApiKey": "<check pins in #tjbot_discussion for the key>",
+    "sourceCodeBaseUrl": "<put_the_source_code_base_url_here>"
 }

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -321,9 +321,11 @@ public final class Config {
     }
 
     /**
-     * The Base URL of the Source code to link tj-bot originated logs to the GitHub file.
+     * The base URL of the source code of this bot. E.g.
+     * {@code getSourceCodeBaseUrl() + "/org/togetherjava/tjbot/config/Config.java"} would point to
+     * this file.
      *
-     * @return the base url of the source code
+     * @return the base url of the source code of this bot
      */
     public String getSourceCodeBaseUrl() {
         return sourceCodeBaseUrl;

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -37,6 +37,7 @@ public final class Config {
     private final String logInfoChannelWebhook;
     private final String logErrorChannelWebhook;
     private final String openaiApiKey;
+    private final String sourceCodeBaseUrl;
 
     @SuppressWarnings("ConstructorWithTooManyParameters")
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
@@ -72,7 +73,8 @@ public final class Config {
                     required = true) String logInfoChannelWebhook,
             @JsonProperty(value = "logErrorChannelWebhook",
                     required = true) String logErrorChannelWebhook,
-            @JsonProperty(value = "openaiApiKey", required = true) String openaiApiKey) {
+            @JsonProperty(value = "openaiApiKey", required = true) String openaiApiKey,
+            @JsonProperty(value = "sourceCodeBaseUrl", required = true) String sourceCodeBaseUrl) {
         this.token = Objects.requireNonNull(token);
         this.gistApiKey = Objects.requireNonNull(gistApiKey);
         this.databasePath = Objects.requireNonNull(databasePath);
@@ -96,6 +98,7 @@ public final class Config {
         this.logInfoChannelWebhook = Objects.requireNonNull(logInfoChannelWebhook);
         this.logErrorChannelWebhook = Objects.requireNonNull(logErrorChannelWebhook);
         this.openaiApiKey = Objects.requireNonNull(openaiApiKey);
+        this.sourceCodeBaseUrl = Objects.requireNonNull(sourceCodeBaseUrl);
     }
 
     /**
@@ -315,5 +318,14 @@ public final class Config {
      */
     public String getOpenaiApiKey() {
         return openaiApiKey;
+    }
+
+    /**
+     * The Base URL of the Source code to link tj-bot originated logs to the GitHub file.
+     *
+     * @return the base url of the source code
+     */
+    public String getSourceCodeBaseUrl() {
+        return sourceCodeBaseUrl;
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/logging/discord/DiscordLogAppender.java
+++ b/application/src/main/java/org/togetherjava/tjbot/logging/discord/DiscordLogAppender.java
@@ -19,10 +19,10 @@ final class DiscordLogAppender extends AbstractAppender {
     private final DiscordLogForwarder logForwarder;
 
     private DiscordLogAppender(String name, Filter filter, StringLayout layout,
-            boolean ignoreExceptions, URI webhook) {
+            boolean ignoreExceptions, URI webhook, String sourceCodeBaseUrl) {
         super(name, filter, layout, ignoreExceptions, NO_PROPERTIES);
 
-        logForwarder = new DiscordLogForwarder(webhook);
+        logForwarder = new DiscordLogForwarder(webhook, sourceCodeBaseUrl);
     }
 
     @Override
@@ -43,8 +43,17 @@ final class DiscordLogAppender extends AbstractAppender {
         @Required
         private URI webhook;
 
+        @Required
+        private String sourceCodeBaseUrl;
+
+
         public DiscordLogAppenderBuilder setWebhook(URI webhook) {
             this.webhook = webhook;
+            return asBuilder();
+        }
+
+        public DiscordLogAppenderBuilder setSourceCodeBaseUrl(String sourceCodeBaseUrl) {
+            this.sourceCodeBaseUrl = sourceCodeBaseUrl;
             return asBuilder();
         }
 
@@ -58,7 +67,7 @@ final class DiscordLogAppender extends AbstractAppender {
             String name = Objects.requireNonNull(getName());
 
             return new DiscordLogAppender(name, getFilter(), (StringLayout) layout,
-                    isIgnoreExceptions(), webhook);
+                    isIgnoreExceptions(), webhook, sourceCodeBaseUrl);
         }
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/logging/discord/DiscordLogAppender.java
+++ b/application/src/main/java/org/togetherjava/tjbot/logging/discord/DiscordLogAppender.java
@@ -46,7 +46,6 @@ final class DiscordLogAppender extends AbstractAppender {
         @Required
         private String sourceCodeBaseUrl;
 
-
         public DiscordLogAppenderBuilder setWebhook(URI webhook) {
             this.webhook = webhook;
             return asBuilder();

--- a/application/src/main/java/org/togetherjava/tjbot/logging/discord/DiscordLogForwarder.java
+++ b/application/src/main/java/org/togetherjava/tjbot/logging/discord/DiscordLogForwarder.java
@@ -80,7 +80,6 @@ final class DiscordLogForwarder {
     private final Queue<LogMessage> pendingLogs = new PriorityQueue<>();
     private final Object pendingLogsLock = new Object();
 
-
     DiscordLogForwarder(URI webhook, String sourceCodeBaseUrl) {
         webhookClient = WebhookClient.withUrl(webhook.toString());
         this.sourceCodeBaseUrl = sourceCodeBaseUrl;
@@ -169,6 +168,7 @@ final class DiscordLogForwarder {
 
         private static LogMessage ofEvent(LogEvent event, String sourceCodeBaseUrl) {
             String authorName = event.getLoggerName();
+            String authorUrl = linkToSource(event.getSource().getClassName(), sourceCodeBaseUrl);
             String title = event.getLevel().name();
             int colorDecimal = Objects.requireNonNull(LEVEL_TO_AMBIENT_COLOR.get(event.getLevel()));
             String description =
@@ -176,8 +176,7 @@ final class DiscordLogForwarder {
             Instant timestamp = Instant.ofEpochMilli(event.getInstant().getEpochMillisecond());
 
             WebhookEmbed embed = new WebhookEmbedBuilder()
-                .setAuthor(new WebhookEmbed.EmbedAuthor(authorName, null,
-                        linkToSource(event.getSource().getClassName(), sourceCodeBaseUrl)))
+                .setAuthor(new WebhookEmbed.EmbedAuthor(authorName, null, authorUrl))
                 .setTitle(new WebhookEmbed.EmbedTitle(title, null))
                 .setDescription(description)
                 .setColor(colorDecimal)

--- a/application/src/main/java/org/togetherjava/tjbot/logging/discord/DiscordLogForwarder.java
+++ b/application/src/main/java/org/togetherjava/tjbot/logging/discord/DiscordLogForwarder.java
@@ -13,8 +13,6 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.features.utils.MessageUtils;
 import org.togetherjava.tjbot.logging.LogMarkers;
 
-import javax.annotation.Nullable;
-
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URI;
@@ -168,7 +166,8 @@ final class DiscordLogForwarder {
 
         private static LogMessage ofEvent(LogEvent event, String sourceCodeBaseUrl) {
             String authorName = event.getLoggerName();
-            String authorUrl = linkToSource(event.getSource().getClassName(), sourceCodeBaseUrl);
+            String authorUrl =
+                    linkToSource(event.getSource().getClassName(), sourceCodeBaseUrl).orElse(null);
             String title = event.getLevel().name();
             int colorDecimal = Objects.requireNonNull(LEVEL_TO_AMBIENT_COLOR.get(event.getLevel()));
             String description =
@@ -199,12 +198,17 @@ final class DiscordLogForwarder {
             return logMessage + "\n" + exceptionWriter.toString().replace("\t", "> ");
         }
 
-        private static @Nullable String linkToSource(String source, String sourceCodeBaseUrl) {
+        private static Optional<String> linkToSource(String source, String sourceCodeBaseUrl) {
             if (!source.startsWith(BASE_PACKAGE)) {
-                return null;
+                return Optional.empty();
             }
 
-            return sourceCodeBaseUrl + source.replace('.', '/') + ".java";
+            if (!sourceCodeBaseUrl.endsWith("/")) {
+                sourceCodeBaseUrl += "/";
+            }
+
+            String link = sourceCodeBaseUrl + source.replace('.', '/') + ".java";
+            return Optional.of(link);
         }
 
         private LogMessage shortened() {

--- a/application/src/main/java/org/togetherjava/tjbot/logging/discord/DiscordLogging.java
+++ b/application/src/main/java/org/togetherjava/tjbot/logging/discord/DiscordLogging.java
@@ -47,11 +47,11 @@ public final class DiscordLogging {
     private static void addAppenders(Configuration logConfig, Config botConfig) {
         parseWebhookUri(botConfig.getLogInfoChannelWebhook())
             .ifPresent(webhookUri -> addDiscordLogAppender("DiscordInfo", createInfoRangeFilter(),
-                    webhookUri, logConfig));
+                    webhookUri, botConfig.getSourceCodeBaseUrl(), logConfig));
 
         parseWebhookUri(botConfig.getLogErrorChannelWebhook())
             .ifPresent(webhookUri -> addDiscordLogAppender("DiscordError", createErrorRangeFilter(),
-                    webhookUri, logConfig));
+                    webhookUri, botConfig.getSourceCodeBaseUrl(), logConfig));
     }
 
     private static Optional<URI> parseWebhookUri(String webhookUri) {
@@ -71,7 +71,7 @@ public final class DiscordLogging {
     // to the config.
     @SuppressWarnings("squid:S4792")
     private static void addDiscordLogAppender(String name, Filter filter, URI webhookUri,
-            Configuration logConfig) {
+            String sourceCodeBaseUrl, Configuration logConfig) {
         // NOTE The whole setup is done programmatically in order to allow the webhooks
         // to be read from the config file
         Filter[] filters = {filter, createDenyMarkerFilter(LogMarkers.NO_DISCORD.getName()),
@@ -80,6 +80,7 @@ public final class DiscordLogging {
         Appender appender = DiscordLogAppender.newBuilder()
             .setName(name)
             .setWebhook(webhookUri)
+            .setSourceCodeBaseUrl(sourceCodeBaseUrl)
             .setFilter(CompositeFilter.createFilters(filters))
             .build();
 


### PR DESCRIPTION
Closes #856

# About
This feature adds links to the source of a log message forwarded to Discord.
Only happens if source is from `org.togetherjava.tjbot` otherwise ignored.

![image](https://github.com/Together-Java/TJ-Bot/assets/88111627/ca3ff8a3-8155-4ba7-85cb-db5be8b6113d)

## Config
Adds `sourceCodeBaseUrl` to the config.
It's used to link the source package + file name e.g. `org.togetherjava.tjbot.features.help.HelpThreadAutoArchiver` to its source.

Example:
sourceCodeBaseUrl = `https://github.com/Together-Java/TJ-Bot/blob/master/application/src/main/java/`
source = `org.togetherjava.tjbot.features.help.HelpThreadAutoArchiver`

--> 
`https://github.com/Together-Java/TJ-Bot/blob/master/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadActivityUpdater.java`