### PR TITLE
refactor onModalSubmit in TransferQuestionCommand to handle multiple users submission

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -13,11 +13,13 @@ import net.dv8tion.jda.api.entities.channel.forums.ForumTagSnowflake;
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.components.Modal;
 import net.dv8tion.jda.api.interactions.components.text.TextInput;
 import net.dv8tion.jda.api.interactions.components.text.TextInput.Builder;
 import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
+import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
@@ -133,7 +135,13 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         // Deleted messages cause retrieveMessageById to fail.
         Consumer<Message> notHandledAction =
                 any -> transferFlow(event, channelId, authorId, messageId);
-        Consumer<Throwable> handledAction = any -> alreadyHandled(sourceChannel, helperForum);
+
+        Consumer<Throwable> handledAction = any -> {
+            if (any instanceof ErrorResponseException errorResponseException
+                    && errorResponseException.getErrorResponse() == ErrorResponse.UNKNOWN_MESSAGE) {
+                alreadyHandled(sourceChannel, helperForum);
+            }
+        };
 
         event.getChannel().retrieveMessageById(messageId).queue(notHandledAction, handledAction);
     }


### PR DESCRIPTION
Problem:
When multiple users use `transfer-question` feature at the same time, it can lead to creation of two or more threads in helper forum in rare occasions. To verify this you'd prolly need an alt account to time it correclty.

Solution:
Bug fix handles this problem by retrieving the original message that needs to be transferred on submitting the transfer modal,
if it's already transferred then message shouldn't be present.

Implementation:
* extracted `onModalSubmit` chain to a method `transferFlow` for clarity.
* added a method(`handledAlready`) to notify user if the transfer was already handled.