### PR TITLE
Implementing support for more accurate github embed colors

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/github/GitHubReference.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/github/GitHubReference.java
@@ -194,18 +194,15 @@ public final class GitHubReference extends MessageReceiverAdapter {
                 return MERGED_STATE;
             } else if (pR.isDraft()) {
                 return DRAFT_STATE;
-            } else {
-                return issue.getState() == GHIssueState.OPEN ? OPEN_STATE : CLOSE_STATE;
             }
         } else {
             if (issue.getStateReason() == GHIssueStateReason.COMPLETED) {
                 return MERGED_STATE;
             } else if (issue.getStateReason() == GHIssueStateReason.NOT_PLANNED) {
                 return NOT_PLANNED_STATE;
-            } else {
-                return issue.getState() == GHIssueState.OPEN ? OPEN_STATE : CLOSE_STATE;
             }
         }
+        return issue.getState() == GHIssueState.OPEN ? OPEN_STATE : CLOSE_STATE;
     }
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/features/github/GitHubReference.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/github/GitHubReference.java
@@ -45,7 +45,7 @@ public final class GitHubReference extends MessageReceiverAdapter {
             Pattern.compile("#(?<%s>\\d{1,5})".formatted(ID_GROUP));
     private static final int ISSUE_OPEN = Color.green.getRGB();
     private static final int ISSUE_CLOSE = Color.red.getRGB();
-    private static final int ISSUE_COMPLETE = Color.magenta.getRGB();
+    private static final int ISSUE_COMPLETE = new Color(141, 106, 187).getRGB();
     private static final int ISSUE_NOT_PLANNED = Color.gray.getRGB();
 
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/github/GitHubReference.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/github/GitHubReference.java
@@ -45,11 +45,11 @@ public final class GitHubReference extends MessageReceiverAdapter {
             Pattern.compile("#(?<%s>\\d{1,5})".formatted(ID_GROUP));
 
     // Representing different GitHub states of an Issue/PR
-    private static final int OPEN_STATE = Color.green.getRGB();
-    private static final int CLOSE_STATE = Color.red.getRGB();
-    private static final int MERGED_STATE = new Color(141, 106, 187).getRGB();
-    private static final int NOT_PLANNED_STATE = new Color(72, 72, 72).getRGB();
-    private static final int DRAFT_STATE = Color.gray.getRGB();
+    private static final Color OPEN_STATE = Color.green;
+    private static final Color CLOSE_STATE = Color.red;
+    private static final Color MERGED_STATE = new Color(141, 106, 187);
+    private static final Color NOT_PLANNED_STATE = new Color(72, 72, 72);
+    private static final Color DRAFT_STATE = Color.gray;
 
 
     /**
@@ -173,7 +173,7 @@ public final class GitHubReference extends MessageReceiverAdapter {
             String dateOfCreation = FORMATTER.format(createdAt);
 
             String footer = "%s • %s • %s".formatted(labels, assignees, dateOfCreation);
-            return new EmbedBuilder().setColor(getIssueState(issue))
+            return new EmbedBuilder().setColor(getIssueStateColor(issue))
                 .setTitle(title, titleUrl)
                 .setDescription(description)
                 .setAuthor(issue.getUser().getName(), null, issue.getUser().getAvatarUrl())
@@ -188,11 +188,11 @@ public final class GitHubReference extends MessageReceiverAdapter {
     /**
      * Returns the state of the issue/PR
      */
-    private int getIssueState(GHIssue issue) throws IOException {
-        if (issue instanceof GHPullRequest pR) {
-            if (pR.isMerged()) {
+    private Color getIssueStateColor(GHIssue issue) throws IOException {
+        if (issue instanceof GHPullRequest pr) {
+            if (pr.isMerged()) {
                 return MERGED_STATE;
-            } else if (pR.isDraft()) {
+            } else if (pr.isDraft()) {
                 return DRAFT_STATE;
             }
         } else {

--- a/application/src/main/java/org/togetherjava/tjbot/features/github/GitHubReference.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/github/GitHubReference.java
@@ -186,7 +186,7 @@ public final class GitHubReference extends MessageReceiverAdapter {
     }
 
     /**
-     * Returns the state of the issue/PR
+     * Returns the color based on the state of the issue/PR
      */
     private Color getIssueStateColor(GHIssue issue) throws IOException {
         if (issue instanceof GHPullRequest pr) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/github/GitHubReference.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/github/GitHubReference.java
@@ -45,6 +45,9 @@ public final class GitHubReference extends MessageReceiverAdapter {
             Pattern.compile("#(?<%s>\\d{1,5})".formatted(ID_GROUP));
     private static final int ISSUE_OPEN = Color.green.getRGB();
     private static final int ISSUE_CLOSE = Color.red.getRGB();
+    private static final int ISSUE_COMPLETE = Color.magenta.getRGB();
+    private static final int ISSUE_NOT_PLANNED = Color.gray.getRGB();
+
 
     /**
      * A constant representing the date and time formatter used for formatting the creation date of
@@ -167,9 +170,7 @@ public final class GitHubReference extends MessageReceiverAdapter {
             String dateOfCreation = FORMATTER.format(createdAt);
 
             String footer = "%s • %s • %s".formatted(labels, assignees, dateOfCreation);
-
-            return new EmbedBuilder()
-                .setColor(issue.getState() == GHIssueState.OPEN ? ISSUE_OPEN : ISSUE_CLOSE)
+            return new EmbedBuilder().setColor(getIssueState(issue))
                 .setTitle(title, titleUrl)
                 .setDescription(description)
                 .setAuthor(issue.getUser().getName(), null, issue.getUser().getAvatarUrl())
@@ -178,6 +179,19 @@ public final class GitHubReference extends MessageReceiverAdapter {
 
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
+        }
+    }
+
+    /**
+     * Returns the state of the issue
+     */
+    private int getIssueState(GHIssue issue) {
+        if (issue.getStateReason() == GHIssueStateReason.COMPLETED) {
+            return ISSUE_COMPLETE;
+        } else if (issue.getStateReason() == GHIssueStateReason.NOT_PLANNED) {
+            return ISSUE_NOT_PLANNED;
+        } else {
+            return issue.getState() == GHIssueState.OPEN ? ISSUE_OPEN : ISSUE_CLOSE;
         }
     }
 


### PR DESCRIPTION
This is for issue #1074 - Make the github embed have more accurate colors

**What I have Done:**

1. For issues that are "**completed**", they become purple as it is assumed their PR's have been merged. 

**Before:**
![image](https://github.com/Together-Java/TJ-Bot/assets/101219745/76a6db88-77be-4ac9-92eb-d53490d994db) 
**After:**
![image](https://github.com/Together-Java/TJ-Bot/assets/101219745/30f73094-813a-4aa0-b52e-8585608e33b4)

2. For issues that are **"not planned"**, they become gray.

**Before:**
![image](https://github.com/Together-Java/TJ-Bot/assets/101219745/02e10780-528c-4539-a660-4d979e9c093c) 
**After:**
![image](https://github.com/Together-Java/TJ-Bot/assets/101219745/d7128e59-7c19-4700-8929-49a4f4a9f038)

3.For PR's that are **"drafts"**, they become gray but lighter than **"not planned"** issues, so that it could be differentiated.

**Before:**
![image](https://github.com/Together-Java/TJ-Bot/assets/101219745/3d3f6a37-bb98-47b1-9af2-1e66b7dc6186)
**After:**
![image](https://github.com/Together-Java/TJ-Bot/assets/101219745/b12156bd-ffb4-4e9a-8ad1-e81f0b1ccc19)

4. For PR's that are **"Merged"**, they become purple.

**Before:**
![image](https://github.com/Together-Java/TJ-Bot/assets/101219745/d7109227-8a57-481a-91b7-6578a1bdbab0)
**After:**
![image](https://github.com/Together-Java/TJ-Bot/assets/101219745/627af7af-5f75-43b6-b2f8-67d2015718ef)


