### PR TITLE
handle invalid channel transfers

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -6,6 +6,7 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.forums.ForumPost;
@@ -299,11 +300,18 @@ public final class TransferQuestionCommand extends BotCommandAdapter
 
     private boolean isInvalidForTransfer(MessageContextInteractionEvent event) {
         User author = event.getTarget().getAuthor();
+        ChannelType channelType = event.getChannelType();
 
         if (isBotMessageTransfer(author)) {
             handleBotMessageTransfer(event);
             return true;
         }
+
+        if (channelType != ChannelType.TEXT) {
+            handleInvalidChannel(event);
+            return true;
+        }
+
         return false;
     }
 
@@ -311,5 +319,11 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         return originalMessage.length() > INPUT_MAX_LENGTH
                 ? originalMessage.substring(0, INPUT_MAX_LENGTH)
                 : originalMessage;
+    }
+
+    private void handleInvalidChannel(MessageContextInteractionEvent event) {
+        event.reply("Transfer can only be done from regular chat channels.")
+            .setEphemeral(true)
+            .queue();
     }
 }


### PR DESCRIPTION
using `transfer-feature` from either a thread or forum thread would result into an error. Since it's not meant to be used outside of regular chat channels.

![image](https://github.com/Together-Java/TJ-Bot/assets/61616007/44312c72-ac9c-4d6a-abe7-52c7531876bd)


Pr refactors `isInvalidTransfer` to handle it with an ephermal response.

![image](https://github.com/Together-Java/TJ-Bot/assets/61616007/585c8f07-e477-4462-b6ab-e9fd7f44a7dc)
