### PR TITLE
Bump to log4j-slf4j2-impl v2.25.0

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation 'net.dv8tion:JDA:5.6.1'
 
     implementation 'org.apache.logging.log4j:log4j-core:2.25.0'
-    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j18-impl:2.18.0'
+    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j2-impl:2.25.0'
 
     implementation 'club.minnced:discord-webhooks:0.8.2'
 


### PR DESCRIPTION
Throughout this entire time, for anybody cloning the repository, setting up the `config.json.template`, following all the steps from the GitHub wiki we have verbatim and running the bot, leads to a SLF4J(E) stacktrace into the console almost as soon as the program begins execution, regardless of the environment:

    SLF4J(E): Unexpected problem occurred during version sanity check
    SLF4J(E): Reported exception:
    java.lang.AbstractMethodError: Receiver class org.apache.logging.slf4j.SLF4JServiceProvider does not define or inherit an implementation of the resolved method 'abstract java.lang.String getRequestedApiVersion()' of interface org.slf4j.spi.SLF4JServiceProvider.
	at org.slf4j.LoggerFactory.versionSanityCheck(LoggerFactory.java:385)
	at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:189)
	at org.slf4j.LoggerFactory.getProvider(LoggerFactory.java:511)
	at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:497)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:446)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:472)
	at org.togetherjava.tjbot.Application.<clinit>(Application.java:35)

There has been no major hurdle noted after this exception being thrown, at least not one that I am personally aware of.

Fix this by updating `log4j-slf4j2-impl` to the latest stable version as of writing this (2.25.0). As a result, the stacktrace is entirely gone and logging appears to be behaving normally.

By doing this we also prevent discouraging novice contributors from contributing by falsely getting them to believe that they have performed something wrong during setup.