### PR TITLE
refactor HelpThreadCreatedListener

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadCreatedListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadCreatedListener.java
@@ -9,10 +9,12 @@ import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
-import net.dv8tion.jda.api.events.channel.ChannelCreateEvent;
+import net.dv8tion.jda.api.entities.channel.unions.IThreadContainerUnion;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.requests.RestAction;
+import org.jetbrains.annotations.NotNull;
 
 import org.togetherjava.tjbot.features.EventReceiver;
 import org.togetherjava.tjbot.features.UserInteractionType;
@@ -56,20 +58,19 @@ public final class HelpThreadCreatedListener extends ListenerAdapter
     }
 
     @Override
-    public void onChannelCreate(ChannelCreateEvent createEvent) {
-        if (!createEvent.getChannelType().isThread()) {
-            return;
+    public void onMessageReceived(@NotNull MessageReceivedEvent event) {
+        if (event.isFromThread()) {
+            IThreadContainerUnion parentChannel =
+                    event.getChannel().asThreadChannel().getParentChannel();
+            if (helper.isHelpForumName(parentChannel.getName())) {
+                ThreadChannel threadChannel = event.getChannel().asThreadChannel();
+                int messageCount = threadChannel.getMessageCount();
+                if (messageCount > 1 || wasThreadAlreadyHandled(threadChannel.getIdLong())) {
+                    return;
+                }
+                handleHelpThreadCreated(threadChannel);
+            }
         }
-        ThreadChannel threadChannel = createEvent.getChannel().asThreadChannel();
-
-        if (wasThreadAlreadyHandled(threadChannel.getIdLong())) {
-            return;
-        }
-
-        if (!helper.isHelpForumName(threadChannel.getParentChannel().getName())) {
-            return;
-        }
-        handleHelpThreadCreated(threadChannel);
     }
 
     private boolean wasThreadAlreadyHandled(long threadChannelId) {
@@ -82,23 +83,10 @@ public final class HelpThreadCreatedListener extends ListenerAdapter
     }
 
     private void handleHelpThreadCreated(ThreadChannel threadChannel) {
-        threadChannel.retrieveMessageById(threadChannel.getIdLong()).queue(message -> {
-
-            long authorId = threadChannel.getOwnerIdLong();
-
-            if (isPostedBySelfUser(message)) {
-                // When transfer-command is used
-                authorId = getMentionedAuthorByMessage(message).getIdLong();
-            }
-
-            helper.writeHelpThreadToDatabase(authorId, threadChannel);
-        });
-
-        // The creation is delayed, because otherwise it could be too fast and be executed
-        // after Discord created the thread, but before Discord send OPs initial message.
-        // Sending messages at that moment is not allowed.
-        createMessages(threadChannel).and(pinOriginalQuestion(threadChannel))
-            .queueAfter(5, TimeUnit.SECONDS);
+        threadChannel.retrieveMessageById(threadChannel.getIdLong()).flatMap(message -> {
+            registerThreadDataInDB(message, threadChannel);
+            return generateAutomatedResponse(threadChannel);
+        }).flatMap(message -> pinOriginalQuestion(threadChannel)).queue();
     }
 
     private static User getMentionedAuthorByMessage(Message message) {
@@ -126,7 +114,7 @@ public final class HelpThreadCreatedListener extends ListenerAdapter
         return threadChannel.retrieveMessageById(threadChannel.getIdLong()).flatMap(Message::pin);
     }
 
-    private RestAction<Message> createMessages(ThreadChannel threadChannel) {
+    private RestAction<Message> generateAutomatedResponse(ThreadChannel threadChannel) {
         return sendHelperHeadsUp(threadChannel).flatMap(any -> createAIResponse(threadChannel));
     }
 
@@ -227,5 +215,16 @@ public final class HelpThreadCreatedListener extends ListenerAdapter
             deleteMessages = deleteMessages.and(channel.deleteMessageById(id));
         }
         deleteMessages.queue();
+    }
+
+    private void registerThreadDataInDB(Message message, ThreadChannel threadChannel) {
+        long authorId = threadChannel.getOwnerIdLong();
+
+        if (isPostedBySelfUser(message)) {
+            // When transfer-command is used
+            authorId = getMentionedAuthorByMessage(message).getIdLong();
+        }
+
+        helper.writeHelpThreadToDatabase(authorId, threadChannel);
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadCreatedListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadCreatedListener.java
@@ -7,9 +7,9 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.Channel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
-import net.dv8tion.jda.api.entities.channel.unions.IThreadContainerUnion;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -60,8 +60,7 @@ public final class HelpThreadCreatedListener extends ListenerAdapter
     @Override
     public void onMessageReceived(@NotNull MessageReceivedEvent event) {
         if (event.isFromThread()) {
-            IThreadContainerUnion parentChannel =
-                    event.getChannel().asThreadChannel().getParentChannel();
+            Channel parentChannel = event.getChannel().asThreadChannel().getParentChannel();
             if (helper.isHelpForumName(parentChannel.getName())) {
                 ThreadChannel threadChannel = event.getChannel().asThreadChannel();
                 int messageCount = threadChannel.getMessageCount();
@@ -83,7 +82,7 @@ public final class HelpThreadCreatedListener extends ListenerAdapter
     }
 
     private void handleHelpThreadCreated(ThreadChannel threadChannel) {
-        threadChannel.retrieveMessageById(threadChannel.getIdLong()).flatMap(message -> {
+        threadChannel.retrieveStartMessage().flatMap(message -> {
             registerThreadDataInDB(message, threadChannel);
             return generateAutomatedResponse(threadChannel);
         }).flatMap(message -> pinOriginalQuestion(threadChannel)).queue();


### PR DESCRIPTION
Resolving error:
![image](https://github.com/Together-Java/TJ-Bot/assets/61616007/b91c1fc3-38eb-42d1-a839-d19c5bb1d9e1)

more context for bugfix : [discord conversation](https://discord.com/channels/272761734820003841/895717328359153664/1221775843286843402)

replacing `onChannelCreate` with `onMessageRecieved` for `HelpThreadCreatedListenerFlow` this also ensures that we no longer need `additional delay` in creating automated response or gpt response. Not only makes code a bit less complex but also possibly resolves this error around `unknown message` 
* move write to db in a method
* use messageRecieved instead of onChannelCreate
* rename createMessages to generateAutomatedResponse
* chain generateAutomatedResponse and pinOriginal to retreiveMessage rest action