### PR TITLE
handling error when member left guild

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -32,8 +32,8 @@ import java.util.function.Function;
  */
 public final class HelpThreadAutoArchiver implements Routine {
     private static final Logger logger = LoggerFactory.getLogger(HelpThreadAutoArchiver.class);
-    private static final int SCHEDULE_MINUTES = 6;
-    private static final Duration ARCHIVE_AFTER_INACTIVITY_OF = Duration.ofSeconds(12);
+    private static final int SCHEDULE_MINUTES = 60;
+    private static final Duration ARCHIVE_AFTER_INACTIVITY_OF = Duration.ofHours(12);
 
     private final HelpSystemHelper helper;
 
@@ -48,7 +48,7 @@ public final class HelpThreadAutoArchiver implements Routine {
 
     @Override
     public Schedule createSchedule() {
-        return new Schedule(ScheduleMode.FIXED_RATE, 0, SCHEDULE_MINUTES, TimeUnit.SECONDS);
+        return new Schedule(ScheduleMode.FIXED_RATE, 0, SCHEDULE_MINUTES, TimeUnit.MINUTES);
     }
 
     @Override

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -159,10 +159,10 @@ public final class HelpThreadAutoArchiver implements Routine {
             })
             .mapToResult()
             .flatMap(sentEmbed -> {
-                if (sentEmbed.isFailure()) {
-                    return handleFailure.apply(sentEmbed.getFailure());
+                if (sentEmbed.isSuccess()) {
+                    return archiveThread.get();
                 }
-                return archiveThread.get();
+                return handleFailure.apply(sentEmbed.getFailure());
             })
             .queue();
     }

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -140,8 +140,10 @@ public final class HelpThreadAutoArchiver implements Routine {
                 if (member.isSuccess()) {
                     return sendEmbedWithMention.apply(member);
                 }
+                LOGGER.info(
+                        "Owner of thread with id: {} left the server, sending embed without mention",
+                        threadChannel.getId(), member.getFailure());
 
-                LOGGER.debug("Unable to mention user", member.getFailure());
                 return sendEmbedWithoutMention.apply(member);
             })
             .mapToResult()

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -162,6 +162,7 @@ public final class HelpThreadAutoArchiver implements Routine {
                 if (sentEmbed.isSuccess()) {
                     return archiveThread.get();
                 }
+
                 return handleFailure.apply(sentEmbed.getFailure());
             })
             .queue();

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -9,7 +9,6 @@ import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.Result;
 import net.dv8tion.jda.api.utils.TimeUtil;
@@ -148,7 +147,7 @@ public final class HelpThreadAutoArchiver implements Routine {
             })
             .mapToResult()
             .flatMap(sentEmbed -> {
-                if (sentEmbed.getFailure() instanceof ErrorResponseException) {
+                if (sentEmbed.isFailure()) {
                     LOGGER.warn(
                             "Unknown error occurred during help thread auto archive routine, archiving thread",
                             sentEmbed.getFailure());

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
  * recent activity.
  */
 public final class HelpThreadAutoArchiver implements Routine {
-    private static final Logger LOGGER = LoggerFactory.getLogger(HelpThreadAutoArchiver.class);
+    private static final Logger logger = LoggerFactory.getLogger(HelpThreadAutoArchiver.class);
     private static final int SCHEDULE_MINUTES = 60;
     private static final Duration ARCHIVE_AFTER_INACTIVITY_OF = Duration.ofHours(12);
 
@@ -57,7 +57,7 @@ public final class HelpThreadAutoArchiver implements Routine {
 
     private void autoArchiveForGuild(Guild guild) {
         Optional<ForumChannel> maybeHelpForum = helper
-            .handleRequireHelpForum(guild, channelPattern -> LOGGER.warn(
+            .handleRequireHelpForum(guild, channelPattern -> logger.warn(
                     "Unable to auto archive help threads, did not find a help forum matching the configured pattern '{}' for guild '{}'",
                     channelPattern, guild.getName()));
 
@@ -65,10 +65,10 @@ public final class HelpThreadAutoArchiver implements Routine {
             return;
         }
 
-        LOGGER.debug("Auto archiving of help threads");
+        logger.debug("Auto archiving of help threads");
 
         List<ThreadChannel> activeThreads = helper.getActiveThreadsIn(maybeHelpForum.orElseThrow());
-        LOGGER.debug("Found {} active questions", activeThreads.size());
+        logger.debug("Found {} active questions", activeThreads.size());
 
         Instant archiveAfterMoment = computeArchiveAfterMoment();
         activeThreads
@@ -81,7 +81,7 @@ public final class HelpThreadAutoArchiver implements Routine {
 
     private void autoArchiveForThread(ThreadChannel threadChannel, Instant archiveAfterMoment) {
         if (shouldBeArchived(threadChannel, archiveAfterMoment)) {
-            LOGGER.debug("Auto archiving help thread {}", threadChannel.getId());
+            logger.debug("Auto archiving help thread {}", threadChannel.getId());
 
             String linkHowToAsk = "https://stackoverflow.com/help/how-to-ask";
 
@@ -140,7 +140,7 @@ public final class HelpThreadAutoArchiver implements Routine {
                 if (foundMember.isSuccess()) {
                     return sendEmbedWithMention.apply(foundMember);
                 }
-                LOGGER.info(
+                logger.info(
                         "Owner of thread with id: {} left the server, sending embed without mention",
                         threadChannel.getId(), foundMember.getFailure());
 
@@ -149,7 +149,7 @@ public final class HelpThreadAutoArchiver implements Routine {
             .mapToResult()
             .flatMap(sentEmbed -> {
                 if (sentEmbed.isFailure()) {
-                    LOGGER.warn(
+                    logger.warn(
                             "Unknown error occurred during help thread auto archive routine, archiving thread",
                             sentEmbed.getFailure());
                 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -130,8 +130,11 @@ public final class HelpThreadAutoArchiver implements Routine {
 
         Consumer<Throwable> handleFailure = error -> {
             if (error instanceof ErrorResponseException) {
-                logger.warn("Unknown error occurred during help thread auto archive routine",
+                logger.warn(
+                        "Unknown error occurred during help thread auto archive routine, archiving thread",
                         error);
+
+                threadChannel.getManager().setArchived(true).queue();
             }
         };
 
@@ -148,7 +151,8 @@ public final class HelpThreadAutoArchiver implements Routine {
                 if (member.isSuccess()) {
                     return sendEmbedWithMention.apply(member);
                 }
-                logger.debug("Member already left server, archiving thread without mention");
+
+                logger.debug("Unable to mention user", member.getFailure());
                 return sendEmbedWithoutMention.apply(member);
             })
             .flatMap(any -> threadChannel.getManager().setArchived(true))

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -129,7 +129,7 @@ public final class HelpThreadAutoArchiver implements Routine {
 
     private void handleArchiveFlow(ThreadChannel threadChannel, MessageEmbed embed) {
 
-        Consumer<Throwable> handleFailure = error -> {
+        Consumer<Throwable> logFailure = error -> {
             if (error instanceof ErrorResponseException) {
                 logger.warn(
                         "Unknown error occurred during help thread auto archive routine, archiving thread",
@@ -159,7 +159,7 @@ public final class HelpThreadAutoArchiver implements Routine {
             })
             .flatMap(any -> archiveThread.get())
             .onErrorFlatMap(error -> {
-                handleFailure.accept(error);
+                logFailure.accept(error);
                 return archiveThread.get();
             })
             .queue();

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
  */
 public final class HelpThreadAutoArchiver implements Routine {
     private static final Logger logger = LoggerFactory.getLogger(HelpThreadAutoArchiver.class);
-    private static final int SCHEDULE_MINUTES = 6;
-    private static final Duration ARCHIVE_AFTER_INACTIVITY_OF = Duration.ofSeconds(60);
+    private static final int SCHEDULE_MINUTES = 60;
+    private static final Duration ARCHIVE_AFTER_INACTIVITY_OF = Duration.ofHours(12);
 
     private final HelpSystemHelper helper;
 
@@ -47,7 +47,7 @@ public final class HelpThreadAutoArchiver implements Routine {
 
     @Override
     public Schedule createSchedule() {
-        return new Schedule(ScheduleMode.FIXED_RATE, 0, SCHEDULE_MINUTES, TimeUnit.SECONDS);
+        return new Schedule(ScheduleMode.FIXED_RATE, 0, SCHEDULE_MINUTES, TimeUnit.MINUTES);
     }
 
     @Override

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -30,7 +30,7 @@ import java.util.function.Function;
  * recent activity.
  */
 public final class HelpThreadAutoArchiver implements Routine {
-    private static final Logger logger = LoggerFactory.getLogger(HelpThreadAutoArchiver.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HelpThreadAutoArchiver.class);
     private static final int SCHEDULE_MINUTES = 60;
     private static final Duration ARCHIVE_AFTER_INACTIVITY_OF = Duration.ofHours(12);
 
@@ -57,7 +57,7 @@ public final class HelpThreadAutoArchiver implements Routine {
 
     private void autoArchiveForGuild(Guild guild) {
         Optional<ForumChannel> maybeHelpForum = helper
-            .handleRequireHelpForum(guild, channelPattern -> logger.warn(
+            .handleRequireHelpForum(guild, channelPattern -> LOGGER.warn(
                     "Unable to auto archive help threads, did not find a help forum matching the configured pattern '{}' for guild '{}'",
                     channelPattern, guild.getName()));
 
@@ -65,10 +65,10 @@ public final class HelpThreadAutoArchiver implements Routine {
             return;
         }
 
-        logger.debug("Auto archiving of help threads");
+        LOGGER.debug("Auto archiving of help threads");
 
         List<ThreadChannel> activeThreads = helper.getActiveThreadsIn(maybeHelpForum.orElseThrow());
-        logger.debug("Found {} active questions", activeThreads.size());
+        LOGGER.debug("Found {} active questions", activeThreads.size());
 
         Instant archiveAfterMoment = computeArchiveAfterMoment();
         activeThreads
@@ -81,7 +81,7 @@ public final class HelpThreadAutoArchiver implements Routine {
 
     private void autoArchiveForThread(ThreadChannel threadChannel, Instant archiveAfterMoment) {
         if (shouldBeArchived(threadChannel, archiveAfterMoment)) {
-            logger.debug("Auto archiving help thread {}", threadChannel.getId());
+            LOGGER.debug("Auto archiving help thread {}", threadChannel.getId());
 
             String linkHowToAsk = "https://stackoverflow.com/help/how-to-ask";
 
@@ -141,13 +141,13 @@ public final class HelpThreadAutoArchiver implements Routine {
                     return sendEmbedWithMention.apply(member);
                 }
 
-                logger.debug("Unable to mention user", member.getFailure());
+                LOGGER.debug("Unable to mention user", member.getFailure());
                 return sendEmbedWithoutMention.apply(member);
             })
             .mapToResult()
             .flatMap(sentEmbed -> {
                 if (sentEmbed.getFailure() instanceof ErrorResponseException) {
-                    logger.warn(
+                    LOGGER.warn(
                             "Unknown error occurred during help thread auto archive routine, archiving thread",
                             sentEmbed.getFailure());
                 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -133,8 +133,6 @@ public final class HelpThreadAutoArchiver implements Routine {
                 logger.warn(
                         "Unknown error occurred during help thread auto archive routine, archiving thread",
                         error);
-
-                threadChannel.getManager().setArchived(true).queue();
             }
         };
 
@@ -156,7 +154,10 @@ public final class HelpThreadAutoArchiver implements Routine {
                 return sendEmbedWithoutMention.apply(member);
             })
             .flatMap(any -> threadChannel.getManager().setArchived(true))
-            .queue(any -> {
-            }, handleFailure);
+            .onErrorFlatMap(error -> {
+                handleFailure.accept(error);
+                return threadChannel.getManager().setArchived(true);
+            })
+            .queue();
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -136,10 +136,10 @@ public final class HelpThreadAutoArchiver implements Routine {
         };
 
         Function<Result<Member>, RestAction<Message>> sendEmbedWithMention =
-                (member) -> threadChannel.sendMessage(member.get().getAsMention()).addEmbeds(embed);
+                member -> threadChannel.sendMessage(member.get().getAsMention()).addEmbeds(embed);
 
         Function<Result<Member>, RestAction<Message>> sendEmbedWithoutMention =
-                (member) -> threadChannel.sendMessageEmbeds(embed);
+                member -> threadChannel.sendMessageEmbeds(embed);
 
         threadChannel.getGuild()
             .retrieveMemberById(threadChannel.getOwnerIdLong())

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -131,7 +131,7 @@ public final class HelpThreadAutoArchiver implements Routine {
         Supplier<RestAction<Void>> archiveThread =
                 () -> threadChannel.getManager().setArchived(true);
 
-        Function<Throwable, RestAction<Void>> handleFailure = (error) -> {
+        Function<Throwable, RestAction<Void>> handleFailure = error -> {
             if (error instanceof ErrorResponseException) {
                 logger.warn(
                         "Unknown error occurred during help thread auto archive routine, archiving thread",

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -146,15 +146,7 @@ public final class HelpThreadAutoArchiver implements Routine {
 
                 return sendEmbedWithoutMention.get();
             })
-            .mapToResult()
-            .flatMap(sentEmbed -> {
-                if (sentEmbed.isFailure()) {
-                    logger.warn(
-                            "Unknown error occurred during help thread auto archive routine, archiving thread",
-                            sentEmbed.getFailure());
-                }
-                return threadChannel.getManager().setArchived(true);
-            })
+            .flatMap(any -> threadChannel.getManager().setArchived(true))
             .queue();
     }
 }


### PR DESCRIPTION
During auto-archive routine for help threads, bot sends an embed educating OP why the thread was archived, it also pings OP in the process. This whole archiving routine depends on whether member was retrieved, thus it fails consecutively until discords built in archive feature kicks in.

![image](https://github.com/Together-Java/TJ-Bot/assets/61616007/02fa2c3e-8cc3-46dd-94ae-053e46419639)
