### PR TITLE
fixed dismiss buttons

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/code/CodeMessageHandler.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/code/CodeMessageHandler.java
@@ -149,6 +149,9 @@ public final class CodeMessageHandler extends MessageReceiverAdapter implements 
     @Override
     public void onButtonClick(ButtonInteractionEvent event, List<String> args) {
         long originalMessageId = Long.parseLong(args.get(0));
+
+        event.deferEdit().queue();
+
         // The third arg indicates a non-code-action button
         if (args.size() >= 3 && DELETE_CUE.equals(args.get(2))) {
             deleteCodeReply(event, originalMessageId);
@@ -156,7 +159,6 @@ public final class CodeMessageHandler extends MessageReceiverAdapter implements 
         }
 
         CodeAction codeAction = getActionOfEvent(event);
-        event.deferEdit().queue();
 
         // User decided for an action, apply it to the code
         event.getChannel()
@@ -189,7 +191,7 @@ public final class CodeMessageHandler extends MessageReceiverAdapter implements 
                 event.getUser().getId(), originalMessageId, event.getChannel().getName());
 
         originalMessageToCodeReply.invalidate(originalMessageId);
-        event.getMessage().delete().queue();
+        event.getHook().deleteOriginal().queue();
     }
 
     private CodeAction getActionOfEvent(ButtonInteractionEvent event) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/filesharing/FileSharingMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/filesharing/FileSharingMessageListener.java
@@ -99,19 +99,19 @@ public final class FileSharingMessageListener extends MessageReceiverAdapter
     public void onButtonClick(ButtonInteractionEvent event, List<String> args) {
         Member interactionUser = event.getMember();
         String gistAuthorId = args.get(0);
+        String gistId = args.get(1);
         boolean hasSoftModPermissions =
                 interactionUser.getRoles().stream().map(Role::getName).anyMatch(isSoftModRole);
 
         if (!gistAuthorId.equals(interactionUser.getId()) && !hasSoftModPermissions) {
-            event.reply("You do not have permission for this action.").setEphemeral(true).queue();
+            event.reply("You do not have permission for this action.").queue();
             return;
         }
 
-        String gistId = args.get(1);
-
         try {
             new GitHubBuilder().withOAuthToken(githubApiKey).build().getGist(gistId).delete();
-            event.getMessage().delete().queue();
+            event.deferEdit().queue();
+            event.getHook().deleteOriginal().queue();
         } catch (IOException e) {
             logger.warn("Failed to delete gist with id {}", gistId, e);
         }

--- a/application/src/main/java/org/togetherjava/tjbot/features/filesharing/FileSharingMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/filesharing/FileSharingMessageListener.java
@@ -99,7 +99,6 @@ public final class FileSharingMessageListener extends MessageReceiverAdapter
     public void onButtonClick(ButtonInteractionEvent event, List<String> args) {
         Member interactionUser = event.getMember();
         String gistAuthorId = args.get(0);
-        String gistId = args.get(1);
         boolean hasSoftModPermissions =
                 interactionUser.getRoles().stream().map(Role::getName).anyMatch(isSoftModRole);
 
@@ -107,6 +106,8 @@ public final class FileSharingMessageListener extends MessageReceiverAdapter
             event.reply("You do not have permission for this action.").setEphemeral(true).queue();
             return;
         }
+
+        String gistId = args.get(1);
 
         try {
             new GitHubBuilder().withOAuthToken(githubApiKey).build().getGist(gistId).delete();

--- a/application/src/main/java/org/togetherjava/tjbot/features/filesharing/FileSharingMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/filesharing/FileSharingMessageListener.java
@@ -104,7 +104,7 @@ public final class FileSharingMessageListener extends MessageReceiverAdapter
                 interactionUser.getRoles().stream().map(Role::getName).anyMatch(isSoftModRole);
 
         if (!gistAuthorId.equals(interactionUser.getId()) && !hasSoftModPermissions) {
-            event.reply("You do not have permission for this action.").queue();
+            event.reply("You do not have permission for this action.").setEphemeral(true).queue();
             return;
         }
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/mathcommands/TeXCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/mathcommands/TeXCommand.java
@@ -170,6 +170,7 @@ public final class TeXCommand extends SlashCommandAdapter {
                 .queue();
             return;
         }
-        event.getMessage().delete().queue();
+        event.deferReply().queue();
+        event.getHook().deleteOriginal().queue();
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/mathcommands/TeXCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/mathcommands/TeXCommand.java
@@ -170,7 +170,7 @@ public final class TeXCommand extends SlashCommandAdapter {
                 .queue();
             return;
         }
-        event.deferReply().queue();
+        event.deferEdit().queue();
         event.getHook().deleteOriginal().queue();
     }
 }


### PR DESCRIPTION
 after the latest jda-upgrade, deleting self message gives "Unkown Webhook" Error, to fix we first need to defer reply to the event
 
 replacing `getMessage().delete()` with `deferEdit().deleteOriginal()` in
 * Tex command
 * tags command
 * File Sharing Listener