### PR TITLE
Block image-based scam messages

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -77,7 +77,9 @@
             "crypto",
             "tele"
         ],
-        "isHostSimilarToKeywordDistanceThreshold": 2
+        "isHostSimilarToKeywordDistanceThreshold": 2,
+        "suspiciousAttachmentsThreshold": 3,
+        "suspiciousAttachmentNamePattern": "(image|\\d{1,2})\\.[^.]{0,5}"
     },
     "wolframAlphaAppId": "79J52T-6239TVXHR7",
     "helpSystem": {

--- a/application/src/main/java/org/togetherjava/tjbot/config/ScamBlockerConfig.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/ScamBlockerConfig.java
@@ -23,6 +23,8 @@ public final class ScamBlockerConfig {
     private final Set<String> hostBlacklist;
     private final Set<String> suspiciousHostKeywords;
     private final int isHostSimilarToKeywordDistanceThreshold;
+    private final int suspiciousAttachmentsThreshold;
+    private final String suspiciousAttachmentNamePattern;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     private ScamBlockerConfig(@JsonProperty(value = "mode", required = true) Mode mode,
@@ -37,7 +39,11 @@ public final class ScamBlockerConfig {
             @JsonProperty(value = "suspiciousHostKeywords",
                     required = true) Set<String> suspiciousHostKeywords,
             @JsonProperty(value = "isHostSimilarToKeywordDistanceThreshold",
-                    required = true) int isHostSimilarToKeywordDistanceThreshold) {
+                    required = true) int isHostSimilarToKeywordDistanceThreshold,
+            @JsonProperty(value = "suspiciousAttachmentsThreshold",
+                    required = true) int suspiciousAttachmentsThreshold,
+            @JsonProperty(value = "suspiciousAttachmentNamePattern",
+                    required = true) String suspiciousAttachmentNamePattern) {
         this.mode = Objects.requireNonNull(mode);
         this.reportChannelPattern = Objects.requireNonNull(reportChannelPattern);
         this.botTrapChannelPattern = Objects.requireNonNull(botTrapChannelPattern);
@@ -46,6 +52,9 @@ public final class ScamBlockerConfig {
         this.hostBlacklist = new HashSet<>(Objects.requireNonNull(hostBlacklist));
         this.suspiciousHostKeywords = new HashSet<>(Objects.requireNonNull(suspiciousHostKeywords));
         this.isHostSimilarToKeywordDistanceThreshold = isHostSimilarToKeywordDistanceThreshold;
+        this.suspiciousAttachmentsThreshold = suspiciousAttachmentsThreshold;
+        this.suspiciousAttachmentNamePattern =
+                Objects.requireNonNull(suspiciousAttachmentNamePattern);
     }
 
     /**
@@ -123,6 +132,26 @@ public final class ScamBlockerConfig {
      */
     public int getIsHostSimilarToKeywordDistanceThreshold() {
         return isHostSimilarToKeywordDistanceThreshold;
+    }
+
+    /**
+     * Gets the minimum amount of suspicious attachments that are required in a message to flag it
+     * as suspicious for its contained attachments.
+     *
+     * @return the minimum amount of suspicious attachments
+     */
+    public int getSuspiciousAttachmentsThreshold() {
+        return suspiciousAttachmentsThreshold;
+    }
+
+    /**
+     * Gets the REGEX pattern used to identify an attachment file name that is considered
+     * suspicious. The file name includes the extension.
+     *
+     * @return the attachment file name pattern
+     */
+    public String getSuspiciousAttachmentNamePattern() {
+        return suspiciousAttachmentNamePattern;
     }
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -137,8 +137,7 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
         }
 
         Message message = event.getMessage();
-        String content = message.getContentDisplay();
-        if (isSafe && scamDetector.isScam(content)) {
+        if (isSafe && scamDetector.isScam(message)) {
             isSafe = false;
         }
 


### PR DESCRIPTION
## Summary

Closes #1278. Extends `ScamBlocker` to detect image-only scam messages, plus unit tests.

## Details

As described in the ticket, messages are now flagged as scam if:

* empty message (`isBlank()`)
* amount of suspicious attachments is greater than configed (`suspiciousAttachmentsThreshold`)
* an attachment is considered suspicious if it is an image (`IsImage()`) and its name matches the configured regex pattern `suspiciousAttachmentNamePattern`

The file name pattern is configured by default as desired in the ticket description. That is, it triggers on files like `image.png` or files with 1-2 digits like `1.jpg` or `23.png`.

## Config

Added two new config params (part of `"scamBlocker"` config):
```json
"suspiciousAttachmentsThreshold": 3,
"suspiciousAttachmentNamePattern": "(image|\\d{1,2})\\.[^.]{0,5}"
```

## Impressions

![bad post](https://i.imgur.com/r2dAsc4.png)

![is flagged](https://i.imgur.com/8XX50va.png)