### PR TITLE
using a better method to retrieve start message for thread

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadCreatedListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadCreatedListener.java
@@ -97,8 +97,7 @@ public final class HelpThreadCreatedListener extends ListenerAdapter
     }
 
     private RestAction<Message> createAIResponse(ThreadChannel threadChannel) {
-        RestAction<Message> originalQuestion =
-                threadChannel.retrieveMessageById(threadChannel.getIdLong());
+        RestAction<Message> originalQuestion = threadChannel.retrieveStartMessage();
         return originalQuestion.flatMap(HelpThreadCreatedListener::isContextSufficient,
                 message -> helper.constructChatGptAttempt(threadChannel, getMessageContent(message),
                         componentIdInteractor));
@@ -172,7 +171,7 @@ public final class HelpThreadCreatedListener extends ListenerAdapter
         ThreadChannel channel = event.getChannel().asThreadChannel();
         Member interactionUser = Objects.requireNonNull(event.getMember());
 
-        channel.retrieveMessageById(channel.getId())
+        channel.retrieveStartMessage()
             .queue(forumPostMessage -> handleDismiss(interactionUser, channel, forumPostMessage,
                     event, args));
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadCreatedListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadCreatedListener.java
@@ -110,7 +110,7 @@ public final class HelpThreadCreatedListener extends ListenerAdapter
     }
 
     private RestAction<Void> pinOriginalQuestion(ThreadChannel threadChannel) {
-        return threadChannel.retrieveMessageById(threadChannel.getIdLong()).flatMap(Message::pin);
+        return threadChannel.retrieveStartMessage().flatMap(Message::pin);
     }
 
     private RestAction<Message> generateAutomatedResponse(ThreadChannel threadChannel) {


### PR DESCRIPTION

![image](https://github.com/Together-Java/TJ-Bot/assets/61616007/4334584c-8236-41e8-a32e-2644df10a80f)

Earlier speculation around this issue in this PR https://github.com/Together-Java/TJ-Bot/pull/1078 were "delay" in thread creation resulted in such behaviour. Method responsible for pinning question to said channel, also rely on earlier way of retrieving thread messages. This is not just better way to retrieve such message but also should possibly fix the above error around unknown message.
