### PR TITLE
Integrade gradle toolchain to manage java versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,13 @@ subprojects {
     if (!skipSonarlint) {
         apply plugin: "name.remal.sonarlint"
     }
+    
+    java {
+        toolchain {
+            // Nails the Java-Version of every Subproject
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+    }
 
     // sonarlint configuration, not to be confused with sonarqube/sonarcloud.
     sonarLint {
@@ -60,17 +67,6 @@ subprojects {
             )
         }
     }
-
-    def compileTasks = {
-        options.encoding = 'UTF-8'
-
-        // Nails the Java-Version of every Subproject
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-
-    compileJava(compileTasks)
-    compileTestJava(compileTasks)
 
     spotless {
         java {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,10 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.7.0'
+}
+
 rootProject.name = 'TJ-Bot'
 
 include 'application'
 include 'database'
 include 'formatter'
 include 'utils'
-


### PR DESCRIPTION
> Working on multiple projects can require interacting with multiple versions of the Java language. Even within a single project different parts of the codebase may be fixed to a particular language level due to backward compatibility requirements. This means different versions of the same tools (a toolchain) must be installed and managed on each machine that builds the project.
>
> A Java toolchain is a set of tools to build and run Java projects, which is usually provided by the environment via local JRE or JDK installations. Compile tasks may use javac as their compiler, test and exec tasks may use the java command while javadoc will be used to generate documentation.
>
> By default, Gradle uses the same Java toolchain for running Gradle itself and building JVM projects. However, this may only sometimes be desirable. Building projects with different Java versions on different developer machines and CI servers may lead to unexpected issues. Additionally, you may want to build a project using a Java version that is not supported for running Gradle.
>
>In order to improve reproducibility of the builds and make build requirements clearer, Gradle allows configuring toolchains on both project and task levels.

Executing the build (e.g. using gradle check) will now handle several things for you and others running your build:
1. Gradle configures all compile, test and javadoc tasks to use the defined toolchain.
2. Gradle detects [locally installed toolchains](https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection).
3. Gradle chooses a toolchain matching the requirements (any Java 17 toolchain for the example above).
4. If no matching toolchain is found, Gradle can automatically download a matching one based on the configured [toolchain download repositories](https://docs.gradle.org/current/userguide/toolchains.html#sub:download_repositories).

* * *

Almost every newcomer had issues with setting up our project, mainly because of java version mismatches, gradle and java compiler configurations. This is an attempt to eliminate these barariers, and streamline the experience for newcomers. With this PR, you don't even need to have java installed, it will do it for you, and it will download the correct matching version.

Since this is not a new feature anymore, I hope IDEs and other developer tooling started to respect and use these preferences from gradle, because last time I checked, intelliJ didn't support is fully, witch means you would still need to configure your IDE environment if you are launching our bot from there.

Old way of pegging the version with `sourceCompatibility = JavaVersion.VERSION_21` is considered deprecated by gradle. Also, it will only download correct jdk if you don't already have it. It's pereference when autoprovisioning is adoptium releases. We can force specific vendor if we want, for the whole project.