### PR TITLE
Fix deprecated use of log4j's `packages` attribute

### DIFF
--- a/application/src/main/resources/log4j2.xml
+++ b/application/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" monitorInterval="30" packages="org.togetherjava.tjbot.logging">
+<Configuration status="WARN" monitorInterval="30">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>


### PR DESCRIPTION
# About
fixes #887 
Removes the deprecated `packages` attribute in the `log4j2.xml`.
Now automatically scanning for `@Plugin` annotation:
https://logging.apache.org/log4j/2.x/manual/plugins.html

> In Log4j 2 a plugin is declared by adding a [@Plugin](https://logging.apache.org/log4j/2.x/log4j-core/apidocs/org/apache/logging/log4j/core/config/plugins/Plugin.html) annotation to the class declaration. During initialization the [Configuration](https://logging.apache.org/log4j/2.x/log4j-core/apidocs/org/apache/logging/log4j/core/config/Configuration.html) will invoke the [PluginManager](https://logging.apache.org/log4j/2.x/log4j-core/apidocs/org/apache/logging/log4j/core/config/plugins/util/PluginManager.html) to load the built-in Log4j plugins **as well as any custom plugins.**