### PR TITLE
Improved ChatGpt requests and response handling

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptCommand.java
@@ -80,11 +80,10 @@ public final class ChatGptCommand extends SlashCommandAdapter {
     public void onModalSubmitted(ModalInteractionEvent event, List<String> args) {
         event.deferReply().queue();
 
-        String context = "";
         String question = event.getValue(QUESTION_INPUT).getAsString();
 
-        Optional<String> optional = chatGptService.ask(question, context);
-        if (optional.isPresent()) {
+        Optional<String> chatgptResponse = chatGptService.ask(question, null);
+        if (chatgptResponse.isPresent()) {
             userIdToAskedAtCache.put(event.getMember().getId(), Instant.now());
         }
 
@@ -93,7 +92,7 @@ public final class ChatGptCommand extends SlashCommandAdapter {
                     Please try again later.
                 """;
 
-        String response = optional.orElse(errorResponse);
+        String response = chatgptResponse.orElse(errorResponse);
         SelfUser selfUser = event.getJDA().getSelfUser();
 
         MessageEmbed responseEmbed = helper.generateGptResponseEmbed(response, selfUser, question);

--- a/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
@@ -10,9 +10,10 @@ import org.slf4j.LoggerFactory;
 
 import org.togetherjava.tjbot.config.Config;
 
+import javax.annotation.Nullable;
+
 import java.time.Duration;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -91,37 +92,33 @@ public class ChatGptService {
      * @see <a href="https://platform.openai.com/docs/guides/chat/managing-tokens">ChatGPT
      *      Tokens</a>.
      */
-    public Optional<String> ask(String question, String context) {
+    public Optional<String> ask(String question, @Nullable String context) {
         if (isDisabled) {
             return Optional.empty();
         }
 
-        try {
-            String instructions = "KEEP IT CONCISE, NOT MORE THAN 280 WORDS";
-            String questionWithContext = "context: Category %s on a Java Q&A discord server. %s %s"
-                .formatted(context, instructions, question);
-            ChatMessage chatMessage = new ChatMessage(ChatMessageRole.USER.value(),
-                    Objects.requireNonNull(questionWithContext));
-            ChatCompletionRequest chatCompletionRequest = ChatCompletionRequest.builder()
-                .model(AI_MODEL)
-                .messages(List.of(chatMessage))
-                .frequencyPenalty(FREQUENCY_PENALTY)
-                .temperature(TEMPERATURE)
-                .maxTokens(MAX_TOKENS)
-                .n(MAX_NUMBER_OF_RESPONSES)
-                .build();
+        String contextText = context == null ? "" : ", Context: %s. ".formatted(context);
+        String fullQuestion = "(KEEP IT CONCISE, NOT MORE THAN 280 WORDS%s) - %s"
+            .formatted(contextText, question);
 
-            String response = openAiService.createChatCompletion(chatCompletionRequest)
+        ChatMessage chatMessage = new ChatMessage(ChatMessageRole.USER.value(), fullQuestion);
+        ChatCompletionRequest chatCompletionRequest = ChatCompletionRequest.builder()
+            .model(AI_MODEL)
+            .messages(List.of(chatMessage))
+            .frequencyPenalty(FREQUENCY_PENALTY)
+            .temperature(TEMPERATURE)
+            .maxTokens(MAX_TOKENS)
+            .n(MAX_NUMBER_OF_RESPONSES)
+            .build();
+        logger.debug("ChatGpt Request: {}", fullQuestion);
+
+        String response = null;
+        try {
+            response = openAiService.createChatCompletion(chatCompletionRequest)
                 .getChoices()
                 .getFirst()
                 .getMessage()
                 .getContent();
-
-            if (response == null) {
-                return Optional.empty();
-            }
-
-            return Optional.of(response);
         } catch (OpenAiHttpException openAiHttpException) {
             logger.warn(
                     "There was an error using the OpenAI API: {} Code: {} Type: {} Status Code: {}",
@@ -131,6 +128,12 @@ public class ChatGptService {
             logger.warn("There was an error using the OpenAI API: {}",
                     runtimeException.getMessage());
         }
-        return Optional.empty();
+
+        logger.debug("ChatGpt Response: {}", response);
+        if (response == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(response);
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -17,7 +17,6 @@ import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionE
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.components.text.TextInput;
-import net.dv8tion.jda.api.interactions.components.text.TextInput.Builder;
 import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
 import net.dv8tion.jda.api.interactions.modals.Modal;
 import net.dv8tion.jda.api.requests.ErrorResponse;
@@ -86,7 +85,6 @@ public final class TransferQuestionCommand extends BotCommandAdapter
 
     @Override
     public void onMessageContext(MessageContextInteractionEvent event) {
-
         if (isInvalidForTransfer(event)) {
             return;
         }
@@ -96,11 +94,12 @@ public final class TransferQuestionCommand extends BotCommandAdapter
         String originalChannelId = event.getTarget().getChannel().getId();
         String authorId = event.getTarget().getAuthor().getId();
         String mostCommonTag = tags.getFirst();
-        String chatGptPrompt =
-                "Summarize the following text into a concise title or heading not more than 4-5 words, remove quotations if any: %s"
+
+        String chatGptTitleRequest =
+                "Summarize the following question into a concise title or heading not more than 5 words, remove quotations if any: %s"
                     .formatted(originalMessage);
-        Optional<String> chatGptResponse = chatGptService.ask(chatGptPrompt, "");
-        String title = chatGptResponse.orElse(createTitle(originalMessage));
+        Optional<String> chatGptTitle = chatGptService.ask(chatGptTitleRequest, null);
+        String title = chatGptTitle.orElse(createTitle(originalMessage));
         if (title.length() > TITLE_MAX_LENGTH) {
             title = title.substring(0, TITLE_MAX_LENGTH);
         }
@@ -112,7 +111,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
             .setValue(title)
             .build();
 
-        Builder modalInputBuilder =
+        TextInput.Builder modalInputBuilder =
                 TextInput.create(MODAL_INPUT_ID, "Question", TextInputStyle.PARAGRAPH)
                     .setRequiredRange(INPUT_MIN_LENGTH, INPUT_MAX_LENGTH)
                     .setPlaceholder("Contents of the question");


### PR DESCRIPTION
This tweaks the requests send to ChatGpt. In many cases the final text was a bit bullshit or weird (for example containing empty strings, text that just stopped or sentences put together without a full stop separating them).

This significantly improves the quality of the ChatGpt responses in many edge cases - in particular for the newly added feature where ChatGpt also adds useful links to questions.

Further:
* "useful links" have been reduced from 5 to 3.
* added proper chatgpt request/response logging (`debug` level)
* question length checking was weird and not robust, simplified the code
* improved the "context" handling and code clarity, especially for the two other features using chatgpt (/transfer title, /chatgpt)
* renamed some variable names for clarity
* reduced the part in chatgpt code that is wrapped by `try-catch` to the part that actually throws