### PR TITLE
replace getAsTag() with getName() on user entity

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/BanCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/BanCommand.java
@@ -76,8 +76,8 @@ public final class BanCommand extends SlashCommandAdapter {
         String reasonText =
                 reason == null || reason.isBlank() ? "" : " (reason: %s)".formatted(reason);
 
-        String message = "The user '%s' is already banned%s.".formatted(ban.getUser().getAsTag(),
-                reasonText);
+        String message =
+                "The user '%s' is already banned%s.".formatted(ban.getUser().getName(), reasonText);
         return hook.sendMessage(message).setEphemeral(true);
     }
 
@@ -123,7 +123,7 @@ public final class BanCommand extends SlashCommandAdapter {
         }
         logger.warn(LogMarkers.SENSITIVE,
                 "Something unexpected went wrong while trying to ban the user '{}'.",
-                target.getAsTag(), alreadyBannedFailure);
+                target.getName(), alreadyBannedFailure);
         return Optional.of(hook.sendMessage("Failed to ban the user due to an unexpected problem.")
             .setEphemeral(true));
     }
@@ -145,7 +145,7 @@ public final class BanCommand extends SlashCommandAdapter {
                 temporaryData == null ? "permanently" : "for " + temporaryData.duration();
         logger.info(LogMarkers.SENSITIVE,
                 "'{}' ({}) banned the user '{}' ({}) {} from guild '{}' and deleted their message history of the last {} days, for reason '{}'.",
-                author.getUser().getAsTag(), author.getId(), target.getAsTag(), target.getId(),
+                author.getUser().getName(), author.getId(), target.getName(), target.getId(),
                 durationMessage, guild.getName(), deleteHistoryDays, reason);
 
         Instant expiresAt = temporaryData == null ? null : temporaryData.expiresAt();

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/KickCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/KickCommand.java
@@ -81,7 +81,7 @@ public final class KickCommand extends SlashCommandAdapter {
             Guild guild) {
         logger.info(LogMarkers.SENSITIVE,
                 "'{}' ({}) kicked the user '{}' ({}) from guild '{}' for reason '{}'.",
-                author.getUser().getAsTag(), author.getId(), target.getUser().getAsTag(),
+                author.getUser().getName(), author.getId(), target.getUser().getName(),
                 target.getId(), guild.getName(), reason);
 
         actionsStore.addAction(guild.getIdLong(), author.getIdLong(), target.getIdLong(),

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ModerationUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ModerationUtils.java
@@ -86,7 +86,7 @@ public class ModerationUtils {
      */
     public static boolean handleCanInteractWithTarget(String actionVerb, Member bot, Member author,
             Member target, IReplyCallback event) {
-        String targetTag = target.getUser().getAsTag();
+        String targetTag = target.getUser().getName();
         if (!author.canInteract(target)) {
             event
                 .reply("The user %s is too powerful for you to %s.".formatted(targetTag,
@@ -279,8 +279,8 @@ public class ModerationUtils {
      */
     static MessageEmbed createActionResponse(User author, ModerationAction action, User target,
             @Nullable String extraMessage, @Nullable String reason) {
-        String description = "%s **%s** (id: %s).".formatted(action.getVerb(), target.getAsTag(),
-                target.getId());
+        String description =
+                "%s **%s** (id: %s).".formatted(action.getVerb(), target.getName(), target.getId());
         if (extraMessage != null && !extraMessage.isBlank()) {
             description += "\n" + extraMessage;
         }
@@ -290,7 +290,7 @@ public class ModerationUtils {
 
         String avatarOrDefaultUrl = author.getEffectiveAvatarUrl();
 
-        return new EmbedBuilder().setAuthor(author.getAsTag(), null, avatarOrDefaultUrl)
+        return new EmbedBuilder().setAuthor(author.getName(), null, avatarOrDefaultUrl)
             .setDescription(description)
             .setTimestamp(Instant.now())
             .setColor(AMBIENT_COLOR)

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/MuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/MuteCommand.java
@@ -99,7 +99,7 @@ public final class MuteCommand extends SlashCommandAdapter {
                 temporaryData == null ? "permanently" : "for " + temporaryData.duration();
         logger.info(LogMarkers.SENSITIVE,
                 "'{}' ({}) muted the user '{}' ({}) {} in guild '{}' for reason '{}'.",
-                author.getUser().getAsTag(), author.getId(), target.getUser().getAsTag(),
+                author.getUser().getName(), author.getId(), target.getUser().getName(),
                 target.getId(), durationMessage, guild.getName(), reason);
 
         Instant expiresAt = temporaryData == null ? null : temporaryData.expiresAt();

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/NoteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/NoteCommand.java
@@ -83,7 +83,7 @@ public final class NoteCommand extends SlashCommandAdapter {
     private void storeNote(User target, Member author, String content, ISnowflake guild) {
         logger.info(LogMarkers.SENSITIVE,
                 "'{}' ({}) wrote a note about the user '{}' ({}) with content '{}'.",
-                author.getUser().getAsTag(), author.getId(), target.getAsTag(), target.getId(),
+                author.getUser().getName(), author.getId(), target.getName(), target.getId(),
                 content);
 
         actionsStore.addAction(guild.getIdLong(), author.getIdLong(), target.getIdLong(),

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/QuarantineCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/QuarantineCommand.java
@@ -85,7 +85,7 @@ public final class QuarantineCommand extends SlashCommandAdapter {
             Guild guild) {
         logger.info(LogMarkers.SENSITIVE,
                 "'{}' ({}) quarantined the user '{}' ({}) in guild '{}' for reason '{}'.",
-                author.getUser().getAsTag(), author.getId(), target.getUser().getAsTag(),
+                author.getUser().getName(), author.getId(), target.getUser().getName(),
                 target.getId(), guild.getName(), reason);
 
         actionsStore.addAction(guild.getIdLong(), author.getIdLong(), target.getIdLong(),

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/RejoinModerationRoleListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/RejoinModerationRoleListener.java
@@ -97,7 +97,7 @@ public final class RejoinModerationRoleListener implements EventReceiver {
         Guild guild = member.getGuild();
         logger.info(LogMarkers.SENSITIVE,
                 "Reapplied existing {} to user '{}' ({}) in guild '{}' after rejoining.",
-                moderationRole.actionName, member.getUser().getAsTag(), member.getId(),
+                moderationRole.actionName, member.getUser().getName(), member.getId(),
                 guild.getName());
 
         guild.addRoleToMember(member, moderationRole.guildToRole.apply(guild))

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/UnbanCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/UnbanCommand.java
@@ -53,7 +53,7 @@ public final class UnbanCommand extends SlashCommandAdapter {
 
             logger.info(LogMarkers.SENSITIVE,
                     "'{}' ({}) unbanned the user '{}' ({}) from guild '{}' for reason '{}'.",
-                    author.getUser().getAsTag(), author.getId(), target.getAsTag(), target.getId(),
+                    author.getUser().getName(), author.getId(), target.getName(), target.getId(),
                     guild.getName(), reason);
 
             actionsStore.addAction(guild.getIdLong(), author.getIdLong(), target.getIdLong(),
@@ -62,7 +62,7 @@ public final class UnbanCommand extends SlashCommandAdapter {
     }
 
     private static void handleFailure(Throwable unbanFailure, User target, IReplyCallback event) {
-        String targetTag = target.getAsTag();
+        String targetTag = target.getName();
         if (unbanFailure instanceof ErrorResponseException errorResponseException) {
             if (errorResponseException.getErrorResponse() == ErrorResponse.UNKNOWN_USER) {
                 event.reply("The specified user does not exist.").setEphemeral(true).queue();

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/UnmuteCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/UnmuteCommand.java
@@ -81,7 +81,7 @@ public final class UnmuteCommand extends SlashCommandAdapter {
             Guild guild) {
         logger.info(LogMarkers.SENSITIVE,
                 "'{}' ({}) unmuted the user '{}' ({}) in guild '{}' for reason '{}'.",
-                author.getUser().getAsTag(), author.getId(), target.getUser().getAsTag(),
+                author.getUser().getName(), author.getId(), target.getUser().getName(),
                 target.getId(), guild.getName(), reason);
 
         actionsStore.addAction(guild.getIdLong(), author.getIdLong(), target.getIdLong(),

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/UnquarantineCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/UnquarantineCommand.java
@@ -85,7 +85,7 @@ public final class UnquarantineCommand extends SlashCommandAdapter {
             Guild guild) {
         logger.info(LogMarkers.SENSITIVE,
                 "'{}' ({}) unquarantined the user '{}' ({}) in guild '{}' for reason '{}'.",
-                author.getUser().getAsTag(), author.getId(), target.getUser().getAsTag(),
+                author.getUser().getName(), author.getId(), target.getUser().getName(),
                 target.getId(), guild.getName(), reason);
 
         actionsStore.addAction(guild.getIdLong(), author.getIdLong(), target.getIdLong(),

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/WarnCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/WarnCommand.java
@@ -69,7 +69,7 @@ public final class WarnCommand extends SlashCommandAdapter {
 
     private void warnUser(User target, Member author, String reason, Guild guild) {
         logger.info(LogMarkers.SENSITIVE, "'{}' ({}) warned the user '{}' ({}) for reason '{}'.",
-                author.getUser().getAsTag(), author.getId(), target.getAsTag(), target.getId(),
+                author.getUser().getName(), author.getId(), target.getName(), target.getId(),
                 reason);
 
         actionsStore.addAction(guild.getIdLong(), author.getIdLong(), target.getIdLong(),

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/WhoIsCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/WhoIsCommand.java
@@ -140,7 +140,7 @@ public final class WhoIsCommand extends SlashCommandAdapter {
 
         EmbedBuilder embedBuilder = new EmbedBuilder().setThumbnail(user.getEffectiveAvatarUrl())
             .setColor(effectiveColor)
-            .setFooter("Requested by " + event.getUser().getAsTag(),
+            .setFooter("Requested by " + event.getUser().getName(),
                     event.getMember().getEffectiveAvatarUrl())
             .setTimestamp(Instant.now());
 
@@ -175,8 +175,8 @@ public final class WhoIsCommand extends SlashCommandAdapter {
      * @return user readable {@link String}
      */
     private static String userIdentificationToStringItem(final User user) {
-        return "**Mention:** " + user.getAsMention() + "\n**Tag:** " + user.getAsTag()
-                + "\n**ID:** " + user.getId();
+        return "**Mention:** " + user.getAsMention() + "\n**Tag:** " + user.getName() + "\n**ID:** "
+                + user.getId();
     }
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/audit/AuditCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/audit/AuditCommand.java
@@ -138,7 +138,7 @@ public final class AuditCommand extends SlashCommandAdapter {
     private static EmbedBuilder createSummaryEmbed(User user, Collection<ActionRecord> actions) {
         String avatarOrDefaultUrl = user.getEffectiveAvatarUrl();
 
-        return new EmbedBuilder().setTitle("Audit log of **%s**".formatted(user.getAsTag()))
+        return new EmbedBuilder().setTitle("Audit log of **%s**".formatted(user.getName()))
             .setAuthor(user.getName(), null, avatarOrDefaultUrl)
             .setDescription(createSummaryMessageDescription(actions))
             .setColor(ModerationUtils.AMBIENT_COLOR);
@@ -190,7 +190,7 @@ public final class AuditCommand extends SlashCommandAdapter {
 
     private static RestAction<MessageEmbed.Field> actionToField(ActionRecord action, JDA jda) {
         return jda.retrieveUserById(action.authorId())
-            .map(author -> author == null ? "(unknown user)" : author.getAsTag())
+            .map(author -> author == null ? "(unknown user)" : author.getName())
             .map(authorText -> {
                 String expiresAtFormatted = action.actionExpiresAt() == null ? ""
                         : "\nTemporary action, expires at: " + formatTime(action.actionExpiresAt());

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/audit/ModAuditLogRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/audit/ModAuditLogRoutine.java
@@ -334,7 +334,7 @@ public final class ModAuditLogRoutine implements Routine {
     private record AuditLogMessage(User author, Action action, @Nullable User target,
             @Nullable String reason, TemporalAccessor timestamp) {
         MessageEmbed toEmbed() {
-            String targetTag = target == null ? "(user unknown)" : target.getAsTag();
+            String targetTag = target == null ? "(user unknown)" : target.getName();
             String description = "%s **%s**.".formatted(action.getVerb(), targetTag);
 
             if (reason != null && !reason.isBlank()) {
@@ -343,7 +343,7 @@ public final class ModAuditLogRoutine implements Routine {
 
             String avatarOrDefaultUrl = author.getEffectiveAvatarUrl();
 
-            return new EmbedBuilder().setAuthor(author.getAsTag(), null, avatarOrDefaultUrl)
+            return new EmbedBuilder().setAuthor(author.getName(), null, avatarOrDefaultUrl)
                 .setDescription(description)
                 .setTimestamp(timestamp)
                 .setColor(AMBIENT_COLOR)

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/audit/ModAuditLogWriter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/audit/ModAuditLogWriter.java
@@ -69,7 +69,7 @@ public final class ModAuditLogWriter {
             .setTimestamp(timestamp)
             .setColor(EMBED_COLOR);
         if (author != null) {
-            embedBuilder.setAuthor(author.getAsTag(), null, author.getAvatarUrl());
+            embedBuilder.setAuthor(author.getName(), null, author.getAvatarUrl());
         }
 
         MessageCreateAction message =

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/modmail/ModMailCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/modmail/ModMailCommand.java
@@ -204,7 +204,7 @@ public final class ModMailCommand extends SlashCommandAdapter {
     }
 
     private MessageEmbed createModMailMessage(@Nullable User author, String userMessage) {
-        String authorTag = author == null ? "Anonymous" : author.getAsTag();
+        String authorTag = author == null ? "Anonymous" : author.getName();
         String authorAvatar = author == null ? null : author.getAvatarUrl();
         return new EmbedBuilder().setTitle("Modmail")
             .setAuthor(authorTag, null, authorAvatar)

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -237,7 +237,7 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
         MessageEmbed embed =
                 new EmbedBuilder().setDescription(event.getMessage().getContentStripped())
                     .setTitle(reportTitle)
-                    .setAuthor(author.getAsTag(), null, avatarOrDefaultUrl)
+                    .setAuthor(author.getName(), null, avatarOrDefaultUrl)
                     .setTimestamp(event.getMessage().getTimeCreated())
                     .setColor(AMBIENT_COLOR)
                     .setFooter(author.getId())

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/temp/TemporaryModerationRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/temp/TemporaryModerationRoutine.java
@@ -126,7 +126,7 @@ public final class TemporaryModerationRoutine implements Routine {
     private RestAction<Void> executeRevocation(Guild guild, User target,
             ModerationAction actionType) {
         logger.info(LogMarkers.SENSITIVE, "Revoked temporary action {} against user '{}' ({}).",
-                actionType, target.getAsTag(), target.getId());
+                actionType, target.getName(), target.getId());
         RevocableModerationAction action = getRevocableActionByType(actionType);
 
         String reason = "Automatic revocation of temporary action.";

--- a/application/src/main/java/org/togetherjava/tjbot/features/reminder/RemindRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/reminder/RemindRoutine.java
@@ -109,7 +109,7 @@ public final class RemindRoutine implements Routine {
 
     private static MessageEmbed createReminderEmbed(CharSequence content,
             TemporalAccessor createdAt, @Nullable User author) {
-        String authorName = author == null ? "Unknown user" : author.getAsTag();
+        String authorName = author == null ? "Unknown user" : author.getName();
         String authorIconUrl = author == null ? null : author.getAvatarUrl();
 
         return new EmbedBuilder().setAuthor(authorName, null, authorIconUrl)

--- a/application/src/test/java/org/togetherjava/tjbot/features/reminder/RemindRoutineTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/features/reminder/RemindRoutineTest.java
@@ -102,7 +102,7 @@ final class RemindRoutineTest {
         MessageEmbed lastMessage = getLastMessageFrom(jdaTester.getTextChannelSpy());
         assertEquals(reminderContent, lastMessage.getDescription());
         assertSimilar(remindAt, lastMessage.getTimestamp().toInstant());
-        assertEquals(author.getUser().getAsTag(), lastMessage.getAuthor().getName());
+        assertEquals(author.getUser().getName(), lastMessage.getAuthor().getName());
     }
 
     @Test

--- a/application/src/test/java/org/togetherjava/tjbot/features/reminder/RemindRoutineTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/features/reminder/RemindRoutineTest.java
@@ -145,7 +145,7 @@ final class RemindRoutineTest {
         MessageEmbed lastMessage = getLastMessageFrom(jdaTester.getPrivateChannelSpy());
         assertEquals(reminderContent, lastMessage.getDescription());
         assertSimilar(remindAt, lastMessage.getTimestamp().toInstant());
-        assertEquals(author.getUser().getAsTag(), lastMessage.getAuthor().getName());
+        assertEquals(author.getUser().getName(), lastMessage.getAuthor().getName());
     }
 
     @Test

--- a/application/src/test/java/org/togetherjava/tjbot/jda/JdaTester.java
+++ b/application/src/test/java/org/togetherjava/tjbot/jda/JdaTester.java
@@ -132,7 +132,9 @@ public final class JdaTester {
         when(jda.getCacheFlags()).thenReturn(EnumSet.noneOf(CacheFlag.class));
 
         SelfUserImpl selfUser = spy(new SelfUserImpl(SELF_USER_ID, jda));
+        selfUser.setName("Self Tester");
         UserImpl user = spy(new UserImpl(USER_ID, jda));
+        user.setName("John Doe Tester");
         guild = spy(new GuildImpl(jda, GUILD_ID));
         Member selfMember = spy(new MemberImpl(guild, selfUser));
         member = spy(new MemberImpl(guild, user));


### PR DESCRIPTION
replaces User#getAsTag() with User#getName() throughout code, except 
`RemindRoutine.java`, `RemindRoutineTest.java`(facing some issues in two tests from RemindRoutineTest)
 and `FilesharingListener.java` (already active PR)

