### PR TITLE
Scam Detector fix false positive

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -45,7 +45,7 @@
             "steamcommunity",
             "freenitro",
             "usd",
-            "earn",
+            "^earn",
             ".exe"
         ],
         "hostWhitelist": [

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetector.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetector.java
@@ -116,11 +116,10 @@ public final class ScamDetector {
             .map(keyword -> keyword.toLowerCase(Locale.US))
             .anyMatch(keyword -> {
                 // Simple regex-inspired syntax "^foo"
-                if (!keyword.isEmpty() && keyword.charAt(0) == '^') {
+                if (startsWith(keyword, '^')) {
                     return preparedToken.startsWith(keyword.substring(1));
-                } else {
-                    return preparedToken.contains(keyword);
                 }
+                return preparedToken.contains(keyword);
             });
     }
 
@@ -145,6 +144,10 @@ public final class ScamDetector {
         }
 
         return false;
+    }
+
+    private static boolean startsWith(CharSequence text, char prefixToTest) {
+        return !text.isEmpty() && text.charAt(0) == prefixToTest;
     }
 
     private static class AnalyseResults {

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetector.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetector.java
@@ -114,7 +114,14 @@ public final class ScamDetector {
         return config.getSuspiciousKeywords()
             .stream()
             .map(keyword -> keyword.toLowerCase(Locale.US))
-            .anyMatch(preparedToken::contains);
+            .anyMatch(keyword -> {
+                // Simple regex-inspired syntax "^foo"
+                if (!keyword.isEmpty() && keyword.charAt(0) == '^') {
+                    return preparedToken.startsWith(keyword.substring(1));
+                } else {
+                    return preparedToken.contains(keyword);
+                }
+            });
     }
 
     private boolean isHostSimilarToKeyword(String host, String keyword) {

--- a/application/src/test/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetectorTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetectorTest.java
@@ -54,6 +54,18 @@ final class ScamDetectorTest {
         assertTrue(isScamResult);
     }
 
+    @ParameterizedTest
+    @MethodSource("provideRealFalsePositiveMessages")
+    @DisplayName("Can ignore real false positive messages")
+    void ignoresFalsePositives(String falsePositiveMessage) {
+        // GIVEN a real false positive message
+        // WHEN analyzing it
+        boolean isScamResult = scamDetector.isScam(falsePositiveMessage);
+
+        // THEN does not flag it as scam
+        assertFalse(isScamResult);
+    }
+
     @Test
     @DisplayName("Can detect messages that contain blacklisted websites as scam")
     void detectsBlacklistedWebsite() {
@@ -226,5 +238,11 @@ final class ScamDetectorTest {
                         """,
                 "Urgently looking for mods & collab managers https://discord.gg/cryptohireo",
                 "Check this - https://transfer.sh/get/ajmkh3l7tzop/Setup.exe");
+    }
+
+    private static List<String> provideRealFalsePositiveMessages() {
+        return List
+            .of("""
+                    https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/types/anonymous-types""");
     }
 }

--- a/application/src/test/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetectorTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetectorTest.java
@@ -26,10 +26,10 @@ final class ScamDetectorTest {
         ScamBlockerConfig scamConfig = mock(ScamBlockerConfig.class);
         when(config.getScamBlocker()).thenReturn(scamConfig);
 
-        when(scamConfig.getSuspiciousKeywords())
-            .thenReturn(Set.of("nitro", "boob", "sexy", "sexi", "esex", "steam", "gift", "onlyfans",
-                    "bitcoin", "btc", "promo", "trader", "trading", "whatsapp", "crypto", "claim",
-                    "teen", "adobe", "hack", "steamcommunity", "freenitro", "usd", "earn", ".exe"));
+        when(scamConfig.getSuspiciousKeywords()).thenReturn(Set.of("nitro", "boob", "sexy", "sexi",
+                "esex", "steam", "gift", "onlyfans", "bitcoin", "btc", "promo", "trader", "trading",
+                "whatsapp", "crypto", "claim", "teen", "adobe", "hack", "steamcommunity",
+                "freenitro", "usd", "^earn", ".exe"));
         when(scamConfig.getHostWhitelist()).thenReturn(Set.of("discord.com", "discord.media",
                 "discordapp.com", "discordapp.net", "discordstatus.com"));
         when(scamConfig.getHostBlacklist()).thenReturn(Set.of("bit.ly", "discord.gg", "teletype.in",


### PR DESCRIPTION
Our Scam Detector recently ran into its first false positive, a message like this:

> https://learn.microsoft.com/en-us/dotnet/csharp/fundamentali/types/anonymous-typesd

The reason it was flagged is because it has the word `learn` in it, which `contains("earn")`, one of our suspicious keywords.

This PR adds unit tests to cover false positives and fixes the above issue by allowing suspicious keywords to require a `startsWith` check instead of `contains` by starting with `^`. So `^earn` will not trigger on `learn` anymore.

Note, the logic for this was self-written. It would also be possible to make them a full regex pattern (which supports `^` as well), but I thought this would be a bit overkill and also annoying, since all other keywords would then need to be changed to `.*foo.*`.

## Config

When deploying, change the suspicious keyword `earn` in the config to `^earn`.