### PR TITLE
chore: rename ban history options to be clearer

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/BanCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/BanCommand.java
@@ -66,7 +66,7 @@ public final class BanCommand extends SlashCommandAdapter {
             .addOption(OptionType.STRING, REASON_OPTION, "Why the user should be banned", true)
             .addOptions(new OptionData(OptionType.INTEGER, DELETE_HISTORY_OPTION,
                     "the amount of days of the message history to delete, none means no messages are deleted.",
-                    true).addChoice("none", 0).addChoice("recent", 1).addChoice("all", 7));
+                    true).addChoice("none", 0).addChoice("day", 1).addChoice("week", 7));
 
         this.actionsStore = Objects.requireNonNull(actionsStore);
     }


### PR DESCRIPTION
Updates the delete history options as follows:
recent => day
all => week

To make how much is cleared clearer.

Resolves #1081 