### PR TITLE
Fixed another false positive (Scam Detector)

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -44,7 +44,6 @@
             "hack",
             "steamcommunity",
             "freenitro",
-            "usd",
             "^earn",
             ".exe"
         ],

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetector.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetector.java
@@ -67,7 +67,7 @@ public final class ScamDetector {
             results.containsSuspiciousKeyword = true;
         }
 
-        if (!results.containsDollarSign && token.contains("$")) {
+        if (!results.containsDollarSign && (token.contains("$") || "usd".equalsIgnoreCase(token))) {
             results.containsDollarSign = true;
         }
 

--- a/application/src/test/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetectorTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetectorTest.java
@@ -26,10 +26,10 @@ final class ScamDetectorTest {
         ScamBlockerConfig scamConfig = mock(ScamBlockerConfig.class);
         when(config.getScamBlocker()).thenReturn(scamConfig);
 
-        when(scamConfig.getSuspiciousKeywords()).thenReturn(Set.of("nitro", "boob", "sexy", "sexi",
-                "esex", "steam", "gift", "onlyfans", "bitcoin", "btc", "promo", "trader", "trading",
-                "whatsapp", "crypto", "claim", "teen", "adobe", "hack", "steamcommunity",
-                "freenitro", "usd", "^earn", ".exe"));
+        when(scamConfig.getSuspiciousKeywords())
+            .thenReturn(Set.of("nitro", "boob", "sexy", "sexi", "esex", "steam", "gift", "onlyfans",
+                    "bitcoin", "btc", "promo", "trader", "trading", "whatsapp", "crypto", "claim",
+                    "teen", "adobe", "hack", "steamcommunity", "freenitro", "^earn", ".exe"));
         when(scamConfig.getHostWhitelist()).thenReturn(Set.of("discord.com", "discord.media",
                 "discordapp.com", "discordapp.net", "discordstatus.com"));
         when(scamConfig.getHostBlacklist()).thenReturn(Set.of("bit.ly", "discord.gg", "teletype.in",
@@ -243,6 +243,8 @@ final class ScamDetectorTest {
     private static List<String> provideRealFalsePositiveMessages() {
         return List
             .of("""
-                    https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/types/anonymous-types""");
+                    https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/types/anonymous-types""",
+                    """
+                            And according to quick google search. Median wage is about $23k usd""");
     }
 }


### PR DESCRIPTION
Fixed a false positive that flagged messages like "25$ usd" because it contains the dollar sign and usd (a suspicious keyword).

With the fix, "usd" is not considered a sus keyword anymore but instead sets the `containsDollarSign` flag to `true` as well, so they do not count twice anymore.

## Config

Remove `usd` from the sus keyword list.