### PR TITLE
Bugfix/npe help thread close

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadLifecycleListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadLifecycleListener.java
@@ -88,10 +88,10 @@ public final class HelpThreadLifecycleListener extends ListenerAdapter implement
         if (threadChannel == null) {
             logger.info("thread with id: {} no longer exists, marking archived in records", id);
             database.write(context -> context.update(HELP_THREADS)
-                    .set(HELP_THREADS.CLOSED_AT, closedAt)
-                    .set(HELP_THREADS.TICKET_STATUS, HelpSystemHelper.TicketStatus.ARCHIVED.val)
-                    .where(HELP_THREADS.CHANNEL_ID.eq(id))
-                    .execute());
+                .set(HELP_THREADS.CLOSED_AT, closedAt)
+                .set(HELP_THREADS.TICKET_STATUS, HelpSystemHelper.TicketStatus.ARCHIVED.val)
+                .where(HELP_THREADS.CHANNEL_ID.eq(id))
+                .execute());
             return;
         }
 
@@ -100,12 +100,12 @@ public final class HelpThreadLifecycleListener extends ListenerAdapter implement
         int participantsExceptAuthor = threadChannel.getMemberCount() - 1;
 
         database.write(context -> context.update(HELP_THREADS)
-                .set(HELP_THREADS.CLOSED_AT, closedAt)
-                .set(HELP_THREADS.TICKET_STATUS, HelpSystemHelper.TicketStatus.ARCHIVED.val)
-                .set(HELP_THREADS.MESSAGE_COUNT, messageCount)
-                .set(HELP_THREADS.PARTICIPANTS, participantsExceptAuthor)
-                .where(HELP_THREADS.CHANNEL_ID.eq(threadId))
-                .execute());
+            .set(HELP_THREADS.CLOSED_AT, closedAt)
+            .set(HELP_THREADS.TICKET_STATUS, HelpSystemHelper.TicketStatus.ARCHIVED.val)
+            .set(HELP_THREADS.MESSAGE_COUNT, messageCount)
+            .set(HELP_THREADS.PARTICIPANTS, participantsExceptAuthor)
+            .where(HELP_THREADS.CHANNEL_ID.eq(threadId))
+            .execute());
 
         logger.info("Thread with id: {}, updated to archived status in database", threadId);
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/MarkHelpThreadCloseInDBRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/MarkHelpThreadCloseInDBRoutine.java
@@ -48,6 +48,7 @@ public final class MarkHelpThreadCloseInDBRoutine implements Routine {
         updateTicketStatus(jda);
     }
 
+    @SuppressWarnings("java:S1181")
     private void updateTicketStatus(JDA jda) {
         Instant now = Instant.now();
         Instant threeDaysAgo = now.minus(3, ChronoUnit.DAYS);

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/MarkHelpThreadCloseInDBRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/MarkHelpThreadCloseInDBRoutine.java
@@ -1,7 +1,6 @@
 package org.togetherjava.tjbot.features.help;
 
 import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +58,7 @@ public final class MarkHelpThreadCloseInDBRoutine implements Routine {
             .map(HelpThreadsRecord::getChannelId)
             .toList());
 
-        threadIdsToClose.forEach(id -> helpThreadLifecycleListener.handleArchiveStatus(now, id, jda));
+        threadIdsToClose
+            .forEach(id -> helpThreadLifecycleListener.handleArchiveStatus(now, id, jda));
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/MarkHelpThreadCloseInDBRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/MarkHelpThreadCloseInDBRoutine.java
@@ -59,14 +59,6 @@ public final class MarkHelpThreadCloseInDBRoutine implements Routine {
             .map(HelpThreadsRecord::getChannelId)
             .toList());
 
-
-        threadIdsToClose.forEach(id -> {
-            try {
-                ThreadChannel threadChannel = jda.getThreadChannelById(id);
-                helpThreadLifecycleListener.handleArchiveStatus(now, threadChannel);
-            } catch (Exception exception) {
-                logger.warn("unable to mark thread as close with id :{}", id, exception);
-            }
-        });
+        threadIdsToClose.forEach(id -> helpThreadLifecycleListener.handleArchiveStatus(now, id, jda));
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/MarkHelpThreadCloseInDBRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/MarkHelpThreadCloseInDBRoutine.java
@@ -48,7 +48,6 @@ public final class MarkHelpThreadCloseInDBRoutine implements Routine {
         updateTicketStatus(jda);
     }
 
-    @SuppressWarnings("java:S1181")
     private void updateTicketStatus(JDA jda) {
         Instant now = Instant.now();
         Instant threeDaysAgo = now.minus(3, ChronoUnit.DAYS);
@@ -62,9 +61,9 @@ public final class MarkHelpThreadCloseInDBRoutine implements Routine {
         threadIdsToClose.forEach(id -> {
             try {
                 helpThreadLifecycleListener.handleArchiveStatus(now, id, jda);
-            } catch (Throwable throwable) {
+            } catch (Exception exception) {
                 logger.warn("Failed to update status of thread with id: {} to archived", id,
-                        throwable);
+                        exception);
             }
         });
     }

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/MarkHelpThreadCloseInDBRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/MarkHelpThreadCloseInDBRoutine.java
@@ -1,8 +1,6 @@
 package org.togetherjava.tjbot.features.help;
 
 import net.dv8tion.jda.api.JDA;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.records.HelpThreadsRecord;
@@ -20,8 +18,6 @@ import static org.togetherjava.tjbot.db.generated.tables.HelpThreads.HELP_THREAD
  * closed.
  */
 public final class MarkHelpThreadCloseInDBRoutine implements Routine {
-    private static final Logger logger =
-            LoggerFactory.getLogger(MarkHelpThreadCloseInDBRoutine.class);
     private final Database database;
     private final HelpThreadLifecycleListener helpThreadLifecycleListener;
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/MarkHelpThreadCloseInDBRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/MarkHelpThreadCloseInDBRoutine.java
@@ -1,9 +1,9 @@
 package org.togetherjava.tjbot.features.help;
 
 import net.dv8tion.jda.api.JDA;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.records.HelpThreadsRecord;
 import org.togetherjava.tjbot.features.Routine;
@@ -28,12 +28,12 @@ public final class MarkHelpThreadCloseInDBRoutine implements Routine {
     /**
      * Creates a new instance.
      *
-     * @param database                    the database to store help thread metadata in
+     * @param database the database to store help thread metadata in
      * @param helpThreadLifecycleListener class which offers method to update thread status in
-     *                                    database
+     *        database
      */
     public MarkHelpThreadCloseInDBRoutine(Database database,
-                                          HelpThreadLifecycleListener helpThreadLifecycleListener) {
+            HelpThreadLifecycleListener helpThreadLifecycleListener) {
         this.database = database;
         this.helpThreadLifecycleListener = helpThreadLifecycleListener;
     }
@@ -52,20 +52,19 @@ public final class MarkHelpThreadCloseInDBRoutine implements Routine {
         Instant now = Instant.now();
         Instant threeDaysAgo = now.minus(3, ChronoUnit.DAYS);
         List<Long> threadIdsToClose = database.read(context -> context.selectFrom(HELP_THREADS)
-                .where(HELP_THREADS.TICKET_STATUS.eq(HelpSystemHelper.TicketStatus.ACTIVE.val))
-                .and(HELP_THREADS.CREATED_AT.lessThan(threeDaysAgo))
-                .stream()
-                .map(HelpThreadsRecord::getChannelId)
-                .toList());
+            .where(HELP_THREADS.TICKET_STATUS.eq(HelpSystemHelper.TicketStatus.ACTIVE.val))
+            .and(HELP_THREADS.CREATED_AT.lessThan(threeDaysAgo))
+            .stream()
+            .map(HelpThreadsRecord::getChannelId)
+            .toList());
 
-        threadIdsToClose
-                .forEach(id -> {
-                            try {
-                                helpThreadLifecycleListener.handleArchiveStatus(now, id, jda);
-                            } catch (Throwable throwable) {
-                                logger.warn("Failed to update status of thread with id: {} to archived",id, throwable);
-                            }
-                        }
-                );
+        threadIdsToClose.forEach(id -> {
+            try {
+                helpThreadLifecycleListener.handleArchiveStatus(now, id, jda);
+            } catch (Throwable throwable) {
+                logger.warn("Failed to update status of thread with id: {} to archived", id,
+                        throwable);
+            }
+        });
     }
 }


### PR DESCRIPTION
resolve #1157

Before
* when running archive help thread in DB routine, it would call a method that uses threadChannel inside a try-catch block
* It would catch Exception outside the method, even tho NPE is triggered inside it.

After
* refactor method to check of if threadChannel is NULL(if a channel is deleted when routine is triggered)
* Removes try-catch block
* conditional logic to handle if thread is NULL