### PR TITLE
handle threads when authorId found

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -127,9 +127,7 @@ public final class HelpThreadAutoArchiver implements Routine {
     private void handleArchiveFlow(ThreadChannel threadChannel, MessageEmbed embed) {
         helper.getAuthorByHelpThreadId(threadChannel.getIdLong()).ifPresentOrElse(authorId -> {
             triggerArchiveFlow(threadChannel, authorId, embed);
-        }, () -> {
-            triggerAuthorIdNotFoundArchiveFlow(threadChannel, embed);
-        });
+        }, () -> triggerAuthorIdNotFoundArchiveFlow(threadChannel, embed));
     }
 
     private void triggerArchiveFlow(ThreadChannel threadChannel, long authorId,

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -125,9 +125,9 @@ public final class HelpThreadAutoArchiver implements Routine {
     }
 
     private void handleArchiveFlow(ThreadChannel threadChannel, MessageEmbed embed) {
-        helper.getAuthorByHelpThreadId(threadChannel.getIdLong()).ifPresentOrElse(authorId -> {
-            triggerArchiveFlow(threadChannel, authorId, embed);
-        }, () -> triggerAuthorIdNotFoundArchiveFlow(threadChannel, embed));
+        helper.getAuthorByHelpThreadId(threadChannel.getIdLong())
+            .ifPresentOrElse(authorId -> triggerArchiveFlow(threadChannel, authorId, embed),
+                    () -> triggerAuthorIdNotFoundArchiveFlow(threadChannel, embed));
     }
 
     private void triggerArchiveFlow(ThreadChannel threadChannel, long authorId,

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -159,6 +159,10 @@ public final class HelpThreadAutoArchiver implements Routine {
 
     private void triggerAuthorIdNotFoundArchiveFlow(ThreadChannel threadChannel,
             MessageEmbed embed) {
+
+        logger.info(
+                "Was unable to find a matching thread for id: {} in DB, archiving thread without mentioning OP",
+                threadChannel.getId());
         threadChannel.sendMessageEmbeds(embed)
             .flatMap(sentEmbed -> threadChannel.getManager().setArchived(true))
             .queue();


### PR DESCRIPTION
Resolves #1067 
Error:
when retrieving threads from DB, helper method would try to get active thread channel and match it's ID with thread record from DB. If a match happens, it would then grab authorID from that record and go on with rest of archive flow (retrieve user and then chooses to archive thread with or without mentioning author based on results)


Changes:
* Dividing archive logic into two parts, if a record match happens in DB aka authorId is found or not
    * `triggerArchiveFlow`
    * `triggerAuthorIdNotFoundArchiveFlow`