### PR TITLE
Include error in rss feed

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/rss/RSSHandlerRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/rss/RSSHandlerRoutine.java
@@ -391,7 +391,7 @@ public final class RSSHandlerRoutine implements Routine {
         try {
             return rssReader.read(rssUrl).toList();
         } catch (IOException e) {
-            logger.warn("Could not fetch RSS from URL ({})", rssUrl);
+            logger.error("Could not fetch RSS from URL ({})", rssUrl, e;
             return List.of();
         }
     }

--- a/application/src/main/java/org/togetherjava/tjbot/features/rss/RSSHandlerRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/rss/RSSHandlerRoutine.java
@@ -391,7 +391,7 @@ public final class RSSHandlerRoutine implements Routine {
         try {
             return rssReader.read(rssUrl).toList();
         } catch (IOException e) {
-            logger.error("Could not fetch RSS from URL ({})", rssUrl, e;
+            logger.error("Could not fetch RSS from URL ({})", rssUrl, e);
             return List.of();
         }
     }


### PR DESCRIPTION
PR improves error handling for cases where the rss feed fails to be read.