### PR TITLE
Feature: Add useful links to ChatGPT response

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpSystemHelper.java
@@ -211,6 +211,10 @@ public final class HelpSystemHelper {
             .min(MAX_QUESTION_LENGTH - questionBuilder.length(), originalQuestion.length()));
 
         questionBuilder.append(originalQuestion);
+
+        questionBuilder.append(
+                ". If possible, get, maximum, 5 top links from reliable websites as references in markdown syntax. Put this message on top of the links list \"Here are some links that may help :\".");
+
         return Optional.of(questionBuilder.toString());
     }
 


### PR DESCRIPTION
This PR  is linked to issue (#991). 

it seems the initial idea is impossible to solve (significant challenge for a small purpose), but I found a way to do it under the OpenAI integration. i'd like to give a recap about the approaches ive followed:

### Initial Idea :
Fetching messages from the server itself and compute 5 top links based on given criteria. This approach was found to be inadequate due to the high volume of responses and lack of message quality indicators such as upvotes or marked correct answers.

### To External Resources :
To improve the quality of responses, i've explored fetching relevant links from Google and [Stack Exchange API](https://api.stackexchange.com/). While this provided some relevant results, it was challenging to filter out irrelevant links and manage long query strings effectively with previous Discord constraints.

### Final Solution: Appending References to AI Generated Responses :
To address these challenges, I implemented an easy solution that combines AI-generated answers with references to reliable external links. by appending a small msg, to include up to five relevant links from reliable websites at the end of the response.

**Screenshot :**
![image](https://github.com/Together-Java/TJ-Bot/assets/37019463/cb0a0c92-9640-44d5-b34b-145781ca23a4)
