### PR TITLE
Switch to new RSS feed

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -166,11 +166,11 @@
     "selectRolesChannelPattern": "select-your-roles",
     "rssConfig": {
         "feeds": [
-          {
-            "url": "https://blogs.oracle.com/java/rss",
-            "targetChannelPattern": "java-news-and-changes",
-            "dateFormatterPattern": "EEE, d MMM yyyy HH:mm:ss z"
-          }
+            {
+                "url": "https://blogs.oracle.com/java/rss",
+                "targetChannelPattern": "java-news-and-changes",
+                "dateFormatterPattern": "EEE, d MMM yyyy HH:mm:ss z"
+            }
         ],
         "fallbackChannelPattern": "java-news-and-changes",
         "pollIntervalInMinutes": 10

--- a/application/config.json.template
+++ b/application/config.json.template
@@ -166,11 +166,11 @@
     "selectRolesChannelPattern": "select-your-roles",
     "rssConfig": {
         "feeds": [
-            {
-                "url": "https://wiki.openjdk.org/spaces/createrssfeed.action?types=page&types=comment&types=blogpost&types=mail&types=attachment&spaces=JDKUpdates&maxResults=15&title=%5BJDK+Updates%5D+All+Content+Feed&amp;publicFeed=true",
-                "targetChannelPattern": "java-news-and-changes",
-                "dateFormatterPattern": "yyyy-MM-dd'T'HH:mm:ssX"
-            }
+          {
+            "url": "https://blogs.oracle.com/java/rss",
+            "targetChannelPattern": "java-news-and-changes",
+            "dateFormatterPattern": "EEE, d MMM yyyy HH:mm:ss z"
+          }
         ],
         "fallbackChannelPattern": "java-news-and-changes",
         "pollIntervalInMinutes": 10

--- a/application/src/main/java/org/togetherjava/tjbot/features/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/Features.java
@@ -34,7 +34,6 @@ import org.togetherjava.tjbot.features.help.HelpThreadLifecycleListener;
 import org.togetherjava.tjbot.features.help.HelpThreadMetadataPurger;
 import org.togetherjava.tjbot.features.help.MarkHelpThreadCloseInDBRoutine;
 import org.togetherjava.tjbot.features.help.PinnedNotificationRemover;
-import org.togetherjava.tjbot.features.rss.RSSHandlerRoutine;
 import org.togetherjava.tjbot.features.jshell.JShellCommand;
 import org.togetherjava.tjbot.features.jshell.JShellEval;
 import org.togetherjava.tjbot.features.mathcommands.TeXCommand;
@@ -66,6 +65,7 @@ import org.togetherjava.tjbot.features.moderation.temp.TemporaryModerationRoutin
 import org.togetherjava.tjbot.features.projects.ProjectsThreadCreatedListener;
 import org.togetherjava.tjbot.features.reminder.RemindRoutine;
 import org.togetherjava.tjbot.features.reminder.ReminderCommand;
+import org.togetherjava.tjbot.features.rss.RSSHandlerRoutine;
 import org.togetherjava.tjbot.features.system.BotCore;
 import org.togetherjava.tjbot.features.system.LogLevelCommand;
 import org.togetherjava.tjbot.features.tags.TagCommand;

--- a/application/src/main/java/org/togetherjava/tjbot/features/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/Features.java
@@ -34,7 +34,7 @@ import org.togetherjava.tjbot.features.help.HelpThreadLifecycleListener;
 import org.togetherjava.tjbot.features.help.HelpThreadMetadataPurger;
 import org.togetherjava.tjbot.features.help.MarkHelpThreadCloseInDBRoutine;
 import org.togetherjava.tjbot.features.help.PinnedNotificationRemover;
-import org.togetherjava.tjbot.features.javamail.RSSHandlerRoutine;
+import org.togetherjava.tjbot.features.rss.RSSHandlerRoutine;
 import org.togetherjava.tjbot.features.jshell.JShellCommand;
 import org.togetherjava.tjbot.features.jshell.JShellEval;
 import org.togetherjava.tjbot.features.mathcommands.TeXCommand;

--- a/application/src/main/java/org/togetherjava/tjbot/features/rss/RSSHandlerRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/rss/RSSHandlerRoutine.java
@@ -1,4 +1,4 @@
-package org.togetherjava.tjbot.features.javamail;
+package org.togetherjava.tjbot.features.rss;
 
 import com.apptasticsoftware.rssreader.Item;
 import com.apptasticsoftware.rssreader.RssReader;

--- a/application/src/main/java/org/togetherjava/tjbot/features/rss/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/rss/package-info.java
@@ -3,7 +3,7 @@
  */
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
-package org.togetherjava.tjbot.features.javamail;
+package org.togetherjava.tjbot.features.rss;
 
 import org.togetherjava.tjbot.annotations.MethodsReturnNonnullByDefault;
 


### PR DESCRIPTION
This PR switches to oracle's java rss feed which appears to be more active (Last post was April) compared to the previous feed we were using. It also refractors the package handling rss feeds from `javamail` (which was the previous feed we used) to `rss`. 

Merging this requires somebody with VPS access to add this to this feeds array:
```json
          {
            "url": "https://blogs.oracle.com/java/rss",
            "targetChannelPattern": "java-news-and-changes",
            "dateFormatterPattern": "EEE, d MMM yyyy HH:mm:ss z"
          }
```


*For the test I just added a new entry to the xml file (being served over a local http server) after starting the bot (system caches the latest posted date if its the first time reading this rss feed).*
```xml  
<item>
    <title>Announcing Test Test Test: Java Cryptographic Service Provider for FIPS Environments</title>
    <description>Announcing the release of Oracle Jipher, which is a Java Cryptographic Service Provider that packages a FIPS 140-validated OpenSSL cryptographic module. </description>
    <link>https://blogs.oracle.com/java/post/jipher-java-cryptographic-service-provider-for-fips-environments</link>
    <guid isPermaLink="false">CORE4DA742E94BEA4A8784D3A97FEC00EBC8</guid>
    <pubDate>Fri, 27 Jun 2025 16:16:00 GMT</pubDate>
   </item>
```
<img width="628" alt="image" src="https://github.com/user-attachments/assets/9d5d6216-7fa5-44f6-b2da-c1c9607b0dec" />. 