### PR TITLE
Fixed Exception when ScamBlocker checks messages outside of TextChannel

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -130,7 +130,11 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
             return;
         }
 
-        boolean isSafe = !isBotTrapChannel.test(event.getChannel().asTextChannel());
+        boolean isSafe = true;
+        if (event.getChannel() instanceof TextChannel textChannel
+                && isBotTrapChannel.test(textChannel)) {
+            isSafe = false;
+        }
 
         Message message = event.getMessage();
         String content = message.getContentDisplay();


### PR DESCRIPTION
Fixes the following exception that keeps happening currently:
```
One of the EventListeners had an uncaught exception
java.lang.IllegalStateException: Cannot convert channel of type ThreadChannel to TextChannel!
at net.dv8tion.jda.internal.utils.ChannelUtil.safeChannelCast(ChannelUtil.java:51)
at net.dv8tion.jda.internal.entities.channel.AbstractChannelImpl.asTextChannel(AbstractChannelImpl.java:82)
at org.togetherjava.tjbot.features.moderation.scam.ScamBlocker.onMessageReceived(ScamBlocker.java:133)
at org.togetherjava.tjbot.features.system.BotCore.lambda$onMessageReceived$9(BotCore.java:221)
at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
at java.base/java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1858)
at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
at java.base/jav...
```