### PR TITLE
Disabled Features should be logged 

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/Features.java
@@ -161,6 +161,16 @@ public class Features {
         features.add(new JShellCommand(jshellEval));
 
         FeatureBlacklist<Class<?>> blacklist = blacklistConfig.normal();
-        return features.stream().filter(f -> blacklist.isEnabled(f.getClass())).toList();
+        List<Feature> enabledFeatures = features.stream()
+                .filter(f -> blacklist.isEnabled(f.getClass()))
+                .peek(f -> {
+                    if (!blacklist.isEnabled(f.getClass())) {
+                        // Log INFO level message for each disabled feature
+                        BotCore.log.info("Feature '{}' is disabled.", f.getClass().getSimpleName());
+                    }
+                })
+                .toList();
+
+        return enabledFeatures;
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/Features.java
@@ -1,6 +1,7 @@
 package org.togetherjava.tjbot.features;
 
 import net.dv8tion.jda.api.JDA;
+import org.slf4j.Logger;
 
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.config.FeatureBlacklist;
@@ -50,8 +51,7 @@ import org.togetherjava.tjbot.features.tophelper.TopHelpersPurgeMessagesRoutine;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
-import java.util.logging.Logger;
+
 
 /**
  * Utility class that offers all features that should be registered by the system, such as commands.
@@ -78,7 +78,8 @@ public class Features {
      * @param logger the logger instance to log disabled features
      * @return a collection of all features
      */
-    public static Collection<Feature> createFeatures(JDA jda, Database database, Config config, Logger logger) {
+    public static Collection<Feature> createFeatures(JDA jda, Database database, Config config,
+            Logger logger) {
         FeatureBlacklistConfig blacklistConfig = config.getFeatureBlacklistConfig();
         JShellEval jshellEval = new JShellEval(config.getJshell());
 
@@ -105,7 +106,8 @@ public class Features {
         features.add(new ScamHistoryPurgeRoutine(scamHistoryStore));
         features.add(new HelpThreadMetadataPurger(database));
         features.add(new HelpThreadActivityUpdater(helpSystemHelper));
-        features.add(new AutoPruneHelperRoutine(config, helpSystemHelper, modAuditLogWriter, database));
+        features
+            .add(new AutoPruneHelperRoutine(config, helpSystemHelper, modAuditLogWriter, database));
         features.add(new HelpThreadAutoArchiver(helpSystemHelper));
         features.add(new LeftoverBookmarksCleanupRoutine(bookmarksSystem));
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/system/BotCore.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/system/BotCore.java
@@ -71,7 +71,7 @@ public final class BotCore extends ListenerAdapter implements CommandProvider {
      */
     public BotCore(JDA jda, Database database, Config config) {
         this.config = config;
-        Collection<Feature> features = Features.createFeatures(jda, database, config);
+        Collection<Feature> features = Features.createFeatures(jda, database, config, logger);
 
         // Message receivers
         features.stream()


### PR DESCRIPTION
I added a feature to log a message when a certain function is turned off. This log message will help us know which features are disabled and understand why. It's like a notification that tells us, "Hey, we turned off this specific feature, and here's why." This can be useful for keeping track of the configuration and troubleshooting any issues related to disabled features.