### PR TITLE
Transfer Feature reopen

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/Features.java
@@ -126,6 +126,7 @@ public class Features {
         features.add(new HelpThreadCreatedListener(helpSystemHelper));
 
         // Message context commands
+        features.add(new TransferQuestionCommand(config));
 
         // User context commands
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -173,22 +173,18 @@ public final class TransferQuestionCommand extends BotCommandAdapter
     private RestAction<Message> dmUser(MessageChannelUnion sourceChannel, ForumPost forumPost,
             Guild guild) {
 
+        String messageTemplate =
+                """
+                        Hello %s 👋 You have asked a question in the wrong channel %s. Not a big deal, but none of the experts who could help you are reading your question there 🙁
+
+                        Your question has been automatically transferred to %s, please continue there, thank you 👍
+                        """;
+
         return forumPost.author.openPrivateChannel()
-            .flatMap(channel -> channel.sendMessage(
-                    """
-                            Hello 👋 You have asked a question on %s in the wrong channel. Not a big deal, but none of the experts who could help you are reading your question there 🙁.
-
-                            Your question has been automatically transferred to %s, please continue there. You might also want to give #welcome a quick read, thank you 👍.
-                            """
-                        .formatted(guild.getName(), forumPost.message.getJumpUrl())))
-            .onErrorFlatMap(error -> sourceChannel.sendMessage(
-                    """
-                            Hello %s 👋 You have asked a question in the wrong channel. Not a big deal, but none of the experts who could help you are reading your question there 🙁.
-
-                            Your question has been automatically transferred to %s, please continue there. You might also want to give #welcome a quick read, thank you 👍.
-                            """
-                        .formatted(forumPost.author.getAsMention(),
-                                forumPost.message.getJumpUrl())));
+            .flatMap(channel -> channel.sendMessage(messageTemplate.formatted("",
+                    "on " + guild.getName(), forumPost.message.getJumpUrl())))
+            .onErrorFlatMap(error -> sourceChannel.sendMessage(messageTemplate
+                .formatted(forumPost.author.getAsMention(), "", forumPost.message.getJumpUrl())));
     }
 
     private RestAction<Void> deleteOriginalMessage(JDA jda, String channelId, String messageId) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -156,12 +156,13 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         String transferQuestionTag = event.getValue(TRANSFER_QUESTION_TAG).getAsString();
 
         ForumChannel questionsForum = getHelperForum(event.getJDA());
+        String mostCommonTag = defaultTags.get(0);
 
         String queryTag = StringDistances.closestMatch(transferQuestionTag, defaultTags)
-            .orElse(defaultTags.get(0));
+            .orElse(mostCommonTag);
 
         ForumTag defaultTag = getDefaultTagOr(questionsForum.getAvailableTagsByName(queryTag, true),
-                () -> questionsForum.getAvailableTagsByName(defaultTags.get(0), true).get(0));
+                () -> questionsForum.getAvailableTagsByName(mostCommonTag, true).get(0));
 
         return questionsForum.createForumPost(forumTitle, forumMessage)
             .setTags(ForumTagSnowflake.fromId(defaultTag.getId()))
@@ -199,8 +200,8 @@ public final class TransferQuestionCommand extends BotCommandAdapter
             .filter(forumChannel -> isHelpForumName.test(forumChannel.getName()))
             .findFirst();
 
-        return forumChannelOptional
-            .orElseThrow(() -> new RuntimeException("Helper Forum Not found"));
+        return forumChannelOptional.orElseThrow(() -> new IllegalStateException(
+                "Did not find the helper-forum while trying to transfer a question. Make sure the config is setup properly."));
     }
 
     private static ForumTag getDefaultTagOr(List<ForumTag> tagsFoundOnForum,

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -100,10 +100,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
             .addActionRow(modalTag)
             .build();
 
-        event.replyModal(transferModal)
-            .queue(success -> logger.debug(
-                    "{} with id: {}  triggered the transfer action on forumPost with id: {}",
-                    event.getUser().getName(), event.getUser().getId(), originalMessageId));
+        event.replyModal(transferModal).queue();
     }
 
     @Override

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -39,9 +39,9 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         implements MessageContextCommand {
     private static final Logger logger = LoggerFactory.getLogger(TransferQuestionCommand.class);
     private static final String COMMAND_NAME = "transfer-question";
-    private static final String TRANSFER_QUESTION_TITLE_ID = "transferID";
-    private static final String TRANSFER_QUESTION_INPUT_ID = "transferQuestion";
-    private static final String TRANSFER_QUESTION_TAG = "tags";
+    private static final String TITLE_ID = "transferID";
+    private static final String INPUT_ID = "transferQuestion";
+    private static final String TAG = "tags";
     private static final int TITLE_MAX_LENGTH = 50;
     private static final Pattern TITLE_COMPACT_REMOVAL_PATTERN = Pattern.compile("\\W");
     private static final int TITLE_COMPACT_LENGTH_MIN = 2;
@@ -71,32 +71,29 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         String authorId = event.getTarget().getAuthor().getId();
         String mostCommonTag = defaultTags.get(0);
 
-        TextInput transferQuestionTitle =
-                TextInput.create(TRANSFER_QUESTION_TITLE_ID, "Title", TextInputStyle.SHORT)
-                    .setMaxLength(70)
-                    .setMinLength(8)
-                    .setValue(createTitle(originalMessage))
-                    .build();
-
-        TextInput transferQuestionInput = TextInput
-            .create(TRANSFER_QUESTION_INPUT_ID, "Transfer question menu", TextInputStyle.PARAGRAPH)
-            .setValue(originalMessage)
-            .setRequiredRange(3, 2000)
+        TextInput title = TextInput.create(TITLE_ID, "Title", TextInputStyle.SHORT)
+            .setMaxLength(70)
+            .setMinLength(4)
+            .setValue(createTitle(originalMessage))
             .build();
 
-        TextInput transferQuestionTag = TextInput
-            .create(TRANSFER_QUESTION_TAG, "Transfer question tags", TextInputStyle.SHORT)
+        TextInput input =
+                TextInput.create(INPUT_ID, "Transfer question menu", TextInputStyle.PARAGRAPH)
+                    .setValue(originalMessage)
+                    .setRequiredRange(3, 2000)
+                    .build();
+
+        TextInput tag = TextInput.create(TAG, "Transfer question tags", TextInputStyle.SHORT)
             .setValue(mostCommonTag)
             .build();
 
-        String transferQuestionModalComponentID =
+        String modalComponentID =
                 generateComponentId(authorId, originalMessageId, originalChannelId);
-        Modal transferModal =
-                Modal.create(transferQuestionModalComponentID, "transfer question menu")
-                    .addActionRow(transferQuestionTitle)
-                    .addActionRow(transferQuestionInput)
-                    .addActionRow(transferQuestionTag)
-                    .build();
+        Modal transferModal = Modal.create(modalComponentID, "transfer question menu")
+            .addActionRow(title)
+            .addActionRow(input)
+            .addActionRow(tag)
+            .build();
 
         event.replyModal(transferModal)
             .queue(success -> logger.debug(
@@ -144,7 +141,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
 
     private RestAction<ForumPost> createForumPost(ModalInteractionEvent event, User originalUser) {
 
-        String originalMessage = event.getValue(TRANSFER_QUESTION_INPUT_ID).getAsString();
+        String originalMessage = event.getValue(INPUT_ID).getAsString();
 
         MessageEmbed embedForPost = makeEmbedForPost(originalUser, originalMessage);
 
@@ -153,8 +150,8 @@ public final class TransferQuestionCommand extends BotCommandAdapter
             .setEmbeds(embedForPost)
             .build();
 
-        String forumTitle = event.getValue(TRANSFER_QUESTION_TITLE_ID).getAsString();
-        String transferQuestionTag = event.getValue(TRANSFER_QUESTION_TAG).getAsString();
+        String forumTitle = event.getValue(TITLE_ID).getAsString();
+        String transferQuestionTag = event.getValue(TAG).getAsString();
 
         ForumChannel questionsForum = getHelperForum(event.getJDA());
         String mostCommonTag = defaultTags.get(0);

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -42,10 +42,10 @@ public final class TransferQuestionCommand extends BotCommandAdapter
     private static final String TITLE_ID = "transferID";
     private static final String INPUT_ID = "transferQuestion";
     private static final String TAG = "tags";
-    private static final int TITLE_MAX_LENGTH = 50;
-    private static final Pattern TITLE_COMPACT_REMOVAL_PATTERN = Pattern.compile("\\W");
-    private static final int TITLE_COMPACT_LENGTH_MIN = 2;
-    private static final int TITLE_COMPACT_LENGTH_MAX = 30;
+    private static final int TITLE_GUESS_MAX_LENGTH = 50;
+    private static final Pattern TITLE_GUESS_COMPACT_REMOVAL_PATTERN = Pattern.compile("\\W");
+    private static final int TITLE_GUESS_COMPACT_LENGTH_MIN = 2;
+    private static final int TITLE_GUESS_COMPACT_LENGTH_MAX = 30;
     private final Predicate<String> isHelpForumName;
     private final List<String> defaultTags;
     private static final Color EMBED_COLOR = new Color(50, 164, 168);
@@ -119,11 +119,11 @@ public final class TransferQuestionCommand extends BotCommandAdapter
     }
 
     private static String createTitle(String message) {
-        if (message.length() >= TITLE_MAX_LENGTH) {
-            int lastWordEnd = message.lastIndexOf(' ', TITLE_MAX_LENGTH);
+        if (message.length() >= TITLE_GUESS_MAX_LENGTH) {
+            int lastWordEnd = message.lastIndexOf(' ', TITLE_GUESS_MAX_LENGTH);
 
             if (lastWordEnd == -1) {
-                lastWordEnd = TITLE_MAX_LENGTH;
+                lastWordEnd = TITLE_GUESS_MAX_LENGTH;
             }
 
             message = message.substring(0, lastWordEnd);
@@ -133,10 +133,10 @@ public final class TransferQuestionCommand extends BotCommandAdapter
     }
 
     private static boolean isTitleValid(CharSequence title) {
-        String titleCompact = TITLE_COMPACT_REMOVAL_PATTERN.matcher(title).replaceAll("");
+        String titleCompact = TITLE_GUESS_COMPACT_REMOVAL_PATTERN.matcher(title).replaceAll("");
 
-        return titleCompact.length() >= TITLE_COMPACT_LENGTH_MIN
-                && titleCompact.length() <= TITLE_COMPACT_LENGTH_MAX;
+        return titleCompact.length() >= TITLE_GUESS_COMPACT_LENGTH_MIN
+                && titleCompact.length() <= TITLE_GUESS_COMPACT_LENGTH_MAX;
     }
 
     private RestAction<ForumPost> createForumPost(ModalInteractionEvent event, User originalUser) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -48,7 +48,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
     private static final int TITLE_GUESS_COMPACT_LENGTH_MAX = 30;
     private static final Color EMBED_COLOR = new Color(50, 164, 168);
     private final Predicate<String> isHelpForumName;
-    private final List<String> defaultTags;
+    private final List<String> tags;
 
 
     /**
@@ -62,7 +62,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         isHelpForumName =
                 Pattern.compile(config.getHelpSystem().getHelpForumPattern()).asMatchPredicate();
 
-        defaultTags = config.getHelpSystem().getCategories();
+        tags = config.getHelpSystem().getCategories();
     }
 
     @Override
@@ -71,7 +71,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         String originalMessageId = event.getTarget().getId();
         String originalChannelId = event.getChannel().getId();
         String authorId = event.getTarget().getAuthor().getId();
-        String mostCommonTag = defaultTags.get(0);
+        String mostCommonTag = tags.get(0);
 
         TextInput modalTitle = TextInput.create(MODAL_TITLE_ID, "Title", TextInputStyle.SHORT)
             .setMaxLength(70)
@@ -159,16 +159,16 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         String transferQuestionTag = event.getValue(MODAL_TAG).getAsString();
 
         ForumChannel questionsForum = getHelperForum(event.getJDA());
-        String mostCommonTag = defaultTags.get(0);
+        String mostCommonTag = tags.get(0);
 
-        String queryTag = StringDistances.closestMatch(transferQuestionTag, defaultTags)
-            .orElse(mostCommonTag);
+        String queryTag =
+                StringDistances.closestMatch(transferQuestionTag, tags).orElse(mostCommonTag);
 
-        ForumTag defaultTag = getDefaultTagOr(questionsForum.getAvailableTagsByName(queryTag, true),
+        ForumTag tag = getTagOr(questionsForum.getAvailableTagsByName(queryTag, true),
                 () -> questionsForum.getAvailableTagsByName(mostCommonTag, true).get(0));
 
         return questionsForum.createForumPost(forumTitle, forumMessage)
-            .setTags(ForumTagSnowflake.fromId(defaultTag.getId()))
+            .setTags(ForumTagSnowflake.fromId(tag.getId()))
             .map(createdPost -> new ForumPost(originalUser, createdPost.getMessage()));
     }
 
@@ -207,7 +207,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
                 "Did not find the helper-forum while trying to transfer a question. Make sure the config is setup properly."));
     }
 
-    private static ForumTag getDefaultTagOr(List<ForumTag> tagsFoundOnForum,
+    private static ForumTag getTagOr(List<ForumTag> tagsFoundOnForum,
             Supplier<ForumTag> defaultTag) {
         return tagsFoundOnForum.isEmpty() ? defaultTag.get() : tagsFoundOnForum.get(0);
     }

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -46,13 +46,15 @@ public final class TransferQuestionCommand extends BotCommandAdapter
     private static final Pattern TITLE_GUESS_COMPACT_REMOVAL_PATTERN = Pattern.compile("\\W");
     private static final int TITLE_GUESS_COMPACT_LENGTH_MIN = 2;
     private static final int TITLE_GUESS_COMPACT_LENGTH_MAX = 30;
+    private static final Color EMBED_COLOR = new Color(50, 164, 168);
     private final Predicate<String> isHelpForumName;
     private final List<String> defaultTags;
-    private static final Color EMBED_COLOR = new Color(50, 164, 168);
 
 
     /**
      * Creates a new instance.
+     *
+     * @param config to get the helper forum and tags
      */
     public TransferQuestionCommand(Config config) {
         super(Commands.message(COMMAND_NAME), CommandVisibility.GUILD);

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -74,7 +74,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         TextInput modalTitle = TextInput.create(MODAL_TITLE_ID, "Title", TextInputStyle.SHORT)
             .setMaxLength(70)
             .setMinLength(4)
-            .setPlaceholder("describe question in short")
+            .setPlaceholder("Describe the question in short")
             .setValue(createTitle(originalMessage))
             .build();
 
@@ -82,17 +82,17 @@ public final class TransferQuestionCommand extends BotCommandAdapter
                 TextInput.create(MODAL_INPUT_ID, "Question", TextInputStyle.PARAGRAPH)
                     .setValue(originalMessage)
                     .setRequiredRange(3, 2000)
-                    .setPlaceholder("contents of question")
+                    .setPlaceholder("Contents of the question")
                     .build();
 
         TextInput modalTag = TextInput.create(MODAL_TAG, "Most fitting tag", TextInputStyle.SHORT)
             .setValue(mostCommonTag)
-            .setPlaceholder("suitable tag for question")
+            .setPlaceholder("Suitable tag for the question")
             .build();
 
-        String modalComponentID =
+        String modalComponentId =
                 generateComponentId(authorId, originalMessageId, originalChannelId);
-        Modal transferModal = Modal.create(modalComponentID, "Transfer this question")
+        Modal transferModal = Modal.create(modalComponentId, "Transfer this question")
             .addActionRow(modalTitle)
             .addActionRow(modalInput)
             .addActionRow(modalTag)
@@ -175,16 +175,20 @@ public final class TransferQuestionCommand extends BotCommandAdapter
 
         String messageTemplate =
                 """
-                        Hello %s 👋 You have asked a question in the wrong channel %s. Not a big deal, but none of the experts who could help you are reading your question there 🙁
+                        Hello%s 👋 You have asked a question in the wrong channel%s. Not a big deal, but none of the experts who could help you are reading your question there 🙁
 
                         Your question has been automatically transferred to %s, please continue there, thank you 👍
                         """;
 
+        String messageForDm = messageTemplate.formatted("", " on" + " " + guild.getName(),
+                forumPost.message.getJumpUrl());
+
+        String messageOnDmFailure = messageTemplate.formatted(" " + forumPost.author.getAsMention(),
+                "", forumPost.message.getJumpUrl());
+
         return forumPost.author.openPrivateChannel()
-            .flatMap(channel -> channel.sendMessage(messageTemplate.formatted("",
-                    "on " + guild.getName(), forumPost.message.getJumpUrl())))
-            .onErrorFlatMap(error -> sourceChannel.sendMessage(messageTemplate
-                .formatted(forumPost.author.getAsMention(), "", forumPost.message.getJumpUrl())));
+            .flatMap(channel -> channel.sendMessage(messageForDm))
+            .onErrorFlatMap(error -> sourceChannel.sendMessage(messageOnDmFailure));
     }
 
     private RestAction<Void> deleteOriginalMessage(JDA jda, String channelId, String messageId) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -144,7 +144,8 @@ public final class TransferQuestionCommand extends BotCommandAdapter
 
         String transferQuestionTag = event.getValue(TRANSFER_QUESTION_TAG).getAsString();
 
-        String queryTag = StringDistances.closestMatch(transferQuestionTag, defaultTags).orElse(defaultTags.get(0));
+        String queryTag = StringDistances.closestMatch(transferQuestionTag, defaultTags)
+            .orElse(defaultTags.get(0));
 
         ForumTag defaultTag = getDefaultTagOr(questionsForum.getAvailableTagsByName(queryTag, true),
                 () -> questionsForum.getAvailableTagsByName(defaultTags.get(0), true).get(0));

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -100,21 +100,23 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         event.replyModal(transferModal)
             .queue(success -> logger.debug(
                     "{} with id: {}  triggered the transfer action on forumPost with id: {}",
-                    event.getUser().getName(), event.getUser().getId(), originalMessageId),
-                    failed -> {
-                    });
+                    event.getUser().getName(), event.getUser().getId(), originalMessageId));
     }
 
     @Override
     public void onModalSubmitted(ModalInteractionEvent event, List<String> args) {
         event.deferEdit().queue();
 
+        String authorId = args.get(0);
+        String messageId = args.get(1);
+        String channelId = args.get(2);
+
         event.getJDA()
-            .retrieveUserById(args.get(0))
+            .retrieveUserById(authorId)
             .flatMap(fetchedUser -> createForumPost(event, fetchedUser))
             .flatMap(createdforumPost -> dmUser(event.getChannel(), createdforumPost,
                     event.getGuild()))
-            .flatMap(dmSent -> deleteOriginalMessage(event.getJDA(), args.get(2), args.get(1)))
+            .flatMap(dmSent -> deleteOriginalMessage(event.getJDA(), channelId, messageId))
             .queue();
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -1,0 +1,177 @@
+package org.togetherjava.tjbot.features.moderation;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
+import net.dv8tion.jda.api.entities.channel.forums.ForumPost;
+import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
+import net.dv8tion.jda.api.entities.channel.forums.ForumTagSnowflake;
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.components.Modal;
+import net.dv8tion.jda.api.interactions.components.text.TextInput;
+import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
+import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.togetherjava.tjbot.config.Config;
+import org.togetherjava.tjbot.features.BotCommandAdapter;
+import org.togetherjava.tjbot.features.CommandVisibility;
+import org.togetherjava.tjbot.features.MessageContextCommand;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+public final class TransferQuestionCommand extends BotCommandAdapter
+        implements MessageContextCommand {
+    private static final Logger logger = LoggerFactory.getLogger(TransferQuestionCommand.class);
+    private static final String COMMAND_NAME = "transfer-question";
+    private static final String TRANSFER_QUESTION_TITLE_ID = "transferID";
+    private static final String TRANSFER_QUESTION_INPUT_ID = "transferQuestion";
+    private static final String TRANSFER_QUESTION_TAG = "tags";
+    private static final int TITLE_MAX_LENGTH = 50;
+    private static final Pattern TITLE_COMPACT_REMOVAL_PATTERN = Pattern.compile("\\W");
+    private static final int TITLE_COMPACT_LENGTH_MIN = 2;
+    private static final int TITLE_COMPACT_LENGTH_MAX = 30;
+    private final Predicate<String> isHelpForumName;
+
+
+    /**
+     * Creates a new instance.
+     */
+    public TransferQuestionCommand(Config config) {
+        super(Commands.message(COMMAND_NAME), CommandVisibility.GUILD);
+
+        isHelpForumName =
+                Pattern.compile(config.getHelpSystem().getHelpForumPattern()).asMatchPredicate();
+    }
+
+    @Override
+    public void onMessageContext(MessageContextInteractionEvent event) {
+        String originalMessage = event.getTarget().getContentRaw();
+        String originalMessageId = event.getTarget().getId();
+        String originalChannelId = event.getChannel().getId();
+        String authorId = event.getTarget().getAuthor().getId();
+
+        TextInput transferQuestionTitle =
+                TextInput.create(TRANSFER_QUESTION_TITLE_ID, "Title", TextInputStyle.SHORT)
+                    .setMaxLength(70)
+                    .setMinLength(8)
+                    .setValue(createTitle(originalMessage))
+                    .build();
+
+        TextInput transferQuestionInput = TextInput
+            .create(TRANSFER_QUESTION_INPUT_ID, "Transfer question menu", TextInputStyle.PARAGRAPH)
+            .setValue(originalMessage)
+            .setRequiredRange(3, 2000)
+            .build();
+
+        TextInput transferQuestionTag = TextInput
+            .create(TRANSFER_QUESTION_TAG, "Transfer question tags", TextInputStyle.SHORT)
+            .setValue("Java")
+            .build();
+
+        String transferQuestionModalComponentID =
+                generateComponentId(authorId, originalMessageId, originalChannelId);
+        Modal transferModal =
+                Modal.create(transferQuestionModalComponentID, "transfer question menu")
+                    .addActionRow(transferQuestionTitle)
+                    .addActionRow(transferQuestionInput)
+                    .addActionRow(transferQuestionTag)
+                    .build();
+
+        event.replyModal(transferModal)
+            .queue(success -> logger.info(
+                    "{} with id: {}  triggered the transfer action on message with id: {}",
+                    event.getUser().getName(), event.getUser().getId(), originalMessageId),
+                    failed -> {
+                    });
+    }
+
+    @Override
+    public void onModalSubmitted(ModalInteractionEvent event, List<String> args) {
+        event.deferReply().queue();
+
+        event.getJDA()
+            .retrieveUserById(args.get(0))
+            .flatMap(fetchedUser -> createForumPost(event, fetchedUser))
+            .flatMap(user -> dmUser(event.getChannel(), user, event.getGuild()))
+            .flatMap(dmSent -> deleteOriginalMessage(event.getJDA(), args.get(2), args.get(1)))
+            .flatMap(deletedOriginalMessage -> event.getHook().sendMessage("Question Transferred"))
+            .queue();
+    }
+
+    private static String createTitle(String message) {
+        if (message.length() >= TITLE_MAX_LENGTH) {
+            int lastWordEnd = message.lastIndexOf(' ', TITLE_MAX_LENGTH);
+
+            if (lastWordEnd == -1) {
+                lastWordEnd = TITLE_MAX_LENGTH;
+            }
+
+            message = message.substring(0, lastWordEnd);
+        }
+
+        return isTitleValid(message) ? message : "Untitled";
+    }
+
+    private static boolean isTitleValid(CharSequence title) {
+        String titleCompact = TITLE_COMPACT_REMOVAL_PATTERN.matcher(title).replaceAll("");
+
+        return titleCompact.length() >= TITLE_COMPACT_LENGTH_MIN
+                && titleCompact.length() <= TITLE_COMPACT_LENGTH_MAX;
+    }
+
+    private RestAction<User> createForumPost(ModalInteractionEvent event, User originalUser) {
+        MessageCreateData forumMessage = MessageCreateData
+            .fromContent(event.getValue(TRANSFER_QUESTION_INPUT_ID).getAsString());
+        String forumTitle = event.getValue(TRANSFER_QUESTION_TITLE_ID).getAsString();
+        ForumChannel questionsForum = getHelperForum(event.getJDA());
+        List<ForumTag> tags = questionsForum.getAvailableTagsByName("JAVA", true);
+        ForumTag javaTag = tags.get(0);
+
+        return questionsForum.createForumPost(forumTitle, forumMessage)
+            .setTags(ForumTagSnowflake.fromId(javaTag.getId()))
+            .map(ForumPost::getMessage)
+            .flatMap(message -> message.reply("Original Post from " + originalUser.getAsMention()))
+            .map(sent -> originalUser);
+
+    }
+
+    private RestAction<Message> dmUser(MessageChannelUnion sourceChannel, User originalUser,
+            Guild guild) {
+
+        return originalUser.openPrivateChannel()
+            .flatMap(channel -> channel.sendMessage(
+                    "Hi, TJ here. You are getting this message because you tried to ask a question in wrong chat, please read rules - %s"
+                        .formatted(guild.getName())))
+            .onErrorFlatMap(error -> sourceChannel.sendMessage(
+                    "Due to failed dm interaction, you are getting this message here. Please read rules about asking questions -%s%s"
+                        .formatted(guild.getName(), originalUser.getAsMention())));
+
+    }
+
+    private RestAction<Void> deleteOriginalMessage(JDA jda, String channelId, String messageId) {
+        return jda.getTextChannelById(channelId).deleteMessageById(messageId);
+    }
+
+
+
+    private ForumChannel getHelperForum(JDA jda) {
+        Optional<ForumChannel> forumChannelOptional = jda.getForumChannels()
+            .stream()
+            .filter(forumChannel -> isHelpForumName.test(forumChannel.getName()))
+            .findFirst();
+
+        return forumChannelOptional
+            .orElseThrow(() -> new RuntimeException("Helper Forum Not found"));
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -6,8 +6,6 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
-import net.dv8tion.jda.api.entities.channel.Channel;
-import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
 import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
 import net.dv8tion.jda.api.entities.channel.forums.ForumTagSnowflake;
@@ -67,11 +65,6 @@ public final class TransferQuestionCommand extends BotCommandAdapter
 
     @Override
     public void onMessageContext(MessageContextInteractionEvent event) {
-
-        if (!isTextChannel(event.getChannel())) {
-            event.reply("feature can be only used in text channels").setEphemeral(true).queue();
-            return;
-        }
         String originalMessage = event.getTarget().getContentRaw();
         String originalMessageId = event.getTarget().getId();
         String originalChannelId = event.getChannel().getId();
@@ -81,7 +74,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         TextInput modalTitle = TextInput.create(MODAL_TITLE_ID, "Title", TextInputStyle.SHORT)
             .setMaxLength(70)
             .setMinLength(4)
-            .setPlaceholder("title for post")
+            .setPlaceholder("describe question in short")
             .setValue(createTitle(originalMessage))
             .build();
 
@@ -89,12 +82,12 @@ public final class TransferQuestionCommand extends BotCommandAdapter
                 TextInput.create(MODAL_INPUT_ID, "Question", TextInputStyle.PARAGRAPH)
                     .setValue(originalMessage)
                     .setRequiredRange(3, 2000)
-                    .setPlaceholder("question for post")
+                    .setPlaceholder("contents of question")
                     .build();
 
         TextInput modalTag = TextInput.create(MODAL_TAG, "Most fitting tag", TextInputStyle.SHORT)
             .setValue(mostCommonTag)
-            .setPlaceholder("suitable tag for post")
+            .setPlaceholder("suitable tag for question")
             .build();
 
         String modalComponentID =
@@ -223,12 +216,5 @@ public final class TransferQuestionCommand extends BotCommandAdapter
     }
 
     private record ForumPost(User author, Message message) {
-    }
-
-    private boolean isTextChannel(Channel channel) {
-        if (channel.getType().equals(ChannelType.TEXT)) {
-            return true;
-        }
-        return false;
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -158,7 +158,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         String queryTag =
                 StringDistances.closestMatch(transferQuestionTag, tags).orElse(mostCommonTag);
 
-        ForumTag tag = getTagOr(questionsForum.getAvailableTagsByName(queryTag, true),
+        ForumTag tag = getTagOrDefault(questionsForum.getAvailableTagsByName(queryTag, true),
                 () -> questionsForum.getAvailableTagsByName(mostCommonTag, true).get(0));
 
         return questionsForum.createForumPost(forumTitle, forumMessage)
@@ -201,7 +201,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
                 "Did not find the helper-forum while trying to transfer a question. Make sure the config is setup properly."));
     }
 
-    private static ForumTag getTagOr(List<ForumTag> tagsFoundOnForum,
+    private static ForumTag getTagOrDefault(List<ForumTag> tagsFoundOnForum,
             Supplier<ForumTag> defaultTag) {
         return tagsFoundOnForum.isEmpty() ? defaultTag.get() : tagsFoundOnForum.get(0);
     }

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -39,9 +39,9 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         implements MessageContextCommand {
     private static final Logger logger = LoggerFactory.getLogger(TransferQuestionCommand.class);
     private static final String COMMAND_NAME = "transfer-question";
-    private static final String TITLE_ID = "transferID";
-    private static final String INPUT_ID = "transferQuestion";
-    private static final String TAG = "tags";
+    private static final String MODAL_TITLE_ID = "transferID";
+    private static final String MODAL_INPUT_ID = "transferQuestion";
+    private static final String MODAL_TAG = "tags";
     private static final int TITLE_GUESS_MAX_LENGTH = 50;
     private static final Pattern TITLE_GUESS_COMPACT_REMOVAL_PATTERN = Pattern.compile("\\W");
     private static final int TITLE_GUESS_COMPACT_LENGTH_MIN = 2;
@@ -71,28 +71,31 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         String authorId = event.getTarget().getAuthor().getId();
         String mostCommonTag = defaultTags.get(0);
 
-        TextInput title = TextInput.create(TITLE_ID, "Title", TextInputStyle.SHORT)
+        TextInput modalTitle = TextInput.create(MODAL_TITLE_ID, "Title", TextInputStyle.SHORT)
             .setMaxLength(70)
             .setMinLength(4)
+            .setPlaceholder("title for question")
             .setValue(createTitle(originalMessage))
             .build();
 
-        TextInput input =
-                TextInput.create(INPUT_ID, "Transfer question menu", TextInputStyle.PARAGRAPH)
+        TextInput modalInput =
+                TextInput.create(MODAL_INPUT_ID, "Question", TextInputStyle.PARAGRAPH)
                     .setValue(originalMessage)
                     .setRequiredRange(3, 2000)
+                    .setPlaceholder("question for post")
                     .build();
 
-        TextInput tag = TextInput.create(TAG, "Transfer question tags", TextInputStyle.SHORT)
+        TextInput modalTag = TextInput.create(MODAL_TAG, "Most fitting tag", TextInputStyle.SHORT)
             .setValue(mostCommonTag)
+            .setPlaceholder("suitable tag for post")
             .build();
 
         String modalComponentID =
                 generateComponentId(authorId, originalMessageId, originalChannelId);
-        Modal transferModal = Modal.create(modalComponentID, "transfer question menu")
-            .addActionRow(title)
-            .addActionRow(input)
-            .addActionRow(tag)
+        Modal transferModal = Modal.create(modalComponentID, "Transfer this question")
+            .addActionRow(modalTitle)
+            .addActionRow(modalInput)
+            .addActionRow(modalTag)
             .build();
 
         event.replyModal(transferModal)
@@ -141,7 +144,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
 
     private RestAction<ForumPost> createForumPost(ModalInteractionEvent event, User originalUser) {
 
-        String originalMessage = event.getValue(INPUT_ID).getAsString();
+        String originalMessage = event.getValue(MODAL_INPUT_ID).getAsString();
 
         MessageEmbed embedForPost = makeEmbedForPost(originalUser, originalMessage);
 
@@ -150,8 +153,8 @@ public final class TransferQuestionCommand extends BotCommandAdapter
             .setEmbeds(embedForPost)
             .build();
 
-        String forumTitle = event.getValue(TITLE_ID).getAsString();
-        String transferQuestionTag = event.getValue(TAG).getAsString();
+        String forumTitle = event.getValue(MODAL_TITLE_ID).getAsString();
+        String transferQuestionTag = event.getValue(MODAL_TAG).getAsString();
 
         ForumChannel questionsForum = getHelperForum(event.getJDA());
         String mostCommonTag = defaultTags.get(0);

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -6,6 +6,8 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.Channel;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
 import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
 import net.dv8tion.jda.api.entities.channel.forums.ForumTagSnowflake;
@@ -65,6 +67,11 @@ public final class TransferQuestionCommand extends BotCommandAdapter
 
     @Override
     public void onMessageContext(MessageContextInteractionEvent event) {
+
+        if (!isTextChannel(event.getChannel())) {
+            event.reply("feature can be only used in text channels").setEphemeral(true).queue();
+            return;
+        }
         String originalMessage = event.getTarget().getContentRaw();
         String originalMessageId = event.getTarget().getId();
         String originalChannelId = event.getChannel().getId();
@@ -74,7 +81,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         TextInput modalTitle = TextInput.create(MODAL_TITLE_ID, "Title", TextInputStyle.SHORT)
             .setMaxLength(70)
             .setMinLength(4)
-            .setPlaceholder("title for question")
+            .setPlaceholder("title for post")
             .setValue(createTitle(originalMessage))
             .build();
 
@@ -216,5 +223,12 @@ public final class TransferQuestionCommand extends BotCommandAdapter
     }
 
     private record ForumPost(User author, Message message) {
+    }
+
+    private boolean isTextChannel(Channel channel) {
+        if (channel.getType().equals(ChannelType.TEXT)) {
+            return true;
+        }
+        return false;
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -69,6 +69,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         String originalMessageId = event.getTarget().getId();
         String originalChannelId = event.getChannel().getId();
         String authorId = event.getTarget().getAuthor().getId();
+        String mostCommonTag = defaultTags.get(0);
 
         TextInput transferQuestionTitle =
                 TextInput.create(TRANSFER_QUESTION_TITLE_ID, "Title", TextInputStyle.SHORT)
@@ -85,7 +86,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
 
         TextInput transferQuestionTag = TextInput
             .create(TRANSFER_QUESTION_TAG, "Transfer question tags", TextInputStyle.SHORT)
-            .setValue("Java")
+            .setValue(mostCommonTag)
             .build();
 
         String transferQuestionModalComponentID =

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -19,8 +19,6 @@ import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.features.BotCommandAdapter;
@@ -37,7 +35,6 @@ import java.util.regex.Pattern;
 
 public final class TransferQuestionCommand extends BotCommandAdapter
         implements MessageContextCommand {
-    private static final Logger logger = LoggerFactory.getLogger(TransferQuestionCommand.class);
     private static final String COMMAND_NAME = "transfer-question";
     private static final String MODAL_TITLE_ID = "transferID";
     private static final String MODAL_INPUT_ID = "transferQuestion";


### PR DESCRIPTION
* Adds a transfer feature for moderation team
* when used, creates a new post in helper forum
* DM user about this infraction
* Delete original message from source channel
* Sends original message to source on dm fail
* resolves #868 

 on a sidenote, third time is the charm

**UPDATED**
**Step 1: Text in chat**

![text-sent](https://github.com/Together-Java/TJ-Bot/assets/61616007/52bcc5ea-89a5-47b2-abc1-9ce756998e4b)


**Step 2: Transfer Command**

![select-transfer-command](https://github.com/Together-Java/TJ-Bot/assets/61616007/5ab8d7ff-6c61-4cb0-8ae2-e019410ce152)

**Step 3: Modal prefilled with values**
![image](https://github.com/Together-Java/TJ-Bot/assets/61616007/d8963047-f775-4712-bcc1-db4acb5b1d93)

**Step 4: selecting transfer-question creates a new post in helper forum**

![image](https://github.com/Together-Java/TJ-Bot/assets/61616007/a957824b-014e-4f09-8fa8-135649f7300c)

**Step 5: followed by DMing User (contains guildName at last)**

![image](https://github.com/Together-Java/TJ-Bot/assets/61616007/0cd79c89-e925-4e6f-82d9-c33ab8ebdb88)


**Step 6:  deletes original Message**

**Incase of failed DM:**

![image](https://github.com/Together-Java/TJ-Bot/assets/61616007/3f00ec43-9c0d-48e4-b972-4997002cfd97)
