### PR TITLE
Improved clarity for GIST message

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/filesharing/FileSharingMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/filesharing/FileSharingMessageListener.java
@@ -182,13 +182,14 @@ public final class FileSharingMessageListener extends MessageReceiverAdapter
 
     private void sendResponse(MessageReceivedEvent event, String url, String gistId) {
         Message message = event.getMessage();
-        String messageContent = "I uploaded your attachments as **Gist**.";
+        String messageContent =
+                "I uploaded your attachments as **Gist**. This makes them more accessible, for example to **mobile users**.";
 
         Button gist = Button.link(url, "Gist");
 
         Button delete = Button.danger(
                 componentIdInteractor.generateComponentId(message.getAuthor().getId(), gistId),
-                "Dismiss");
+                "Delete");
 
         message.reply(messageContent).setActionRow(gist, delete).queue();
     }


### PR DESCRIPTION
Sometimes users delete the GIST because they do not know its benefits, i.e. mostly so that mobile users can read the content.
But also because they might not know that "Dismiss" actually deletes the gist.

This improves the message for better UX, no logic-change, just text.