### PR TITLE
inconsistency in titles generated by GPT #fixed

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -96,14 +96,17 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         String originalChannelId = event.getTarget().getChannel().getId();
         String authorId = event.getTarget().getAuthor().getId();
         String mostCommonTag = tags.getFirst();
+        final int TITLE_MAX_LENGTH = 50;
         String chatGptPrompt =
                 "Summarize the following text into a concise title or heading not more than 4-5 words, remove quotations if any: %s"
                     .formatted(originalMessage);
         Optional<String> chatGptResponse = chatGptService.ask(chatGptPrompt, "");
         String title = chatGptResponse.orElse(createTitle(originalMessage));
+        title = title.replaceAll("^\"|\"$", "").replaceAll("^'|'$", "");
         if (title.length() > TITLE_MAX_LENGTH) {
             title = title.substring(0, TITLE_MAX_LENGTH);
         }
+
 
         TextInput modalTitle = TextInput.create(MODAL_TITLE_ID, "Title", TextInputStyle.SHORT)
             .setMaxLength(TITLE_MAX_LENGTH)
@@ -176,8 +179,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
             .retrieveUserById(authorId)
             .flatMap(fetchedUser -> createForumPost(event, fetchedUser))
             .flatMap(createdForumPost -> dmUser(event.getChannel(), createdForumPost,
-                    event.getGuild())
-                .and(sendMessageToTransferrer.apply(createdForumPost)))
+                    event.getGuild()).and(sendMessageToTransferrer.apply(createdForumPost)))
             .flatMap(dmSent -> deleteOriginalMessage(event.getJDA(), channelId, messageId))
             .queue();
     }


### PR DESCRIPTION
#1134 fixed

[contributing]: https://github.com/Together-Java/TJ-Bot/wiki/Contributing
[code_guidelines]: https://github.com/Together-Java/TJ-Bot/wiki/Code-Guidelines
[new_issue]: https://github.com/Together-Java/TJ-Bot/issues/new/choose

## Pull-request

- [x] I have read the [contributing guidelines][contributing].
- [x] I have read the [code guidelines][code_guidelines].
- [x] I have created a relating [issue][new_issue].

### Changes

- [x] Existing code
- [x] New feature

<!--
While an issue isn't required, this is preferred for most changes.
It helps make it maintainable for us, and will save you from possibly recoding everything :p
If there's no relating issue, keep it NaN
-->

Closes Issue: NaN

## Description

This pull request addresses the issue where titles generated by the GPT model occasionally include quotation marks. To ensure consistency and clean titles, this PR includes changes to sanitize the generated title by removing any leading or trailing quotation marks (both single and double quotes). Additionally, the title is truncated if it exceeds the maximum allowed length (TITLE_MAX_LENGTH)