### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
Created a .gitattributes to enforce LF encoding. On Windows when I ran spotless, it changes the line encoding to CFRL which is incorrect. 