### PR TITLE
Fix: Pinned Threads Archiving Issue #1084 

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -79,6 +79,9 @@ public final class HelpThreadAutoArchiver implements Routine {
     }
 
     private void autoArchiveForThread(ThreadChannel threadChannel, Instant archiveAfterMoment) {
+        // if threadChannel is pinned then do not archive it!
+        if (threadChannel.isPinned())
+            return;
         if (shouldBeArchived(threadChannel, archiveAfterMoment)) {
             logger.debug("Auto archiving help thread {}", threadChannel.getId());
 


### PR DESCRIPTION
This pull request solves the problem outlined in issue #1084, where pinned threads in the "questions" forum were being archived by the auto-archiving routine. 


**Testing:**
For testing purposes i used SCHEDULE_MINUTES = 1 and ARCHIVE_AFTER_INACTIVITY_OF = 100 seconds


**Screenshots:**

<img width="500" alt="before PR" src="https://github.com/Together-Java/TJ-Bot/assets/101461017/e9090544-255e-4412-9e45-f63b8ff51201">

_**After INACTIVITY**_

<img width="500" alt="after PR" src="https://github.com/Together-Java/TJ-Bot/assets/101461017/f681fcd0-22f9-4a25-b7a0-e9bd3a672d2e">


[Screen recording of test](https://drive.google.com/file/d/1jd29RrAsNJUkGIQv4SYQpeoA5MVH_54e/view?usp=sharing)
