### PR TITLE
refactor methods to handle invalid transfers

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -238,7 +238,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
 
     private void handleQuestionTooShort(MessageContextInteractionEvent event) {
         event
-            .reply("message content should be at least %s characters long"
+            .reply("Message content should be at least %s characters long."
                 .formatted(INPUT_MIN_LENGTH))
             .setEphemeral(true)
             .queue();

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -50,7 +50,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
     private static final Pattern TITLE_GUESS_COMPACT_REMOVAL_PATTERN = Pattern.compile("\\W");
     private static final int TITLE_MIN_LENGTH = 3;
     private static final Color EMBED_COLOR = new Color(50, 164, 168);
-    private static final int INPUT_MAX_LENGTH = 2000;
+    private static final int INPUT_MAX_LENGTH = Message.MAX_CONTENT_LENGTH;
     private static final int INPUT_MIN_LENGTH = 3;
     private final Predicate<String> isHelpForumName;
     private final List<String> tags;
@@ -96,7 +96,8 @@ public final class TransferQuestionCommand extends BotCommandAdapter
                     .setPlaceholder("Contents of the question");
 
         if (!isQuestionTooShort(originalMessage)) {
-            modalInputBuilder.setValue(originalMessage);
+            String trimmedMessage = getMessageUptoMaxLimit(originalMessage);
+            modalInputBuilder.setValue(trimmedMessage);
         }
 
         TextInput modalTag = TextInput.create(MODAL_TAG, "Most fitting tag", TextInputStyle.SHORT)
@@ -253,5 +254,11 @@ public final class TransferQuestionCommand extends BotCommandAdapter
             return true;
         }
         return false;
+    }
+
+    private String getMessageUptoMaxLimit(String originalMessage) {
+        return originalMessage.length() > INPUT_MAX_LENGTH
+                ? originalMessage.substring(0, INPUT_MAX_LENGTH)
+                : originalMessage;
     }
 }


### PR DESCRIPTION
* refactor bot transfer checks
* add check for too short message transfers 
* resolves #926

updates:
* transfer on short messages now opens up modal menu with empty question/text field with "untitled" as title.
* longer messages than max length are trimmed.
 
![image](https://github.com/Together-Java/TJ-Bot/assets/61616007/3e3c2df8-ba6a-4ef4-8c3c-a8e5a1332474)
