### PR TITLE
[1142] PR notifications for projects

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/Features.java
@@ -23,6 +23,8 @@ import org.togetherjava.tjbot.features.code.CodeMessageManualDetection;
 import org.togetherjava.tjbot.features.filesharing.FileSharingMessageListener;
 import org.togetherjava.tjbot.features.github.GitHubCommand;
 import org.togetherjava.tjbot.features.github.GitHubReference;
+import org.togetherjava.tjbot.features.github.projectnotification.LinkGHProjectCommand;
+import org.togetherjava.tjbot.features.github.projectnotification.ProjectPRNotifierRoutine;
 import org.togetherjava.tjbot.features.help.GuildLeaveCloseThreadListener;
 import org.togetherjava.tjbot.features.help.HelpSystemHelper;
 import org.togetherjava.tjbot.features.help.HelpThreadActivityUpdater;
@@ -136,6 +138,7 @@ public class Features {
         features.add(new MarkHelpThreadCloseInDBRoutine(database, helpThreadLifecycleListener));
         features.add(new MemberCountDisplayRoutine(config));
         features.add(new RSSHandlerRoutine(config, database));
+        features.add(new ProjectPRNotifierRoutine(config.getGitHubApiKey(), database));
 
         // Message receivers
         features.add(new TopHelpersMessageListener(database, config));
@@ -192,6 +195,7 @@ public class Features {
         features.add(new BookmarksCommand(bookmarksSystem));
         features.add(new ChatGptCommand(chatGptService, helpSystemHelper));
         features.add(new JShellCommand(jshellEval));
+        features.add(new LinkGHProjectCommand(config.getGitHubApiKey(), database));
 
         FeatureBlacklist<Class<?>> blacklist = blacklistConfig.normal();
         return blacklist.filterStream(features.stream(), Object::getClass).toList();

--- a/application/src/main/java/org/togetherjava/tjbot/features/github/projectnotification/LinkGHProjectCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/github/projectnotification/LinkGHProjectCommand.java
@@ -1,0 +1,133 @@
+package org.togetherjava.tjbot.features.github.projectnotification;
+
+import net.dv8tion.jda.api.entities.channel.Channel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.togetherjava.tjbot.db.Database;
+import org.togetherjava.tjbot.db.generated.tables.GhLinkedProjects;
+import org.togetherjava.tjbot.features.CommandVisibility;
+import org.togetherjava.tjbot.features.SlashCommandAdapter;
+
+/**
+ * This slash command (/link-gh-project) is used to link a project posted in #projects to a GitHub
+ * repository associated with the project.
+ *
+ * The association created is: 1. Channel ID 2. GitHub repository details (owner, name)
+ *
+ * These details are stored within the GH_LINKED_PROJECTS table.
+ *
+ * @author Suraj Kumar
+ */
+public class LinkGHProjectCommand extends SlashCommandAdapter {
+    private static final Logger logger = LoggerFactory.getLogger(LinkGHProjectCommand.class);
+    private static final String COMMAND_NAME = "link-gh-project";
+    private static final String REPOSITORY_OWNER_OPTION = "Repository Owner";
+    private static final String REPOSITORY_NAME_OPTION = "Repository Name";
+    private final Database database;
+    private final PullRequestFetcher pullRequestFetcher;
+
+    /**
+     * Creates a new LinkGHProjectCommand.
+     *
+     * There are 2 required options which are bound to this command:
+     * <ul>
+     * <li>"Repository Owner" the owner/organisation name that owns the repository</li>
+     * <li>"Repository Name" the name of the repository as seen on GitHub</li>
+     * </ul>
+     *
+     * @param githubPersonalAccessToken A personal access token used to authenticate against the
+     *        GitHub API
+     * @param database the database to store linked projects
+     */
+    public LinkGHProjectCommand(String githubPersonalAccessToken, Database database) {
+        super(COMMAND_NAME, "description", CommandVisibility.GUILD);
+
+        this.database = database;
+        this.pullRequestFetcher = new PullRequestFetcher(githubPersonalAccessToken);
+
+        getData().addOption(OptionType.STRING, REPOSITORY_OWNER_OPTION,
+                "The repository owner/organisation name", true, false);
+
+        getData().addOption(OptionType.STRING, REPOSITORY_NAME_OPTION, "The repository name", true,
+                false);
+    }
+
+    /**
+     * The slash command event handler. When a user initiates the /link-gh-project command in the
+     * server this method is invoked.
+     *
+     * The following happens when the command is invoked:
+     * <ul>
+     * <li>Try fetch the current PRs for the given repository. If that is unsuccessful an error
+     * message is returned back to the user.</li>
+     * <li>The project details are saved to the GH_LINKED_PROJECTS table. If a record already exists
+     * for the given project, the value is updated with the new repository details.</li>
+     * <li>A confirmation message is sent within the project thread</li>
+     * </ul>
+     * 
+     * @param event the event that triggered this
+     */
+    @Override
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
+        logger.trace("Entry LinkGHProjectCommand#onSlashCommand");
+        OptionMapping repositoryOwner = event.getOption(REPOSITORY_OWNER_OPTION);
+        OptionMapping repositoryName = event.getOption(REPOSITORY_NAME_OPTION);
+        Channel channel = event.getChannel();
+
+        if (repositoryOwner == null || repositoryName == null) {
+            event.reply("The repository owner and repository name must both have values").queue();
+            return;
+        }
+
+        logger.trace("Received repositoryOwner={} repositoryName={} in channel {}", repositoryOwner,
+                repositoryName, channel.getName());
+
+        String repositoryOwnerValue = repositoryOwner.getAsString();
+        String repositoryNameValue = repositoryName.getAsString();
+
+        if (!pullRequestFetcher.isRepositoryAccessible(repositoryOwnerValue, repositoryNameValue)) {
+            logger.info("Repository {}/{} cannot be linked as the repository is not accessible",
+                    repositoryOwnerValue, repositoryNameValue);
+            event.reply("Unable to access {}/{}. To link a project please ensure it is public.")
+                .queue();
+            logger.trace("Exit LinkGHProjectCommand#onSlashCommand");
+            return;
+        }
+
+        logger.trace("Saving project details to database");
+        saveProjectToDatabase(repositoryOwner.getAsString(), repositoryName.getAsString(),
+                channel.getId());
+        event.reply(repositoryName.getAsString() + " has been linked to this project").queue();
+
+        logger.trace("Exit LinkGHProjectCommand#onSlashCommand");
+    }
+
+    /** Saves project details to the GH_LINKED_PROJECTS, replacing the value if it already exists */
+    private void saveProjectToDatabase(String repositoryOwner, String repositoryName,
+            String channelId) {
+
+        logger.trace(
+                "Entry LinkGHProjectCommand#saveProjectToDatabase repositoryOwner={} repositoryName={} channelId={}",
+                repositoryOwner, repositoryName, channelId);
+
+        GhLinkedProjects table = GhLinkedProjects.GH_LINKED_PROJECTS;
+
+        logger.info("Saving {}/{} to database", repositoryOwner, repositoryName);
+
+        database.write(context -> context.insertInto(table)
+            .set(table.REPOSITORYNAME, repositoryName)
+            .set(table.REPOSITORYOWNER, repositoryOwner)
+            .set(table.CHANNELID, channelId)
+            .onConflict(table.CHANNELID)
+            .doUpdate()
+            .set(table.REPOSITORYNAME, repositoryName)
+            .set(table.REPOSITORYOWNER, repositoryOwner)
+            .execute());
+
+        logger.trace("Exit LinkGHProjectCommand#saveProjectToDatabase");
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/features/github/projectnotification/ProjectPRNotifierRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/github/projectnotification/ProjectPRNotifierRoutine.java
@@ -1,0 +1,106 @@
+package org.togetherjava.tjbot.features.github.projectnotification;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.togetherjava.tjbot.db.Database;
+import org.togetherjava.tjbot.db.generated.tables.GhLinkedProjects;
+import org.togetherjava.tjbot.db.generated.tables.records.GhLinkedProjectsRecord;
+import org.togetherjava.tjbot.features.Routine;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The regularly, scheduled routine that checks for pull requests and reports their status. The way
+ * this works is that we poll the GitHub API and send a message to the discord project channel with
+ * the information. Any PRs that were created before the `lastRun` time are ignored. We only notify
+ * on newly created PRs since the last run of this routine.
+ *
+ * @author Suraj Kumar
+ */
+public class ProjectPRNotifierRoutine implements Routine {
+    private static final Logger logger = LoggerFactory.getLogger(ProjectPRNotifierRoutine.class);
+    private static final int SCHEDULE_TIME_IN_MINUTES = 10;
+    private final Database database;
+    private final PullRequestFetcher pullRequestFetcher;
+    private OffsetDateTime lastRun;
+
+    /**
+     * Constructs a new ProjectPRNotifierRoutine
+     *
+     * @param githubPersonalAccessToken The PAT used to authenticate against the GitHub API
+     * @param database The database object to store project information in
+     */
+    public ProjectPRNotifierRoutine(String githubPersonalAccessToken, Database database) {
+        this.database = database;
+        this.pullRequestFetcher = new PullRequestFetcher(githubPersonalAccessToken);
+        this.lastRun = OffsetDateTime.now();
+    }
+
+    @Override
+    public @NotNull Schedule createSchedule() {
+        return new Schedule(ScheduleMode.FIXED_RATE, 0, SCHEDULE_TIME_IN_MINUTES, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void runRoutine(@NotNull JDA jda) {
+        logger.trace("Entry ProjectPRNotifierRoutine#runRoutine");
+        List<GhLinkedProjectsRecord> projects = getAllProjects();
+        logger.trace("Running routine, against {} projects", projects.size());
+        for (GhLinkedProjectsRecord project : projects) {
+            String channelId = project.getChannelid();
+            String repositoryOwner = project.getRepositoryowner();
+            String repositoryName = project.getRepositoryname();
+            logger.debug("Searching for pull requests for {}/{} for channel {}", repositoryOwner,
+                    repositoryName, channelId);
+            if (pullRequestFetcher.isRepositoryAccessible(repositoryOwner, repositoryName)) {
+                List<PullRequest> pullRequests =
+                        pullRequestFetcher.fetchPullRequests(repositoryOwner, repositoryName);
+                logger.debug("Found {} pull requests in {}/{}", pullRequests.size(),
+                        repositoryOwner, repositoryName);
+                for (PullRequest pullRequest : pullRequests) {
+                    if (pullRequest.createdAt().isAfter(lastRun)) {
+                        logger.info("Found new PR for {}, sending information to discord",
+                                channelId);
+                        sendNotificationToProject(channelId, jda, pullRequest);
+                    }
+                }
+            } else {
+                logger.warn("{}/{} is not accessible", repositoryOwner, repositoryName);
+            }
+        }
+        lastRun = OffsetDateTime.now();
+        logger.debug("lastRun has been set to {}", lastRun);
+        logger.trace("Exit ProjectPRNotifierRoutine#runRoutine");
+    }
+
+    private void sendNotificationToProject(String channelId, JDA jda, PullRequest pullRequest) {
+        logger.trace(
+                "Entry ProjectPRNotifierRoutine#sendNotificationToProject, channelId={}, pullRequest={}",
+                channelId, pullRequest);
+        TextChannel channel = jda.getTextChannelById(channelId);
+        if (channel != null) {
+            logger.trace("Sending PR notification to channel {}", channel);
+            channel.sendMessage("PR from " + pullRequest.user().name()).queue();
+        } else {
+            logger.warn("No channel found for channelId {}, pull request {}", channelId,
+                    pullRequest.htmlUrl());
+        }
+        logger.trace("Exit ProjectPRNotifierRoutine#sendNotificationToProject");
+    }
+
+    private List<GhLinkedProjectsRecord> getAllProjects() {
+        logger.trace("Entry ProjectPRNotifierRoutine#getAllProjects");
+        try {
+            return database
+                .read(dsl -> dsl.selectFrom(GhLinkedProjects.GH_LINKED_PROJECTS).fetch());
+        } finally {
+            logger.trace("Exit ProjectPRNotifierRoutine#getAllProjects");
+        }
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/features/github/projectnotification/PullRequest.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/github/projectnotification/PullRequest.java
@@ -1,0 +1,27 @@
+package org.togetherjava.tjbot.features.github.projectnotification;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.OffsetDateTime;
+
+/**
+ * This record is a container for the pull request information received when calling the GitHub pull
+ * requests endpoint.
+ *
+ * @param htmlUrl The user-friendly link to the PR
+ * @param number The pull request number
+ * @param state The state that the PR is in for example "opened", "closed", "merged"
+ * @param title The title of the PR
+ * @param user The user object representing the pull request author
+ * @param body The PR description
+ * @param createdAt The time that the PR was created
+ * @param draft True if the PR is in draft otherwise false
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PullRequest(@JsonProperty("html_url") String htmlUrl,
+        @JsonProperty("number") int number, @JsonProperty("state") String state,
+        @JsonProperty("title") String title, @JsonProperty("user") User user,
+        @JsonProperty("body") String body, @JsonProperty("created_at") OffsetDateTime createdAt,
+        @JsonProperty("draft") boolean draft) {
+}

--- a/application/src/main/java/org/togetherjava/tjbot/features/github/projectnotification/PullRequestFetcher.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/github/projectnotification/PullRequestFetcher.java
@@ -1,0 +1,132 @@
+package org.togetherjava.tjbot.features.github.projectnotification;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class is used to fetch pull requests for a given repository. When using the GitHub API a
+ * valid PAT (personal access token) is required, and it must not be expired. Expired PAT will
+ * result in HTTP 401.
+ *
+ * @author Suraj Kumar
+ */
+public class PullRequestFetcher {
+    private static final Logger logger = LoggerFactory.getLogger(PullRequestFetcher.class);
+    private static final ObjectMapper OBJECT_MAPPER =
+            new ObjectMapper().registerModule(new JavaTimeModule());
+    private static final String GITHUB_API_URL = "https://api.github.com/repos/%s/%s/pulls";
+
+    private final String githubPersonalAccessToken;
+    private final HttpClient httpClient;
+
+    /**
+     * Constructs a PullRequestFetcher
+     *
+     * @param githubPersonalAccessToken The PAT used to authenticate against the GitHub API
+     */
+    public PullRequestFetcher(String githubPersonalAccessToken) {
+        this.githubPersonalAccessToken = githubPersonalAccessToken;
+        this.httpClient = HttpClient.newBuilder().build();
+    }
+
+    /**
+     * Makes a request to the https://api.github.com/repos/%s/%s/pulls API and returns the result as
+     * a List of PullRequest objects.
+     *
+     * On any API error, this code will not throw. Instead, a warning/error level log message is
+     * sent. In this situation an empty List will be returned.
+     *
+     * @param repositoryOwner The owner of the GitHub repository
+     * @param repositoryName The repository name
+     * @return A List of PullRequest objects
+     */
+    public List<PullRequest> fetchPullRequests(String repositoryOwner, String repositoryName) {
+        logger.trace(
+                "Entry PullRequestFetcher#fetchPullRequests repositoryOwner={}, repositoryName={}",
+                repositoryOwner, repositoryName);
+        List<PullRequest> pullRequests = new ArrayList<>();
+        HttpResponse<String> response = callGitHubRepoAPI(repositoryOwner, repositoryName);
+
+        if (response == null) {
+            logger.warn(
+                    "Failed to make the request to the GitHub API which resulted in a null response");
+            logger.trace("Exit PullRequestFetcher#fetchPullRequests");
+            return pullRequests;
+        }
+
+        int statusCode = response.statusCode();
+        logger.debug("Received http status {}", statusCode);
+
+        if (statusCode == 200) {
+            try {
+                pullRequests = OBJECT_MAPPER.readValue(response.body(), new TypeReference<>() {});
+            } catch (JsonProcessingException jpe) {
+                logger.error("Failed to parse JSON", jpe);
+            }
+        } else {
+            logger.warn("Unexpected HTTP status {} while fetching pull requests for {}, body={}",
+                    statusCode, repositoryName, response.body());
+        }
+
+        logger.trace("Exit PullRequestFetcher#fetchPullRequests");
+        return pullRequests;
+    }
+
+    private HttpResponse<String> callGitHubRepoAPI(String repositoryOwner, String repositoryName) {
+        logger.trace(
+                "Entry PullRequestFetcher#callGitHubRepoAPI repositoryOwner={}, repositoryName={}",
+                repositoryOwner, repositoryName);
+        String apiURL = GITHUB_API_URL.formatted(repositoryOwner, repositoryName);
+
+        HttpResponse<String> response;
+
+        HttpRequest httpRequest = HttpRequest.newBuilder()
+            .uri(URI.create(apiURL))
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("Authorization", githubPersonalAccessToken)
+            .build();
+
+        try {
+            logger.trace("Sending request to {}", apiURL);
+            response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+            logger.debug("Received response httpStatus={} body={}", response.statusCode(),
+                    response.body());
+        } catch (IOException | InterruptedException e) {
+            logger.error("Failed to fetch pull request from discord for {}/{}: {}", repositoryOwner,
+                    repositoryName, e);
+            response = null;
+        }
+
+        logger.trace("Exit PullRequestFetcher#callGitHubRepoAPI");
+        return response;
+    }
+
+    /**
+     * Check if we can read a repositories pull request
+     *
+     * @param repositoryOwner The repository owner name
+     * @param repositoryName The repository name
+     * @return True if we can access the pull requests
+     */
+    public boolean isRepositoryAccessible(String repositoryOwner, String repositoryName) {
+        logger.trace(
+                "Entry isRepositoryAccessible#isRepositoryAccessible repositoryOwner={}, repositoryName={}",
+                repositoryOwner, repositoryName);
+        HttpResponse<String> response = callGitHubRepoAPI(repositoryOwner, repositoryName);
+        logger.trace("Exit isRepositoryAccessible#isRepositoryAccessible");
+        return response != null && response.statusCode() == 200;
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/features/github/projectnotification/User.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/github/projectnotification/User.java
@@ -1,0 +1,15 @@
+package org.togetherjava.tjbot.features.github.projectnotification;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * This record represents an author of a pull request
+ * 
+ * @param name The GitHub username of the PR author
+ * @param avatarUrl The GitHub users profile picture/avatar URL
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record User(@JsonProperty("name") String name,
+        @JsonProperty("avatar_url") String avatarUrl) {
+}

--- a/application/src/main/resources/db/V16__GH_Linked_Projects.sql
+++ b/application/src/main/resources/db/V16__GH_Linked_Projects.sql
@@ -1,0 +1,6 @@
+CREATE TABLE gh_linked_projects
+(
+    channelId       TEXT NOT NULL PRIMARY KEY,
+    repositoryOwner TEXT NOT NULL,
+    repositoryName  TEXT NOT NULL
+)


### PR DESCRIPTION
**Still in progress**

## About this PR
Introduces 1 slash command `/link-gh-project` and a new routine.

`/link-gh-project`:
This command is used to link a project posted in `#projects` to a GitHub repository. The term "linking" is used lighly because under the hood it's just saving the following details to the database:
* channel ID
* repository owner name
* repository name
There are checks done to ensure the repo is accessible before linking. 

**ProjectPRNotifierRoutine**
This routine runs on a 10 minute schedule. It goes over all the projects and checks for any PRs that have been created since the last poll time and then sends the notification to discord.

This PR features verbose logging at various levels. Don't complain, they are there so we can follow the entire logic in the event of a bug/error. It's useful debugging. I won't change this. 

closes #1142 
