### PR TITLE
Command /jshell version result is broken visually. #1147

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/jshell/JShellCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/jshell/JShellCommand.java
@@ -111,12 +111,11 @@ public class JShellCommand extends SlashCommandAdapter {
 
     private void handleVersionCommand(SlashCommandInteractionEvent event) {
         String code = """
-                System.out.println("```");
                 System.out.println("Version: " + Runtime.version());
                 System.out.println("Vendor:  " + System.getProperty("java.vendor"));
                 System.out.println("OS:      " + System.getProperty("os.name"));
                 System.out.println("Arch:    " + System.getProperty("os.arch"));
-                System.out.println("```");""";
+                """;
         handleEval(event, null, false, code, false);
     }
 


### PR DESCRIPTION
https://github.com/Together-Java/TJ-Bot/issues/1147

Fixed an issue with backsticks appearing in the "/jshell version" command