### PR TITLE
Ignore "scam" send by trusted users

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetector.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetector.java
@@ -1,6 +1,8 @@
 package org.togetherjava.tjbot.features.moderation.scam;
 
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.Role;
 
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.config.ScamBlockerConfig;
@@ -24,6 +26,7 @@ public final class ScamDetector {
     private static final Pattern TOKENIZER = Pattern.compile("[\\s,]");
     private final ScamBlockerConfig config;
     private final Predicate<String> isSuspiciousAttachmentName;
+    private final Predicate<String> hasTrustedRole;
 
     /**
      * Creates a new instance with the given configuration
@@ -32,9 +35,11 @@ public final class ScamDetector {
      */
     public ScamDetector(Config config) {
         this.config = config.getScamBlocker();
+
         isSuspiciousAttachmentName =
                 Pattern.compile(config.getScamBlocker().getSuspiciousAttachmentNamePattern())
                     .asMatchPredicate();
+        hasTrustedRole = Pattern.compile(config.getSoftModerationRolePattern()).asMatchPredicate();
     }
 
     /**
@@ -44,6 +49,13 @@ public final class ScamDetector {
      * @return Whether the message classifies as scam
      */
     public boolean isScam(Message message) {
+        Member author = message.getMember();
+        boolean isTrustedUser = author != null
+                && author.getRoles().stream().map(Role::getName).noneMatch(hasTrustedRole);
+        if (isTrustedUser) {
+            return false;
+        }
+
         String content = message.getContentDisplay();
         List<Message.Attachment> attachments = message.getAttachments();
 

--- a/application/src/test/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetectorTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetectorTest.java
@@ -1,6 +1,8 @@
 package org.togetherjava.tjbot.features.moderation.scam;
 
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.Role;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,6 +50,8 @@ final class ScamDetectorTest {
             .thenReturn(SUSPICIOUS_ATTACHMENTS_THRESHOLD);
         when(scamConfig.getSuspiciousAttachmentNamePattern())
             .thenReturn(SUSPICIOUS_ATTACHMENT_NAME);
+
+        when(config.getSoftModerationRolePattern()).thenReturn("Moderator|Community Ambassador");
 
         scamDetector = new ScamDetector(config);
     }
@@ -204,6 +208,23 @@ final class ScamDetectorTest {
         assertFalse(isScamResult);
     }
 
+    @Test
+    @DisplayName("Suspicious messages send by trusted users are not flagged")
+    void ignoreTrustedUser() {
+        // GIVEN a scam message send by a trusted user
+        String content = "Checkout https://bit.ly/3IhcLiO to get your free nitro !";
+        Member trustedUser = createAuthorMock(List.of("Moderator"));
+        Message message = createMessageMock(content, List.of());
+
+        when(message.getMember()).thenReturn(trustedUser);
+
+        // WHEN analyzing it
+        boolean isScamResult = scamDetector.isScam(message);
+
+        // THEN flags it as harmless
+        assertTrue(isScamResult);
+    }
+
     private static Message createMessageMock(String content, List<Message.Attachment> attachments) {
         Message message = mock(Message.class);
         when(message.getContentRaw()).thenReturn(content);
@@ -217,6 +238,19 @@ final class ScamDetectorTest {
         when(attachment.isImage()).thenReturn(true);
         when(attachment.getFileName()).thenReturn(name);
         return attachment;
+    }
+
+    private static Member createAuthorMock(List<String> roleNames) {
+        List<Role> roles = new ArrayList<>();
+        for (String roleName : roleNames) {
+            Role role = mock(Role.class);
+            when(role.getName()).thenReturn(roleName);
+            roles.add(role);
+        }
+
+        Member member = mock(Member.class);
+        when(member.getRoles()).thenReturn(roles);
+        return member;
     }
 
     private static List<String> provideRealScamMessages() {


### PR DESCRIPTION
## Summary

This makes it so that trusted users, such as moderators, are ignored by the scam detection.

The idea here is not to let them send scam around but when the scam detector has a false positive, mods could then at least still send the message for the user.

This of course bears the risk that if a mod is hacked, they can freely send undetected scam in the server. We never had such a case though and mods are required to enable 2FA anyways.

## Details

This does not require a config change as it uses the already-existing:

```json
"softModerationRolePattern": "Moderator|Community Ambassador",
```