### PR TITLE
Bug/gpt response compact

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptCommand.java
@@ -74,8 +74,9 @@ public final class ChatGptCommand extends SlashCommandAdapter {
     public void onModalSubmitted(ModalInteractionEvent event, List<String> args) {
         event.deferReply().queue();
 
+        String context = "";
         Optional<String[]> optional =
-                chatGptService.ask(event.getValue(QUESTION_INPUT).getAsString());
+                chatGptService.ask(event.getValue(QUESTION_INPUT).getAsString(), context);
         if (optional.isPresent()) {
             userIdToAskedAtCache.put(event.getMember().getId(), Instant.now());
         }

--- a/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
@@ -72,7 +72,7 @@ public class ChatGptService {
         }
 
         try {
-            String instructions = "KEEP IT CONCISE, NOT MORE THAN 500 WORDS";
+            String instructions = "KEEP IT CONCISE, NOT MORE THAN 280 WORDS";
             String questionWithContext = "context: Category %s on a Java Q&A discord server. %s %s"
                 .formatted(context, instructions, question);
             ChatMessage chatMessage = new ChatMessage(ChatMessageRole.USER.value(),

--- a/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
@@ -42,12 +42,9 @@ public class ChatGptService {
 
         openAiService = new OpenAiService(apiKey, TIMEOUT);
 
-        ChatMessage setupMessage = new ChatMessage(ChatMessageRole.SYSTEM.value(),
-                """
-                        Please answer questions in 1500 characters or less. Remember to count spaces in the
-                        character limit. For code supplied for review, refer to the old code supplied rather than
-                        rewriting the code. Don't supply a corrected version of the code. If response contains any code,
-                        replace parts of it using pseudo code to strictly follow character limit.\s""");
+        ChatMessage setupMessage = new ChatMessage(ChatMessageRole.SYSTEM.value(), """
+                For code supplied for review, refer to the old code supplied rather than
+                rewriting the code. DON'T supply a corrected version of the code.\s""");
         ChatCompletionRequest systemSetupRequest = ChatCompletionRequest.builder()
             .model(AI_MODEL)
             .messages(List.of(setupMessage))
@@ -75,8 +72,9 @@ public class ChatGptService {
         }
 
         try {
-            String questionWithContext = "context: Category %s on a Java Q&A discord server. %s"
-                .formatted(context, question);
+            String instructions = "KEEP IT CONCISE, NOT MORE THAN 500 WORDS";
+            String questionWithContext = "context: Category %s on a Java Q&A discord server. %s %s"
+                .formatted(context, instructions, question);
             ChatMessage chatMessage = new ChatMessage(ChatMessageRole.USER.value(),
                     Objects.requireNonNull(questionWithContext));
             ChatCompletionRequest chatCompletionRequest = ChatCompletionRequest.builder()
@@ -90,7 +88,7 @@ public class ChatGptService {
 
             String response = openAiService.createChatCompletion(chatCompletionRequest)
                 .getChoices()
-                .get(0)
+                .getFirst()
                 .getMessage()
                 .getContent();
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
@@ -68,14 +68,15 @@ public class ChatGptService {
      * @see <a href="https://platform.openai.com/docs/guides/chat/managing-tokens">ChatGPT
      *      Tokens</a>.
      */
-    public Optional<String[]> ask(String question) {
+    public Optional<String[]> ask(String question, String context) {
         if (isDisabled) {
             return Optional.empty();
         }
 
         try {
-            ChatMessage chatMessage =
-                    new ChatMessage(ChatMessageRole.USER.value(), Objects.requireNonNull(question));
+            String questionWithContext = "context: %s  %s".formatted(context, question);
+            ChatMessage chatMessage = new ChatMessage(ChatMessageRole.USER.value(),
+                    Objects.requireNonNull(questionWithContext));
             ChatCompletionRequest chatCompletionRequest = ChatCompletionRequest.builder()
                 .model(AI_MODEL)
                 .messages(List.of(chatMessage))

--- a/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
@@ -46,7 +46,8 @@ public class ChatGptService {
                 """
                         Please answer questions in 1500 characters or less. Remember to count spaces in the
                         character limit. For code supplied for review, refer to the old code supplied rather than
-                        rewriting the code. Don't supply a corrected version of the code.\s""");
+                        rewriting the code. Don't supply a corrected version of the code. If response contains any code,
+                        replace parts of it by pseudo code to strictly follow character limit.\s""");
         ChatCompletionRequest systemSetupRequest = ChatCompletionRequest.builder()
             .model(AI_MODEL)
             .messages(List.of(setupMessage))

--- a/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
@@ -75,7 +75,8 @@ public class ChatGptService {
         }
 
         try {
-            String questionWithContext = "context: %s  %s".formatted(context, question);
+            String questionWithContext =
+                    "context: Category %s on a java q/a server.  %s".formatted(context, question);
             ChatMessage chatMessage = new ChatMessage(ChatMessageRole.USER.value(),
                     Objects.requireNonNull(questionWithContext));
             ChatCompletionRequest chatCompletionRequest = ChatCompletionRequest.builder()

--- a/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
@@ -47,7 +47,7 @@ public class ChatGptService {
                         Please answer questions in 1500 characters or less. Remember to count spaces in the
                         character limit. For code supplied for review, refer to the old code supplied rather than
                         rewriting the code. Don't supply a corrected version of the code. If response contains any code,
-                        replace parts of it by pseudo code to strictly follow character limit.\s""");
+                        replace parts of it using pseudo code to strictly follow character limit.\s""");
         ChatCompletionRequest systemSetupRequest = ChatCompletionRequest.builder()
             .model(AI_MODEL)
             .messages(List.of(setupMessage))
@@ -75,8 +75,8 @@ public class ChatGptService {
         }
 
         try {
-            String questionWithContext =
-                    "context: Category %s on a java q/a server.  %s".formatted(context, question);
+            String questionWithContext = "context: Category %s on a Java Q&A discord server. %s"
+                .formatted(context, question);
             ChatMessage chatMessage = new ChatMessage(ChatMessageRole.USER.value(),
                     Objects.requireNonNull(questionWithContext));
             ChatCompletionRequest chatCompletionRequest = ChatCompletionRequest.builder()

--- a/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
@@ -21,7 +21,30 @@ import java.util.Optional;
 public class ChatGptService {
     private static final Logger logger = LoggerFactory.getLogger(ChatGptService.class);
     private static final Duration TIMEOUT = Duration.ofSeconds(90);
+
+    /** The maximum number of tokens allowed for the generated answer. */
     private static final int MAX_TOKENS = 3_000;
+
+    /**
+     * This parameter reduces the likelihood of the AI repeating itself. A higher frequency penalty
+     * makes the model less likely to repeat the same lines verbatim. It helps in generating more
+     * diverse and varied responses.
+     */
+    private static final double FREQUENCY_PENALTY = 0.5;
+
+    /**
+     * This parameter controls the randomness of the AI's responses. A higher temperature results in
+     * more varied, unpredictable, and creative responses. Conversely, a lower temperature makes the
+     * model's responses more deterministic and conservative.
+     */
+    private static final double TEMPERATURE = 0.8;
+
+    /**
+     * n: This parameter specifies the number of responses to generate for each prompt. If n is more
+     * than 1, the AI will generate multiple different responses to the same prompt, each one being
+     * a separate iteration based on the input.
+     */
+    private static final int MAX_NUMBER_OF_RESPONSES = 1;
     private static final String AI_MODEL = "gpt-3.5-turbo";
 
     private boolean isDisabled = false;
@@ -48,10 +71,10 @@ public class ChatGptService {
         ChatCompletionRequest systemSetupRequest = ChatCompletionRequest.builder()
             .model(AI_MODEL)
             .messages(List.of(setupMessage))
-            .frequencyPenalty(0.5)
-            .temperature(0.3)
+            .frequencyPenalty(FREQUENCY_PENALTY)
+            .temperature(TEMPERATURE)
             .maxTokens(50)
-            .n(1)
+            .n(MAX_NUMBER_OF_RESPONSES)
             .build();
 
         // Sending the system setup message to ChatGPT.
@@ -80,10 +103,10 @@ public class ChatGptService {
             ChatCompletionRequest chatCompletionRequest = ChatCompletionRequest.builder()
                 .model(AI_MODEL)
                 .messages(List.of(chatMessage))
-                .frequencyPenalty(0.5)
-                .temperature(0.3)
+                .frequencyPenalty(FREQUENCY_PENALTY)
+                .temperature(TEMPERATURE)
                 .maxTokens(MAX_TOKENS)
-                .n(1)
+                .n(MAX_NUMBER_OF_RESPONSES)
                 .build();
 
             String response = openAiService.createChatCompletion(chatCompletionRequest)

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpSystemHelper.java
@@ -125,7 +125,8 @@ public final class HelpSystemHelper {
         String question = questionOptional.get();
         logger.debug("The final question sent to chatGPT: {}", question);
 
-        chatGPTAnswer = chatGptService.ask(question);
+        String context = threadChannel.getAppliedTags().getFirst().getName();
+        chatGPTAnswer = chatGptService.ask(question, context);
         if (chatGPTAnswer.isEmpty()) {
             return useChatGptFallbackMessage(threadChannel);
         }
@@ -178,20 +179,6 @@ public final class HelpSystemHelper {
             .min(MAX_QUESTION_LENGTH - questionBuilder.length(), originalQuestion.length()));
 
         questionBuilder.append(originalQuestion);
-
-        StringBuilder tagBuilder = new StringBuilder();
-        int stringLength = questionBuilder.length();
-        for (ForumTag tag : threadChannel.getAppliedTags()) {
-            String tagName = tag.getName();
-            stringLength += tagName.length();
-            if (stringLength > MAX_QUESTION_LENGTH) {
-                break;
-            }
-            tagBuilder.append(String.format("%s ", tagName));
-        }
-
-        questionBuilder.insert(0, tagBuilder);
-
         return Optional.of(questionBuilder.toString());
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpSystemHelper.java
@@ -125,7 +125,10 @@ public final class HelpSystemHelper {
         String question = questionOptional.get();
         logger.debug("The final question sent to chatGPT: {}", question);
 
-        String context = threadChannel.getAppliedTags().getFirst().getName();
+        ForumTag defaultTag = threadChannel.getAppliedTags().getFirst();
+        ForumTag matchingTag = getCategoryTagOfChannel(threadChannel).orElse(defaultTag);
+
+        String context = matchingTag.getName();
         chatGPTAnswer = chatGptService.ask(question, context);
         if (chatGPTAnswer.isEmpty()) {
             return useChatGptFallbackMessage(threadChannel);


### PR DESCRIPTION
resolves #920 
* sets context for responses
* attempts to reduce char limit, **but hard to be consistent or verify it.**
* removes tag builder that is added to question builder

Note: There's no way to generate shorter responses, i could go down to really low using `BRIEF` as a keyword but that's very very short. Imo char limit shouldn't be priority. **We can always paginate the response in embeds**. 

If we cross limit of 2k chars atm, AIResponseParser class will automatically cut it into multiple short messages as mentioned in #928 .

Reducing `MAX_TOKEN` would just lead to lost responses at times.

Bottom Line, when implementing "embeds" for rare responses that go over 4k limit we can either paginate or using gpt again on generated response by dropping more fillers or something otherwise most responses should very well fall under 4k limit.