### PR TITLE
Fix: Pre-commit hook includes untracked files in commits

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -44,8 +44,8 @@ if [ "$spotlessExitCode" -ne 0 ]; then
   exit "$spotlessExitCode"
 fi
 
-# Spotless possibly found changes, apply them
-git add -A
+# Spotless possibly found changes, apply them, excluding untracked files
+git add -u
 
 # Restore back the unstaged changes
 pop_stash


### PR DESCRIPTION
Fixes #1039.

With this pull request, untracked files do not get included in commits handled by the pre-commit hook.

**Screenshots**
<img width="1154" alt="image" src="https://github.com/Together-Java/TJ-Bot/assets/26795353/5bf311a2-98e4-4b82-9ffe-12e000f854ab">
<img width="1193" alt="image" src="https://github.com/Together-Java/TJ-Bot/assets/26795353/e929e6ce-3153-4b4f-8b95-359aa6dbc7f0">
<img width="2538" alt="image" src="https://github.com/Together-Java/TJ-Bot/assets/26795353/36f75e2d-3fa5-4e98-a5ed-3f79183edc37">
