### PR TITLE
Fixed ScamDetector ignoring untrusted users

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetector.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetector.java
@@ -53,7 +53,7 @@ public final class ScamDetector {
     public boolean isScam(Message message) {
         Member author = message.getMember();
         boolean isTrustedUser = author != null
-                && author.getRoles().stream().map(Role::getName).noneMatch(hasTrustedRole);
+                && author.getRoles().stream().map(Role::getName).anyMatch(hasTrustedRole);
         if (isTrustedUser) {
             return false;
         }

--- a/application/src/test/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetectorTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetectorTest.java
@@ -223,7 +223,7 @@ final class ScamDetectorTest {
         boolean isScamResult = scamDetector.isScam(message);
 
         // THEN flags it as harmless
-        assertTrue(isScamResult);
+        assertFalse(isScamResult);
     }
 
     private static Message createMessageMock(String content, List<Message.Attachment> attachments) {


### PR DESCRIPTION
Due to a bool-flip the bot is currently firing against trusted users only and ignoring untrusted users.

This needs to be deployed _asap_.

The code change has been tested locally.