### PR TITLE
Bot-Trap Channel for Scam Detection

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -21,6 +21,7 @@
     "scamBlocker": {
         "mode": "AUTO_DELETE_BUT_APPROVE_QUARANTINE",
         "reportChannelPattern": "commands",
+        "botTrapChannelPattern": "bot-trap",
         "suspiciousKeywords": [
             "nitro",
             "boob",

--- a/application/src/main/java/org/togetherjava/tjbot/config/ScamBlockerConfig.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/ScamBlockerConfig.java
@@ -17,6 +17,7 @@ import java.util.Set;
 public final class ScamBlockerConfig {
     private final Mode mode;
     private final String reportChannelPattern;
+    private final String botTrapChannelPattern;
     private final Set<String> suspiciousKeywords;
     private final Set<String> hostWhitelist;
     private final Set<String> hostBlacklist;
@@ -27,6 +28,8 @@ public final class ScamBlockerConfig {
     private ScamBlockerConfig(@JsonProperty(value = "mode", required = true) Mode mode,
             @JsonProperty(value = "reportChannelPattern",
                     required = true) String reportChannelPattern,
+            @JsonProperty(value = "botTrapChannelPattern",
+                    required = true) String botTrapChannelPattern,
             @JsonProperty(value = "suspiciousKeywords",
                     required = true) Set<String> suspiciousKeywords,
             @JsonProperty(value = "hostWhitelist", required = true) Set<String> hostWhitelist,
@@ -37,6 +40,7 @@ public final class ScamBlockerConfig {
                     required = true) int isHostSimilarToKeywordDistanceThreshold) {
         this.mode = Objects.requireNonNull(mode);
         this.reportChannelPattern = Objects.requireNonNull(reportChannelPattern);
+        this.botTrapChannelPattern = Objects.requireNonNull(botTrapChannelPattern);
         this.suspiciousKeywords = new HashSet<>(Objects.requireNonNull(suspiciousKeywords));
         this.hostWhitelist = new HashSet<>(Objects.requireNonNull(hostWhitelist));
         this.hostBlacklist = new HashSet<>(Objects.requireNonNull(hostBlacklist));
@@ -61,6 +65,16 @@ public final class ScamBlockerConfig {
      */
     public String getReportChannelPattern() {
         return reportChannelPattern;
+    }
+
+    /**
+     * Gets the REGEX pattern used to identify the channel that is used to as bot-trap. Sending
+     * messages in this channel identifies the author as bot.
+     *
+     * @return the channel name pattern
+     */
+    public String getBotTrapChannelPattern() {
+        return botTrapChannelPattern;
     }
 
     /**


### PR DESCRIPTION
This adds a special public bot-trap/honeypot channel. When users post a message in this channel the Scam Detector will automatically classify them as scammers and take action.

## Release ##

When releasing this, make sure to change the config:
```json
"botTrapChannelPattern": "bot-trap",
```
and create a public text channel that matches this name.

To deactivate the feature simply delete the channel or change the pattern name. It will then silently not trigger anymore.