### PR TITLE
Title generation by ChatGPT for transfer-questions command

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/Features.java
@@ -133,7 +133,7 @@ public class Features {
         features.add(new HelpThreadCreatedListener(helpSystemHelper));
 
         // Message context commands
-        features.add(new TransferQuestionCommand(config));
+        features.add(new TransferQuestionCommand(config, chatGptService));
 
         // User context commands
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -32,6 +32,7 @@ import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.features.BotCommandAdapter;
 import org.togetherjava.tjbot.features.CommandVisibility;
 import org.togetherjava.tjbot.features.MessageContextCommand;
+import org.togetherjava.tjbot.features.chatgpt.ChatGptService;
 import org.togetherjava.tjbot.features.utils.StringDistances;
 
 import java.awt.Color;
@@ -64,20 +65,23 @@ public final class TransferQuestionCommand extends BotCommandAdapter
     private static final int INPUT_MIN_LENGTH = 3;
     private final Predicate<String> isHelpForumName;
     private final List<String> tags;
+    private final ChatGptService chatGptService;
 
 
     /**
      * Creates a new instance.
      *
      * @param config to get the helper forum and tags
+     * @param chatGptService the service used to ask ChatGPT questions via the API.
      */
-    public TransferQuestionCommand(Config config) {
+    public TransferQuestionCommand(Config config, ChatGptService chatGptService) {
         super(Commands.message(COMMAND_NAME), CommandVisibility.GUILD);
 
         isHelpForumName =
                 Pattern.compile(config.getHelpSystem().getHelpForumPattern()).asMatchPredicate();
 
         tags = config.getHelpSystem().getCategories();
+        this.chatGptService = chatGptService;
     }
 
     @Override
@@ -92,12 +96,20 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         String originalChannelId = event.getTarget().getChannel().getId();
         String authorId = event.getTarget().getAuthor().getId();
         String mostCommonTag = tags.get(0);
+        String chatGptPrompt =
+                "generate title for this question %s, it shouldn't be longer than 4-5 words with no header"
+                    .formatted(originalMessage);
+        Optional<String> chatGptResponse = chatGptService.ask(chatGptPrompt, "");
+        String title = chatGptResponse.orElse(createTitle(originalMessage));
+        if (title.length() > TITLE_MAX_LENGTH) {
+            title = title.substring(0, TITLE_MAX_LENGTH);
+        }
 
         TextInput modalTitle = TextInput.create(MODAL_TITLE_ID, "Title", TextInputStyle.SHORT)
             .setMaxLength(TITLE_MAX_LENGTH)
             .setMinLength(TITLE_MIN_LENGTH)
             .setPlaceholder("Describe the question in short")
-            .setValue(createTitle(originalMessage))
+            .setValue(title)
             .build();
 
         Builder modalInputBuilder =

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -97,7 +97,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         String authorId = event.getTarget().getAuthor().getId();
         String mostCommonTag = tags.get(0);
         String chatGptPrompt =
-                "generate title for this question %s, it shouldn't be longer than 4-5 words with no header"
+                "Summarize the following text into a concise title or heading not more than 4-5 words, remove quotations if any: %s"
                     .formatted(originalMessage);
         Optional<String> chatGptResponse = chatGptService.ask(chatGptPrompt, "");
         String title = chatGptResponse.orElse(createTitle(originalMessage));


### PR DESCRIPTION
Previously, the title was simply created by putting the message when /transfer-questions command was invoked. The title had to be written by a human for clarity. This PR solves that issue by using ChatGPT for title generation. #1011 

![question](https://github.com/Together-Java/TJ-Bot/assets/55508798/68b0005b-db5a-4f7c-8e07-33cc1fc9d3fc)
![response](https://github.com/Together-Java/TJ-Bot/assets/55508798/c2be62b4-796d-4814-9783-c8c98d249b9b)

