### PR TITLE
Semi-Automatic Top Helper Assignment

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -192,7 +192,7 @@
     "memberCountCategoryPattern": "Info",
     "topHelpers": {
         "rolePattern": "Top Helper.*",
-        "assignmentChannelPattern": "commands",
+        "assignmentChannelPattern": "community-commands",
         "announcementChannelPattern": "hall-of-fame"
     }
 }

--- a/application/config.json.template
+++ b/application/config.json.template
@@ -10,8 +10,8 @@
     "mutedRolePattern": "Muted",
     "heavyModerationRolePattern": "Moderator",
     "softModerationRolePattern": "Moderator|Community Ambassador",
-    "tagManageRolePattern": "Moderator|Community Ambassador|Top Helpers .+",
-    "excludeCodeAutoDetectionRolePattern": "Top Helpers .+|Moderator|Community Ambassador|Expert",
+    "tagManageRolePattern": "Moderator|Community Ambassador|Top Helper.*",
+    "excludeCodeAutoDetectionRolePattern": "Top Helper.*|Moderator|Community Ambassador|Expert",
     "suggestions": {
         "channelPattern": "tj-suggestions",
         "upVoteEmoteName": "peepo_yes",
@@ -22,7 +22,7 @@
         "mode": "AUTO_DELETE_BUT_APPROVE_QUARANTINE",
         "reportChannelPattern": "commands",
         "botTrapChannelPattern": "bot-trap",
-        "trustedUserRolePattern": "Top Helpers .+|Moderator|Community Ambassador|Expert",
+        "trustedUserRolePattern": "Top Helper.*|Moderator|Community Ambassador|Expert",
         "suspiciousKeywords": [
             "nitro",
             "boob",
@@ -190,5 +190,9 @@
         "pollIntervalInMinutes": 10
     },
     "memberCountCategoryPattern": "Info",
-    "topHelperAssignmentChannelPattern": "commands"
+    "topHelpers": {
+        "rolePattern": "Top Helper.*",
+        "assignmentChannelPattern": "commands",
+        "announcementChannelPattern": "hall-of-fame"
+    }
 }

--- a/application/config.json.template
+++ b/application/config.json.template
@@ -189,5 +189,6 @@
         "fallbackChannelPattern": "java-news-and-changes",
         "pollIntervalInMinutes": 10
     },
-    "memberCountCategoryPattern": "Info"
+    "memberCountCategoryPattern": "Info",
+    "topHelperAssignmentChannelPattern": "commands"
 }

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -48,7 +48,7 @@ public final class Config {
     private final RSSFeedsConfig rssFeedsConfig;
     private final String selectRolesChannelPattern;
     private final String memberCountCategoryPattern;
-    private final String topHelperAssignmentChannelPattern;
+    private final TopHelpersConfig topHelpers;
 
     @SuppressWarnings("ConstructorWithTooManyParameters")
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
@@ -102,8 +102,7 @@ public final class Config {
             @JsonProperty(value = "rssConfig", required = true) RSSFeedsConfig rssFeedsConfig,
             @JsonProperty(value = "selectRolesChannelPattern",
                     required = true) String selectRolesChannelPattern,
-            @JsonProperty(value = "topHelperAssignmentChannelPattern",
-                    required = true) String topHelperAssignmentChannelPattern) {
+            @JsonProperty(value = "topHelpers", required = true) TopHelpersConfig topHelpers) {
         this.token = Objects.requireNonNull(token);
         this.githubApiKey = Objects.requireNonNull(githubApiKey);
         this.databasePath = Objects.requireNonNull(databasePath);
@@ -138,8 +137,7 @@ public final class Config {
         this.featureBlacklistConfig = Objects.requireNonNull(featureBlacklistConfig);
         this.rssFeedsConfig = Objects.requireNonNull(rssFeedsConfig);
         this.selectRolesChannelPattern = Objects.requireNonNull(selectRolesChannelPattern);
-        this.topHelperAssignmentChannelPattern =
-                Objects.requireNonNull(topHelperAssignmentChannelPattern);
+        this.topHelpers = Objects.requireNonNull(topHelpers);
     }
 
     /**
@@ -452,12 +450,11 @@ public final class Config {
     }
 
     /**
-     * Gets the REGEX pattern used to identify the channel where Top Helper Assignments are
-     * automatically executed.
+     * Gets the config for the Top Helpers system.
      *
-     * @return the channel name pattern
+     * @return the configuration
      */
-    public String getTopHelperAssignmentChannelPattern() {
-        return topHelperAssignmentChannelPattern;
+    public TopHelpersConfig getTopHelpers() {
+        return topHelpers;
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/config/Config.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/Config.java
@@ -48,6 +48,7 @@ public final class Config {
     private final RSSFeedsConfig rssFeedsConfig;
     private final String selectRolesChannelPattern;
     private final String memberCountCategoryPattern;
+    private final String topHelperAssignmentChannelPattern;
 
     @SuppressWarnings("ConstructorWithTooManyParameters")
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
@@ -100,7 +101,9 @@ public final class Config {
                     required = true) FeatureBlacklistConfig featureBlacklistConfig,
             @JsonProperty(value = "rssConfig", required = true) RSSFeedsConfig rssFeedsConfig,
             @JsonProperty(value = "selectRolesChannelPattern",
-                    required = true) String selectRolesChannelPattern) {
+                    required = true) String selectRolesChannelPattern,
+            @JsonProperty(value = "topHelperAssignmentChannelPattern",
+                    required = true) String topHelperAssignmentChannelPattern) {
         this.token = Objects.requireNonNull(token);
         this.githubApiKey = Objects.requireNonNull(githubApiKey);
         this.databasePath = Objects.requireNonNull(databasePath);
@@ -135,6 +138,8 @@ public final class Config {
         this.featureBlacklistConfig = Objects.requireNonNull(featureBlacklistConfig);
         this.rssFeedsConfig = Objects.requireNonNull(rssFeedsConfig);
         this.selectRolesChannelPattern = Objects.requireNonNull(selectRolesChannelPattern);
+        this.topHelperAssignmentChannelPattern =
+                Objects.requireNonNull(topHelperAssignmentChannelPattern);
     }
 
     /**
@@ -444,5 +449,15 @@ public final class Config {
      */
     public RSSFeedsConfig getRSSFeedsConfig() {
         return rssFeedsConfig;
+    }
+
+    /**
+     * Gets the REGEX pattern used to identify the channel where Top Helper Assignments are
+     * automatically executed.
+     *
+     * @return the channel name pattern
+     */
+    public String getTopHelperAssignmentChannelPattern() {
+        return topHelperAssignmentChannelPattern;
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/config/TopHelpersConfig.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/TopHelpersConfig.java
@@ -1,0 +1,58 @@
+package org.togetherjava.tjbot.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import java.util.Objects;
+
+/**
+ * Configuration for the top helper system, see
+ * {@link org.togetherjava.tjbot.features.tophelper.TopHelpersCommand}.
+ */
+@JsonRootName("topHelpers")
+public final class TopHelpersConfig {
+    private final String rolePattern;
+    private final String assignmentChannelPattern;
+    private final String announcementChannelPattern;
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    private TopHelpersConfig(
+            @JsonProperty(value = "rolePattern", required = true) String rolePattern,
+            @JsonProperty(value = "assignmentChannelPattern",
+                    required = true) String assignmentChannelPattern,
+            @JsonProperty(value = "announcementChannelPattern",
+                    required = true) String announcementChannelPattern) {
+        this.rolePattern = Objects.requireNonNull(rolePattern);
+        this.assignmentChannelPattern = Objects.requireNonNull(assignmentChannelPattern);
+        this.announcementChannelPattern = Objects.requireNonNull(announcementChannelPattern);
+    }
+
+    /**
+     * Gets the REGEX pattern matching the role used to represent Top Helpers.
+     *
+     * @return the role name pattern
+     */
+    public String getRolePattern() {
+        return rolePattern;
+    }
+
+    /**
+     * Gets the REGEX pattern used to identify the channel where Top Helper assignments are
+     * automatically executed.
+     *
+     * @return the channel name pattern
+     */
+    public String getAssignmentChannelPattern() {
+        return assignmentChannelPattern;
+    }
+
+    /**
+     * Gets the REGEX pattern used to identify the channel where Top Helper announcements are send.
+     *
+     * @return the channel name pattern
+     */
+    public String getAnnouncementChannelPattern() {
+        return announcementChannelPattern;
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/features/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/Features.java
@@ -72,9 +72,11 @@ import org.togetherjava.tjbot.features.tags.TagCommand;
 import org.togetherjava.tjbot.features.tags.TagManageCommand;
 import org.togetherjava.tjbot.features.tags.TagSystem;
 import org.togetherjava.tjbot.features.tags.TagsCommand;
+import org.togetherjava.tjbot.features.tophelper.TopHelpersAssignmentRoutine;
 import org.togetherjava.tjbot.features.tophelper.TopHelpersCommand;
 import org.togetherjava.tjbot.features.tophelper.TopHelpersMessageListener;
 import org.togetherjava.tjbot.features.tophelper.TopHelpersPurgeMessagesRoutine;
+import org.togetherjava.tjbot.features.tophelper.TopHelpersService;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -119,6 +121,9 @@ public class Features {
         HelpSystemHelper helpSystemHelper = new HelpSystemHelper(config, database, chatGptService);
         HelpThreadLifecycleListener helpThreadLifecycleListener =
                 new HelpThreadLifecycleListener(helpSystemHelper, database);
+        TopHelpersService topHelpersService = new TopHelpersService(database);
+        TopHelpersAssignmentRoutine topHelpersAssignmentRoutine =
+                new TopHelpersAssignmentRoutine(config, topHelpersService);
 
         // NOTE The system can add special system relevant commands also by itself,
         // hence this list may not necessarily represent the full list of all commands actually
@@ -140,6 +145,7 @@ public class Features {
         features.add(new MarkHelpThreadCloseInDBRoutine(database, helpThreadLifecycleListener));
         features.add(new MemberCountDisplayRoutine(config));
         features.add(new RSSHandlerRoutine(config, database));
+        features.add(topHelpersAssignmentRoutine);
 
         // Message receivers
         features.add(new TopHelpersMessageListener(database, config));
@@ -182,7 +188,7 @@ public class Features {
         features.add(new AuditCommand(actionsStore));
         features.add(new MuteCommand(actionsStore, config));
         features.add(new UnmuteCommand(actionsStore, config));
-        features.add(new TopHelpersCommand(database));
+        features.add(new TopHelpersCommand(topHelpersService, topHelpersAssignmentRoutine));
         features.add(new RoleSelectCommand());
         features.add(new NoteCommand(actionsStore));
         features.add(new ReminderCommand(database));

--- a/application/src/main/java/org/togetherjava/tjbot/features/Routine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/Routine.java
@@ -102,11 +102,9 @@ public interface Routine extends Feature {
          */
         public static Schedule atFixedRateFromNextFixedTime(int periodStartHour, int periodHours) {
             // NOTE This scheduler could be improved, for example supporting arbitrary periods (not
-            // just
-            // hour-based). Also, it probably does not correctly handle all date/time-quirks, for
-            // example if a schedule would hit a time that does not exist for a specific date due to
-            // DST
-            // or similar issues. Those are minor though and can be ignored for now.
+            // just hour-based). Also, it probably does not correctly handle all date/time-quirks,
+            // for example if a schedule would hit a time that does not exist for a specific date
+            // due to DST or similar issues. Those are minor though and can be ignored for now.
             if (periodStartHour < 0 || periodStartHour >= HOURS_OF_DAY) {
                 throw new IllegalArgumentException(
                         "Schedule period start hour must be a valid hour of a day (0-23)");

--- a/application/src/main/java/org/togetherjava/tjbot/features/Routine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/Routine.java
@@ -2,7 +2,19 @@ package org.togetherjava.tjbot.features;
 
 import net.dv8tion.jda.api.JDA;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 /**
  * Routines are executed on a reoccurring schedule by the core system.
@@ -45,6 +57,99 @@ public interface Routine extends Feature {
      *        seconds
      */
     record Schedule(ScheduleMode mode, long initialDuration, long duration, TimeUnit unit) {
+
+        private static final int HOURS_OF_DAY = 24;
+
+        /**
+         * Creates a schedule for execution at a fixed hour of the day. The initial first execution
+         * will be delayed to the next fixed time that matches the given hour of the day,
+         * effectively making execution stable at that fixed hour - regardless of when this method
+         * was originally triggered.
+         * <p>
+         * For example, if the given hour is 12 o'clock, this leads to the fixed execution times of
+         * only 12:00 each day. The first execution is then delayed to the closest time in that
+         * schedule. For example, if triggered at 7:00, execution will happen at 12:00 and then
+         * follow the schedule.
+         * <p>
+         * Execution will also correctly roll over to the next day, for example if the method is
+         * triggered at 21:30, the next execution will be at 12:00 the following day.
+         *
+         * @param hourOfDay the hour of the day that marks the start of this period
+         * @return the according schedule representing the planned execution
+         */
+        public static Schedule atFixedHour(int hourOfDay) {
+            return atFixedRateFromNextFixedTime(hourOfDay, HOURS_OF_DAY);
+        }
+
+        /**
+         * Creates a schedule for execution at a fixed rate (see
+         * {@link ScheduledExecutorService#scheduleAtFixedRate(Runnable, long, long, TimeUnit)}).
+         * The initial first execution will be delayed to the next fixed time that matches the given
+         * period, effectively making execution stable at fixed times of a day - regardless of when
+         * this method was originally triggered.
+         * <p>
+         * For example, if the given period is 8 hours with a start hour of 4 o'clock, this leads to
+         * the fixed execution times of 4:00, 12:00 and 20:00 each day. The first execution is then
+         * delayed to the closest time in that schedule. For example, if triggered at 7:00,
+         * execution will happen at 12:00 and then follow the schedule.
+         * <p>
+         * Execution will also correctly roll over to the next day, for example if the method is
+         * triggered at 21:30, the next execution will be at 4:00 the following day.
+         *
+         * @param periodStartHour the hour of the day that marks the start of this period
+         * @param periodHours the scheduling period in hours
+         * @return the according schedule representing the planned execution
+         */
+        public static Schedule atFixedRateFromNextFixedTime(int periodStartHour, int periodHours) {
+            // NOTE This scheduler could be improved, for example supporting arbitrary periods (not
+            // just
+            // hour-based). Also, it probably does not correctly handle all date/time-quirks, for
+            // example if a schedule would hit a time that does not exist for a specific date due to
+            // DST
+            // or similar issues. Those are minor though and can be ignored for now.
+            if (periodStartHour < 0 || periodStartHour >= HOURS_OF_DAY) {
+                throw new IllegalArgumentException(
+                        "Schedule period start hour must be a valid hour of a day (0-23)");
+            }
+            if (periodHours <= 0 || periodHours > HOURS_OF_DAY) {
+                throw new IllegalArgumentException(
+                        "Schedule period must not be zero and must fit into a single day (0-24)");
+            }
+
+            // Compute fixed schedule hours
+            List<Integer> fixedScheduleHours = new ArrayList<>();
+
+            for (int hour = periodStartHour; hour < HOURS_OF_DAY; hour += periodHours) {
+                fixedScheduleHours.add(hour);
+            }
+
+            Instant now = Instant.now();
+            Instant nextFixedTime =
+                    computeClosestNextScheduleDate(now, fixedScheduleHours, periodHours);
+            return new Schedule(ScheduleMode.FIXED_RATE,
+                    ChronoUnit.SECONDS.between(now, nextFixedTime),
+                    TimeUnit.HOURS.toSeconds(periodHours), TimeUnit.SECONDS);
+        }
+
+        private static Instant computeClosestNextScheduleDate(Instant instant,
+                List<Integer> scheduleHours, int periodHours) {
+            OffsetDateTime offsetDateTime = instant.atOffset(ZoneOffset.UTC);
+            BiFunction<OffsetDateTime, Integer, Instant> dateAtTime =
+                    (date, hour) -> date.with(LocalTime.of(hour, 0)).toInstant();
+
+            // The instant is either before the given hours, in between, or after.
+            // For latter, we roll the schedule over once to the next day
+            List<Instant> scheduleDates = scheduleHours.stream()
+                .map(hour -> dateAtTime.apply(offsetDateTime, hour))
+                .collect(Collectors.toCollection(ArrayList::new));
+            int rolloverHour = (scheduleHours.getLast() + periodHours) % HOURS_OF_DAY;
+            scheduleDates.add(dateAtTime.apply(offsetDateTime.plusDays(1), rolloverHour));
+
+            return scheduleDates.stream()
+                .filter(instant::isBefore)
+                .min(Comparator.comparing(scheduleDate -> Duration.between(instant, scheduleDate)))
+                .orElseThrow();
+        }
     }
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/features/filesharing/FileSharingMessageListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/filesharing/FileSharingMessageListener.java
@@ -2,7 +2,6 @@ package org.togetherjava.tjbot.features.filesharing;
 
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
@@ -21,6 +20,7 @@ import org.togetherjava.tjbot.features.UserInteractionType;
 import org.togetherjava.tjbot.features.UserInteractor;
 import org.togetherjava.tjbot.features.componentids.ComponentIdGenerator;
 import org.togetherjava.tjbot.features.componentids.ComponentIdInteractor;
+import org.togetherjava.tjbot.features.utils.Guilds;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -99,8 +99,7 @@ public final class FileSharingMessageListener extends MessageReceiverAdapter
     public void onButtonClick(ButtonInteractionEvent event, List<String> args) {
         Member interactionUser = event.getMember();
         String gistAuthorId = args.getFirst();
-        boolean hasSoftModPermissions =
-                interactionUser.getRoles().stream().map(Role::getName).anyMatch(isSoftModRole);
+        boolean hasSoftModPermissions = Guilds.hasMemberRole(interactionUser, isSoftModRole);
 
         if (!gistAuthorId.equals(interactionUser.getId()) && !hasSoftModPermissions) {
             event.reply("You do not have permission for this action.").setEphemeral(true).queue();

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpSystemHelper.java
@@ -27,6 +27,7 @@ import org.togetherjava.tjbot.db.generated.tables.records.HelpThreadsRecord;
 import org.togetherjava.tjbot.features.chatgpt.ChatGptCommand;
 import org.togetherjava.tjbot.features.chatgpt.ChatGptService;
 import org.togetherjava.tjbot.features.componentids.ComponentIdInteractor;
+import org.togetherjava.tjbot.features.utils.Guilds;
 
 import java.awt.Color;
 import java.time.Instant;
@@ -57,7 +58,7 @@ public final class HelpSystemHelper {
 
     static final Color AMBIENT_COLOR = new Color(255, 255, 165);
 
-    private final Predicate<String> hasTagManageRole;
+    private final Predicate<String> isTagManageRole;
     private final Predicate<String> isHelpForumName;
     private final String helpForumPattern;
     /**
@@ -88,7 +89,7 @@ public final class HelpSystemHelper {
         this.database = database;
         this.chatGptService = chatGptService;
 
-        hasTagManageRole = Pattern.compile(config.getTagManageRolePattern()).asMatchPredicate();
+        isTagManageRole = Pattern.compile(config.getTagManageRolePattern()).asMatchPredicate();
         helpForumPattern = helpConfig.getHelpForumPattern();
         isHelpForumName = Pattern.compile(helpForumPattern).asMatchPredicate();
 
@@ -344,7 +345,7 @@ public final class HelpSystemHelper {
     }
 
     boolean hasTagManageRole(Member member) {
-        return member.getRoles().stream().map(Role::getName).anyMatch(hasTagManageRole);
+        return Guilds.hasMemberRole(member, isTagManageRole);
     }
 
     boolean isHelpForumName(String channelName) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpSystemHelper.java
@@ -361,11 +361,7 @@ public final class HelpSystemHelper {
         Predicate<String> isChannelName = this::isHelpForumName;
         String channelPattern = getHelpForumPattern();
 
-        Optional<ForumChannel> maybeChannel = guild.getForumChannelCache()
-            .stream()
-            .filter(channel -> isChannelName.test(channel.getName()))
-            .findAny();
-
+        Optional<ForumChannel> maybeChannel = Guilds.findForumChannel(guild, isChannelName);
         if (maybeChannel.isEmpty()) {
             consumeChannelPatternIfNotFound.accept(channelPattern);
         }

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ModerationUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ModerationUtils.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.features.moderation.modmail.ModMailCommand;
+import org.togetherjava.tjbot.features.utils.Guilds;
 import org.togetherjava.tjbot.features.utils.MessageUtils;
 
 import javax.annotation.Nullable;
@@ -321,7 +322,7 @@ public class ModerationUtils {
      */
     public static Optional<Role> getMutedRole(Guild guild, Config config) {
         Predicate<String> isMutedRole = getIsMutedRolePredicate(config);
-        return guild.getRoles().stream().filter(role -> isMutedRole.test(role.getName())).findAny();
+        return Guilds.findRole(guild, isMutedRole);
     }
 
     /**
@@ -343,10 +344,7 @@ public class ModerationUtils {
      */
     public static Optional<Role> getQuarantinedRole(Guild guild, Config config) {
         Predicate<String> isQuarantinedRole = getIsQuarantinedRolePredicate(config);
-        return guild.getRoles()
-            .stream()
-            .filter(role -> isQuarantinedRole.test(role.getName()))
-            .findAny();
+        return Guilds.findRole(guild, isQuarantinedRole);
     }
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/audit/ModAuditLogRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/audit/ModAuditLogRoutine.java
@@ -28,24 +28,14 @@ import org.togetherjava.tjbot.features.moderation.ModerationUtils;
 import javax.annotation.Nullable;
 
 import java.awt.Color;
-import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 
 
 /**
@@ -60,7 +50,6 @@ public final class ModAuditLogRoutine implements Routine {
     private static final Logger logger = LoggerFactory.getLogger(ModAuditLogRoutine.class);
     private static final int CHECK_AUDIT_LOG_START_HOUR = 4;
     private static final int CHECK_AUDIT_LOG_EVERY_HOURS = 8;
-    private static final int HOURS_OF_DAY = 24;
     private static final Color AMBIENT_COLOR = Color.decode("#4FC3F7");
 
     private final Database database;
@@ -93,74 +82,6 @@ public final class ModAuditLogRoutine implements Routine {
 
     private static boolean isSnowflakeAfter(ISnowflake snowflake, Instant timestamp) {
         return TimeUtil.getTimeCreated(snowflake.getIdLong()).toInstant().isAfter(timestamp);
-    }
-
-    /**
-     * Creates a schedule for execution at a fixed rate (see
-     * {@link ScheduledExecutorService#scheduleAtFixedRate(Runnable, long, long, TimeUnit)}). The
-     * initial first execution will be delayed to the next fixed time that matches the given period,
-     * effectively making execution stable at fixed times of a day - regardless of when this method
-     * was originally triggered.
-     * <p>
-     * For example, if the given period is 8 hours with a start hour of 4 o'clock, this leads to the
-     * fixed execution times of 4:00, 12:00 and 20:00 each day. The first execution is then delayed
-     * to the closest time in that schedule. For example, if triggered at 7:00, execution will
-     * happen at 12:00 and then follow the schedule.
-     * <p>
-     * Execution will also correctly roll over to the next day, for example if the method is
-     * triggered at 21:30, the next execution will be at 4:00 the following day.
-     *
-     * @param periodStartHour the hour of the day that marks the start of this period
-     * @param periodHours the scheduling period in hours
-     * @return the according schedule representing the planned execution
-     */
-    private static Schedule scheduleAtFixedRateFromNextFixedTime(int periodStartHour,
-            int periodHours) {
-        // NOTE This scheduler could be improved, for example supporting arbitrary periods (not just
-        // hour-based). Also, it probably does not correctly handle all date/time-quirks, for
-        // example if a schedule would hit a time that does not exist for a specific date due to DST
-        // or similar issues. Those are minor though and can be ignored for now.
-        if (periodHours <= 0 || periodHours >= HOURS_OF_DAY) {
-            throw new IllegalArgumentException(
-                    "Schedule period must not be zero and must fit into a single day");
-        }
-        if (periodStartHour <= 0 || periodStartHour >= HOURS_OF_DAY) {
-            throw new IllegalArgumentException(
-                    "Schedule period start hour must be a valid hour of a day (0-23)");
-        }
-
-        // Compute fixed schedule hours
-        List<Integer> fixedScheduleHours = new ArrayList<>();
-
-        for (int hour = periodStartHour; hour < HOURS_OF_DAY; hour += periodHours) {
-            fixedScheduleHours.add(hour);
-        }
-
-        Instant now = Instant.now();
-        Instant nextFixedTime =
-                computeClosestNextScheduleDate(now, fixedScheduleHours, periodHours);
-        return new Schedule(ScheduleMode.FIXED_RATE, ChronoUnit.SECONDS.between(now, nextFixedTime),
-                TimeUnit.HOURS.toSeconds(periodHours), TimeUnit.SECONDS);
-    }
-
-    private static Instant computeClosestNextScheduleDate(Instant instant,
-            List<Integer> scheduleHours, int periodHours) {
-        OffsetDateTime offsetDateTime = instant.atOffset(ZoneOffset.UTC);
-        BiFunction<OffsetDateTime, Integer, Instant> dateAtTime =
-                (date, hour) -> date.with(LocalTime.of(hour, 0)).toInstant();
-
-        // The instant is either before the given hours, in between, or after.
-        // For latter, we roll the schedule over once to the next day
-        List<Instant> scheduleDates = scheduleHours.stream()
-            .map(hour -> dateAtTime.apply(offsetDateTime, hour))
-            .collect(Collectors.toCollection(ArrayList::new));
-        int rolloverHour = (scheduleHours.getLast() + periodHours) % HOURS_OF_DAY;
-        scheduleDates.add(dateAtTime.apply(offsetDateTime.plusDays(1), rolloverHour));
-
-        return scheduleDates.stream()
-            .filter(instant::isBefore)
-            .min(Comparator.comparing(scheduleDate -> Duration.between(instant, scheduleDate)))
-            .orElseThrow();
     }
 
     private static Optional<RestAction<MessageEmbed>> handleBanEntry(AuditLogEntry entry) {
@@ -205,7 +126,7 @@ public final class ModAuditLogRoutine implements Routine {
 
     @Override
     public Schedule createSchedule() {
-        Schedule schedule = scheduleAtFixedRateFromNextFixedTime(CHECK_AUDIT_LOG_START_HOUR,
+        Schedule schedule = Schedule.atFixedRateFromNextFixedTime(CHECK_AUDIT_LOG_START_HOUR,
                 CHECK_AUDIT_LOG_EVERY_HOURS);
         logger.info("Checking audit logs is scheduled for {}.",
                 Instant.now().plus(schedule.initialDuration(), schedule.unit().toChronoUnit()));

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/audit/ModAuditLogWriter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/audit/ModAuditLogWriter.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.togetherjava.tjbot.config.Config;
+import org.togetherjava.tjbot.features.utils.Guilds;
 
 import javax.annotation.Nullable;
 
@@ -34,7 +35,7 @@ public final class ModAuditLogWriter {
 
     private final Config config;
 
-    private final Predicate<String> auditLogChannelNamePredicate;
+    private final Predicate<String> isAuditLogChannelName;
 
     /**
      * Creates a new instance.
@@ -43,7 +44,7 @@ public final class ModAuditLogWriter {
      */
     public ModAuditLogWriter(Config config) {
         this.config = config;
-        auditLogChannelNamePredicate =
+        isAuditLogChannelName =
                 Pattern.compile(config.getModAuditLogChannelPattern()).asMatchPredicate();
     }
 
@@ -90,11 +91,8 @@ public final class ModAuditLogWriter {
      * @return the channel used for moderation audit logs, if present
      */
     public Optional<TextChannel> getAndHandleModAuditLogChannel(Guild guild) {
-        Optional<TextChannel> auditLogChannel = guild.getTextChannelCache()
-            .stream()
-            .filter(channel -> auditLogChannelNamePredicate.test(channel.getName()))
-            .findAny();
-
+        Optional<TextChannel> auditLogChannel =
+                Guilds.findTextChannel(guild, isAuditLogChannelName);
         if (auditLogChannel.isEmpty()) {
             logger.warn(
                     "Unable to log moderation events, did not find a mod audit log channel matching the configured pattern '{}' for guild '{}'",

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -66,7 +66,7 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
     private final ScamBlockerConfig.Mode mode;
     private final String reportChannelPattern;
     private final String botTrapChannelPattern;
-    private final Predicate<TextChannel> isReportChannel;
+    private final Predicate<String> isReportChannelName;
     private final Predicate<TextChannel> isBotTrapChannel;
     private final ScamDetector scamDetector;
     private final Config config;
@@ -92,9 +92,7 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
         scamDetector = new ScamDetector(config);
 
         reportChannelPattern = config.getScamBlocker().getReportChannelPattern();
-        Predicate<String> isReportChannelName =
-                Pattern.compile(reportChannelPattern).asMatchPredicate();
-        isReportChannel = channel -> isReportChannelName.test(channel.getName());
+        isReportChannelName = Pattern.compile(reportChannelPattern).asMatchPredicate();
 
         botTrapChannelPattern = config.getScamBlocker().getBotTrapChannelPattern();
         Predicate<String> isBotTrapChannelName =
@@ -297,7 +295,7 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
     }
 
     private Optional<TextChannel> getReportChannel(Guild guild) {
-        return guild.getTextChannelCache().stream().filter(isReportChannel).findAny();
+        return Guilds.findTextChannel(guild, isReportChannelName);
     }
 
     private List<Button> createConfirmDialog(MessageReceivedEvent event) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetector.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetector.java
@@ -2,10 +2,10 @@ package org.togetherjava.tjbot.features.moderation.scam;
 
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.Role;
 
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.config.ScamBlockerConfig;
+import org.togetherjava.tjbot.features.utils.Guilds;
 
 import java.util.Collection;
 import java.util.List;
@@ -51,8 +51,7 @@ public final class ScamDetector {
      */
     public boolean isScam(Message message) {
         Member author = message.getMember();
-        boolean isTrustedUser = author != null
-                && author.getRoles().stream().map(Role::getName).anyMatch(hasTrustedRole);
+        boolean isTrustedUser = author != null && Guilds.hasMemberRole(author, hasTrustedRole);
         if (isTrustedUser) {
             return false;
         }

--- a/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersAssignmentRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersAssignmentRoutine.java
@@ -288,9 +288,10 @@ public final class TopHelpersAssignmentRoutine implements Routine, UserInteracto
     public void onButtonClick(ButtonInteractionEvent event, List<String> args) {
         event.deferEdit().queue();
         String name = args.getFirst();
+        List<String> otherArgs = args.subList(1, args.size());
 
         switch (name) {
-            case YES_MESSAGE_BUTTON_NAME -> prepareAnnouncement(event, args);
+            case YES_MESSAGE_BUTTON_NAME -> prepareAnnouncement(event, otherArgs);
             case NO_MESSAGE_BUTTON_NAME -> reportFlowFinished(event, "not posting an announcement");
             case CANCEL_BUTTON_NAME -> reportFlowFinished(event, "cancelled");
             default -> throw new AssertionError("Unknown button name: " + name);
@@ -298,7 +299,7 @@ public final class TopHelpersAssignmentRoutine implements Routine, UserInteracto
     }
 
     private void prepareAnnouncement(ButtonInteractionEvent event, List<String> args) {
-        List<Long> topHelperIds = args.stream().skip(1).map(Long::parseLong).toList();
+        List<Long> topHelperIds = args.stream().map(Long::parseLong).toList();
 
         event.getGuild().retrieveMembersByIds(topHelperIds).onError(error -> {
             logger.warn("Failed to retrieve top-helper data for automatic assignment", error);

--- a/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersAssignmentRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersAssignmentRoutine.java
@@ -131,10 +131,8 @@ public final class TopHelpersAssignmentRoutine implements Routine, UserInteracto
      * @param guild to start the dialog and compute Top Helpers for
      */
     public void startDialogFor(Guild guild) {
-        Optional<TextChannel> assignmentChannel = guild.getTextChannelCache()
-            .stream()
-            .filter(channel -> assignmentChannelNamePredicate.test(channel.getName()))
-            .findAny();
+        Optional<TextChannel> assignmentChannel =
+                Guilds.findTextChannel(guild, assignmentChannelNamePredicate);
 
         assignmentChannel.ifPresentOrElse(this::startDialogIn, () -> logger.warn(
                 "Unable to assign Top Helpers, did not find an assignment channel matching the configured pattern '{}' for guild '{}'",
@@ -313,10 +311,8 @@ public final class TopHelpersAssignmentRoutine implements Routine, UserInteracto
 
     private void postAnnouncement(ButtonInteractionEvent event, List<? extends Member> topHelpers) {
         Guild guild = Objects.requireNonNull(event.getGuild());
-        Optional<TextChannel> announcementChannel = guild.getTextChannelCache()
-            .stream()
-            .filter(channel -> announcementChannelNamePredicate.test(channel.getName()))
-            .findAny();
+        Optional<TextChannel> announcementChannel =
+                Guilds.findTextChannel(guild, announcementChannelNamePredicate);
 
         if (announcementChannel.isEmpty()) {
             logger.warn(

--- a/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersAssignmentRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersAssignmentRoutine.java
@@ -166,8 +166,9 @@ public final class TopHelpersAssignmentRoutine implements Routine, UserInteracto
             Collection<? extends Member> members, TopHelpersService.TimeRange timeRange,
             MessageChannel channel) {
         String content = """
-                Starting assignment of Top Helpers for %s:
+                Starting assignment of Top Helpers:
                 ```java
+                // %s
                 %s
                 ```""".formatted(timeRange.description(),
                 TopHelpersService.asAsciiTable(topHelpers, members));

--- a/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersAssignmentRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersAssignmentRoutine.java
@@ -2,35 +2,72 @@ package org.togetherjava.tjbot.features.tophelper;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import net.dv8tion.jda.api.interactions.components.selections.SelectOption;
+import net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu;
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.features.Routine;
+import org.togetherjava.tjbot.features.UserInteractionType;
+import org.togetherjava.tjbot.features.UserInteractor;
+import org.togetherjava.tjbot.features.componentids.ComponentIdGenerator;
+import org.togetherjava.tjbot.features.componentids.ComponentIdInteractor;
+
+import javax.annotation.Nullable;
 
 import java.time.Instant;
 import java.time.Month;
 import java.time.ZoneOffset;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 // TODO Javadoc everywhere
-public final class TopHelpersAssignmentRoutine implements Routine {
+public final class TopHelpersAssignmentRoutine implements Routine, UserInteractor {
     private static final Logger logger = LoggerFactory.getLogger(TopHelpersAssignmentRoutine.class);
     private static final int CHECK_AT_HOUR = 12;
 
     private final Config config;
     private final TopHelpersService service;
     private final Predicate<String> assignmentChannelNamePredicate;
+    private final ComponentIdInteractor componentIdInteractor;
 
     public TopHelpersAssignmentRoutine(Config config, TopHelpersService service) {
         this.config = config;
         this.service = service;
+
         assignmentChannelNamePredicate =
                 Pattern.compile(config.getTopHelperAssignmentChannelPattern()).asMatchPredicate();
+
+        componentIdInteractor = new ComponentIdInteractor(getInteractionType(), getName());
+    }
+
+    @Override
+    public String getName() {
+        return "top-helper-assignment";
+    }
+
+    @Override
+    public UserInteractionType getInteractionType() {
+        return UserInteractionType.OTHER;
+    }
+
+    @Override
+    public void acceptComponentIdGenerator(ComponentIdGenerator generator) {
+        componentIdInteractor.acceptComponentIdGenerator(generator);
     }
 
     @Override
@@ -60,11 +97,13 @@ public final class TopHelpersAssignmentRoutine implements Routine {
     }
 
     private void startDialogIn(TextChannel channel) {
+        Guild guild = channel.getGuild();
+
         Month previousMonth = Instant.now().atZone(ZoneOffset.UTC).minusMonths(1).getMonth();
         TopHelpersService.TimeRange timeRange =
                 TopHelpersService.TimeRange.fromMonth(previousMonth);
-        List<TopHelpersService.TopHelperResult> topHelpers = service.computeTopHelpersDescending(
-                channel.getGuild().getIdLong(), timeRange.start(), timeRange.end());
+        List<TopHelpersService.TopHelperResult> topHelpers = service
+            .computeTopHelpersDescending(guild.getIdLong(), timeRange.start(), timeRange.end());
 
         if (topHelpers.isEmpty()) {
             channel.sendMessage(
@@ -74,6 +113,68 @@ public final class TopHelpersAssignmentRoutine implements Routine {
             return;
         }
 
-        logger.error("TODO Implement me");
+        service.retrieveTopHelperMembers(topHelpers, guild)
+            .onError(error -> handleError(error, channel))
+            .onSuccess(members -> sendSelectionMenu(topHelpers, members, timeRange, channel));
+    }
+
+    private static void handleError(Throwable error, TextChannel channel) {
+        logger.warn("Failed to compute top-helpers for automatic assignment", error);
+        channel.sendMessage("Wanted to assign Top Helpers, but something went wrong.").queue();
+    }
+
+    private void sendSelectionMenu(Collection<TopHelpersService.TopHelperResult> topHelpers,
+            Collection<? extends Member> members, TopHelpersService.TimeRange timeRange,
+            TextChannel channel) {
+        String content = """
+                Starting assignment of Top Helpers for %s:
+                ```java
+                %s
+                ```""".formatted(timeRange.description(),
+                service.asAsciiTable(topHelpers, members, false));
+
+        StringSelectMenu.Builder menu =
+                StringSelectMenu.create(componentIdInteractor.generateComponentId("foo"))
+                    .setPlaceholder("Select the Top Helpers")
+                    .setMinValues(1)
+                    .setMaxValues(topHelpers.size());
+
+        Map<Long, Member> userIdToMember =
+                members.stream().collect(Collectors.toMap(Member::getIdLong, Function.identity()));
+        topHelpers.stream()
+            .map(topHelper -> topHelperToSelectOption(topHelper,
+                    userIdToMember.get(topHelper.authorId())))
+            .forEach(menu::addOptions);
+
+        MessageCreateData message = new MessageCreateBuilder().setContent(content)
+            .addActionRow(menu.build())
+            .addActionRow(
+                    Button.danger(componentIdInteractor.generateComponentId("cancel"), "Cancel"))
+            .build();
+
+        channel.sendMessage(message).queue();
+    }
+
+    private static SelectOption topHelperToSelectOption(TopHelpersService.TopHelperResult topHelper,
+            @Nullable Member member) {
+        String id = Long.toString(topHelper.authorId());
+
+        String name = TopHelpersService.getUsernameDisplay(member);
+        long messageLengths = topHelper.messageLengths().longValue();
+        String label = messageLengths + " - " + name;
+
+        return SelectOption.of(label, id);
+    }
+
+    @Override
+    public void onButtonClick(ButtonInteractionEvent event, List<String> args) {
+        // TODO Implement
+        logger.error("TODO Button clicked: {}", args);
+    }
+
+    @Override
+    public void onStringSelectSelection(StringSelectInteractionEvent event, List<String> args) {
+        // TODO Implement
+        logger.error("TODO Menu used: {}", args);
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersAssignmentRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersAssignmentRoutine.java
@@ -25,6 +25,7 @@ import org.togetherjava.tjbot.features.UserInteractionType;
 import org.togetherjava.tjbot.features.UserInteractor;
 import org.togetherjava.tjbot.features.componentids.ComponentIdGenerator;
 import org.togetherjava.tjbot.features.componentids.ComponentIdInteractor;
+import org.togetherjava.tjbot.features.utils.Guilds;
 
 import javax.annotation.Nullable;
 
@@ -213,10 +214,7 @@ public final class TopHelpersAssignmentRoutine implements Routine, UserInteracto
             .map(Long::parseLong)
             .collect(Collectors.toSet());
 
-        Optional<Role> topHelperRole = guild.getRoles()
-            .stream()
-            .filter(role -> roleNamePredicate.test(role.getName()))
-            .findAny();
+        Optional<Role> topHelperRole = Guilds.findRole(guild, roleNamePredicate);
         if (topHelperRole.isEmpty()) {
             logger.warn(
                     "Unable to assign Top Helpers, did not find a role matching the configured pattern '{}' for guild '{}'",

--- a/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersAssignmentRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersAssignmentRoutine.java
@@ -1,0 +1,79 @@
+package org.togetherjava.tjbot.features.tophelper;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.togetherjava.tjbot.config.Config;
+import org.togetherjava.tjbot.features.Routine;
+
+import java.time.Instant;
+import java.time.Month;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+// TODO Javadoc everywhere
+public final class TopHelpersAssignmentRoutine implements Routine {
+    private static final Logger logger = LoggerFactory.getLogger(TopHelpersAssignmentRoutine.class);
+    private static final int CHECK_AT_HOUR = 12;
+
+    private final Config config;
+    private final TopHelpersService service;
+    private final Predicate<String> assignmentChannelNamePredicate;
+
+    public TopHelpersAssignmentRoutine(Config config, TopHelpersService service) {
+        this.config = config;
+        this.service = service;
+        assignmentChannelNamePredicate =
+                Pattern.compile(config.getTopHelperAssignmentChannelPattern()).asMatchPredicate();
+    }
+
+    @Override
+    public Schedule createSchedule() {
+        return Schedule.atFixedHour(CHECK_AT_HOUR);
+    }
+
+    @Override
+    public void runRoutine(JDA jda) {
+        int dayOfMonth = Instant.now().atOffset(ZoneOffset.UTC).getDayOfMonth();
+        if (dayOfMonth != 1) {
+            return;
+        }
+
+        jda.getGuilds().forEach(this::startDialogFor);
+    }
+
+    public void startDialogFor(Guild guild) {
+        Optional<TextChannel> assignmentChannel = guild.getTextChannelCache()
+            .stream()
+            .filter(channel -> assignmentChannelNamePredicate.test(channel.getName()))
+            .findAny();
+
+        assignmentChannel.ifPresentOrElse(this::startDialogIn, () -> logger.warn(
+                "Unable to assign Top Helpers, did not find an assignment channel matching the configured pattern '{}' for guild '{}'",
+                config.getTopHelperAssignmentChannelPattern(), guild.getName()));
+    }
+
+    private void startDialogIn(TextChannel channel) {
+        Month previousMonth = Instant.now().atZone(ZoneOffset.UTC).minusMonths(1).getMonth();
+        TopHelpersService.TimeRange timeRange =
+                TopHelpersService.TimeRange.fromMonth(previousMonth);
+        List<TopHelpersService.TopHelperResult> topHelpers = service.computeTopHelpersDescending(
+                channel.getGuild().getIdLong(), timeRange.start(), timeRange.end());
+
+        if (topHelpers.isEmpty()) {
+            channel.sendMessage(
+                    "Wanted to assign Top Helpers, but there seems to be no entries for that time range (%s)."
+                        .formatted(timeRange.description()))
+                .queue();
+            return;
+        }
+
+        logger.error("TODO Implement me");
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersAssignmentRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersAssignmentRoutine.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -179,8 +178,7 @@ public final class TopHelpersAssignmentRoutine implements Routine, UserInteracto
                     .setMinValues(1)
                     .setMaxValues(topHelpers.size());
 
-        Map<Long, Member> userIdToMember =
-                members.stream().collect(Collectors.toMap(Member::getIdLong, Function.identity()));
+        Map<Long, Member> userIdToMember = TopHelpersService.mapUserIdToMember(members);
         topHelpers.stream()
             .map(topHelper -> topHelperToSelectOption(topHelper,
                     userIdToMember.get(topHelper.authorId())))

--- a/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersCommand.java
@@ -82,7 +82,7 @@ public final class TopHelpersCommand extends SlashCommandAdapter {
         OptionMapping atMonthData = event.getOption(MONTH_OPTION);
 
         TopHelpersService.TimeRange timeRange =
-                TopHelpersService.TimeRange.fromMonth(computeMonth(atMonthData));
+                TopHelpersService.TimeRange.ofMonth(computeMonth(atMonthData));
         List<TopHelpersService.TopHelperResult> topHelpers = service.computeTopHelpersDescending(
                 event.getGuild().getIdLong(), timeRange.start(), timeRange.end());
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersService.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersService.java
@@ -1,0 +1,72 @@
+package org.togetherjava.tjbot.features.tophelper;
+
+import org.jooq.Records;
+import org.jooq.impl.DSL;
+
+import org.togetherjava.tjbot.db.Database;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.TextStyle;
+import java.util.List;
+import java.util.Locale;
+
+import static org.togetherjava.tjbot.db.generated.tables.HelpChannelMessages.HELP_CHANNEL_MESSAGES;
+
+// TODO Javadoc everywhere
+public final class TopHelpersService {
+    private static final int TOP_HELPER_LIMIT = 18;
+
+    private final Database database;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param database the database containing the message records of top helpers
+     */
+    public TopHelpersService(Database database) {
+        this.database = database;
+    }
+
+    public List<TopHelperResult> computeTopHelpersDescending(long guildId, Instant start,
+            Instant end) {
+        return database.read(context -> context
+            .select(HELP_CHANNEL_MESSAGES.AUTHOR_ID, DSL.sum(HELP_CHANNEL_MESSAGES.MESSAGE_LENGTH))
+            .from(HELP_CHANNEL_MESSAGES)
+            .where(HELP_CHANNEL_MESSAGES.GUILD_ID.eq(guildId)
+                .and(HELP_CHANNEL_MESSAGES.SENT_AT.between(start, end)))
+            .groupBy(HELP_CHANNEL_MESSAGES.AUTHOR_ID)
+            .orderBy(DSL.two().desc())
+            .limit(TOP_HELPER_LIMIT)
+            .fetch(Records.mapping(TopHelperResult::new)));
+    }
+
+    public record TopHelperResult(long authorId, BigDecimal messageLengths) {
+    }
+
+    public record TimeRange(Instant start, Instant end, String description) {
+        public static TimeRange fromMonth(Month atMonth) {
+            ZonedDateTime now = Instant.now().atZone(ZoneOffset.UTC);
+
+            int atYear = now.getYear();
+            // E.g. using November, while it is March 2022, should use November 2021
+            if (atMonth.compareTo(now.getMonth()) > 0) {
+                atYear--;
+            }
+            YearMonth atYearMonth = YearMonth.of(atYear, atMonth);
+
+            Instant start = atYearMonth.atDay(1).atTime(LocalTime.MIN).toInstant(ZoneOffset.UTC);
+            Instant end =
+                    atYearMonth.atEndOfMonth().atTime(LocalTime.MAX).toInstant(ZoneOffset.UTC);
+            String description = "%s %d"
+                .formatted(atMonth.getDisplayName(TextStyle.FULL_STANDALONE, Locale.US), atYear);
+
+            return new TimeRange(start, end, description);
+        }
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersService.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersService.java
@@ -141,13 +141,13 @@ public final class TopHelpersService {
 
     /**
      * Retrieves the member-data to a given list of top helpers.
-     * <p>
-     * The resulting list is in the same order as the given list and will contain {@code null} for
-     * any Top Helper who is not member of the guild anymore.
      *
      * @param topHelpers the list of top helpers to retrieve member-data for
      * @param guild the guild the top helpers are members of
-     * @return list of member-data for each top helper, same size and same order.
+     * @return list of member-data for each top helper. If a Top helper is not member of the guild
+     *         anymore, it will not be contained in the list of members. Also, the order is not
+     *         given and in particular does not have to line up with the original order of Top
+     *         Helpers.
      */
     public static Task<List<Member>> retrieveTopHelperMembers(List<TopHelperStats> topHelpers,
             Guild guild) {
@@ -160,8 +160,8 @@ public final class TopHelpersService {
      * Name and Message lengths.
      *
      * @param topHelpers the list of top helpers to represent
-     * @param members the list of member-data that lines up with the topHelpers, for example given
-     *        by {@link #retrieveTopHelperMembers(List, Guild)}
+     * @param members the list of available member-data, for example given by
+     *        {@link #retrieveTopHelperMembers(List, Guild)}
      * @return ASCII table representing the Top Helpers
      */
     public static String asAsciiTableWithIds(Collection<TopHelperStats> topHelpers,
@@ -174,8 +174,8 @@ public final class TopHelpersService {
      * Name and Message lengths.
      *
      * @param topHelpers the list of top helpers to represent
-     * @param members the list of member-data that lines up with the topHelpers, for example given
-     *        by {@link #retrieveTopHelperMembers(List, Guild)}
+     * @param members the list of available member-data, for example given by
+     *        {@link #retrieveTopHelperMembers(List, Guild)}
      * @return ASCII table representing the Top Helpers
      */
     public static String asAsciiTable(Collection<TopHelperStats> topHelpers,

--- a/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersService.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersService.java
@@ -7,6 +7,8 @@ import com.github.freva.asciitable.HorizontalAlign;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.utils.concurrent.Task;
+import org.jooq.Records;
+import org.jooq.impl.DSL;
 
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.features.utils.MessageUtils;
@@ -31,7 +33,14 @@ import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-// TODO Javadoc everywhere
+import static org.togetherjava.tjbot.db.generated.tables.HelpChannelMessages.HELP_CHANNEL_MESSAGES;
+
+/**
+ * Service used to compute Top Helpers of a given time range, see
+ * {@link #computeTopHelpersDescending(Guild, TimeRange)}.
+ * <p>
+ * Also offers utility to process or display Top Helper results.
+ */
 public final class TopHelpersService {
     private static final int TOP_HELPER_LIMIT = 18;
     private static final int MAX_USER_NAME_LIMIT = 15;
@@ -47,31 +56,134 @@ public final class TopHelpersService {
         this.database = database;
     }
 
-    public List<TopHelperResult> computeTopHelpersDescending(long guildId, Instant start,
-            Instant end) {
-        // TODO Undo after testing!
-        /*
-         * return database.read(context -> context .select(HELP_CHANNEL_MESSAGES.AUTHOR_ID,
-         * DSL.sum(HELP_CHANNEL_MESSAGES.MESSAGE_LENGTH)) .from(HELP_CHANNEL_MESSAGES)
-         * .where(HELP_CHANNEL_MESSAGES.GUILD_ID.eq(guildId)
-         * .and(HELP_CHANNEL_MESSAGES.SENT_AT.between(start, end)))
-         * .groupBy(HELP_CHANNEL_MESSAGES.AUTHOR_ID) .orderBy(DSL.two().desc())
-         * .limit(TOP_HELPER_LIMIT) .fetch(Records.mapping(TopHelperResult::new)));
-         */
-        return List.of(new TopHelperResult(1014989258165072028L, BigDecimal.valueOf(500)),
-                new TopHelperResult(257500867568205824L, BigDecimal.valueOf(400)),
-                new TopHelperResult(238042761490595843L, BigDecimal.valueOf(300)),
-                new TopHelperResult(905767721814351892L, BigDecimal.valueOf(200)),
-                new TopHelperResult(157994153806921728L, BigDecimal.valueOf(100)));
+    /**
+     * Stats for a single Top Helper, computed for a specific time range. See
+     * {@link #computeTopHelpersDescending(Guild, TimeRange)}.
+     * 
+     * @param authorId ID of the Top Helper
+     * @param messageLengths lengths of messages send in the time range, the more, the better
+     */
+    public record TopHelperStats(long authorId, BigDecimal messageLengths) {
     }
 
-    public Task<List<Member>> retrieveTopHelperMembers(List<TopHelperResult> topHelpers,
+
+    /**
+     * Represents a time range with a defined start and end.
+     * 
+     * @param start the inclusive start of the range
+     * @param end the exclusive end of the range
+     * @param description used for visual representation e.g., 'July 2025'
+     */
+    public record TimeRange(Instant start, Instant end, String description) {
+        /**
+         * Creates a time range representing the previous month (assuming UTC). For example if the
+         * current month is April, this will return a time range for March.
+         * 
+         * @return time range for the previous month
+         */
+        public static TimeRange ofPreviousMonth() {
+            Month previousMonth = Instant.now().atZone(ZoneOffset.UTC).minusMonths(1).getMonth();
+            return TimeRange.ofPastMonth(previousMonth);
+        }
+
+        /**
+         * Creates a time range representing the given month (assuming UTC). If the month lies in
+         * the future for the current year, the past year will be used instead. For example, if the
+         * current month is April 2025:
+         * <ul>
+         * <li>{@code ofPastMonth(Month.APRIL)} returns April 2025</li>
+         * <li>{@code ofPastMonth(Month.MARCH)} returns March 2025</li>
+         * <li>{@code ofPastMonth(Month.JUNE)} returns June 2024</li>
+         * </ul>
+         * 
+         * @param atMonth the month to represent
+         * @return Time range representing the given month, either for the current or the previous
+         *         year.
+         */
+        public static TimeRange ofPastMonth(Month atMonth) {
+            ZonedDateTime now = Instant.now().atZone(ZoneOffset.UTC);
+
+            int atYear = now.getYear();
+            // E.g. using November, while it is March 2022, should use November 2021
+            if (atMonth.compareTo(now.getMonth()) > 0) {
+                atYear--;
+            }
+            YearMonth atYearMonth = YearMonth.of(atYear, atMonth);
+
+            Instant start = atYearMonth.atDay(1).atTime(LocalTime.MIN).toInstant(ZoneOffset.UTC);
+            Instant end =
+                    atYearMonth.atEndOfMonth().atTime(LocalTime.MAX).toInstant(ZoneOffset.UTC);
+            String description = "%s %d"
+                .formatted(atMonth.getDisplayName(TextStyle.FULL_STANDALONE, Locale.US), atYear);
+
+            return new TimeRange(start, end, description);
+        }
+    }
+
+    /**
+     * Computes the Top Helpers of the given time range.
+     * 
+     * @param guild to compute Top Helpers for
+     * @param range of the time to compute results for
+     * @return list of top helpers, descending with the user who helped the most first
+     */
+    public List<TopHelperStats> computeTopHelpersDescending(Guild guild, TimeRange range) {
+        return database.read(context -> context
+            .select(HELP_CHANNEL_MESSAGES.AUTHOR_ID, DSL.sum(HELP_CHANNEL_MESSAGES.MESSAGE_LENGTH))
+            .from(HELP_CHANNEL_MESSAGES)
+            .where(HELP_CHANNEL_MESSAGES.GUILD_ID.eq(guild.getIdLong())
+                .and(HELP_CHANNEL_MESSAGES.SENT_AT.between(range.start(), range.end())))
+            .groupBy(HELP_CHANNEL_MESSAGES.AUTHOR_ID)
+            .orderBy(DSL.two().desc())
+            .limit(TOP_HELPER_LIMIT)
+            .fetch(Records.mapping(TopHelperStats::new)));
+    }
+
+    /**
+     * Retrieves the member-data to a given list of top helpers.
+     * <p>
+     * The resulting list is in the same order as the given list and will contain {@code null} for
+     * any Top Helper who is not member of the guild anymore.
+     *
+     * @param topHelpers the list of top helpers to retrieve member-data for
+     * @param guild the guild the top helpers are members of
+     * @return list of member-data for each top helper, same size and same order.
+     */
+    public static Task<List<Member>> retrieveTopHelperMembers(List<TopHelperStats> topHelpers,
             Guild guild) {
-        List<Long> topHelperIds = topHelpers.stream().map(TopHelperResult::authorId).toList();
+        List<Long> topHelperIds = topHelpers.stream().map(TopHelperStats::authorId).toList();
         return guild.retrieveMembersByIds(topHelperIds);
     }
 
-    public String asAsciiTable(Collection<TopHelperResult> topHelpers,
+    /**
+     * Visual representation of the given Top Helpers as ASCII table. The table includes columns ID,
+     * Name and Message lengths.
+     *
+     * @param topHelpers the list of top helpers to represent
+     * @param members the list of member-data that lines up with the topHelpers, for example given
+     *        by {@link #retrieveTopHelperMembers(List, Guild)}
+     * @return ASCII table representing the Top Helpers
+     */
+    public static String asAsciiTableWithIds(Collection<TopHelperStats> topHelpers,
+            Collection<? extends Member> members) {
+        return asAsciiTable(topHelpers, members, true);
+    }
+
+    /**
+     * Visual representation of the given Top Helpers as ASCII table. The table includes columns
+     * Name and Message lengths.
+     *
+     * @param topHelpers the list of top helpers to represent
+     * @param members the list of member-data that lines up with the topHelpers, for example given
+     *        by {@link #retrieveTopHelperMembers(List, Guild)}
+     * @return ASCII table representing the Top Helpers
+     */
+    public static String asAsciiTable(Collection<TopHelperStats> topHelpers,
+            Collection<? extends Member> members) {
+        return asAsciiTable(topHelpers, members, false);
+    }
+
+    private static String asAsciiTable(Collection<TopHelperStats> topHelpers,
             Collection<? extends Member> members, boolean includeIds) {
         Map<Long, Member> userIdToMember =
                 members.stream().collect(Collectors.toMap(Member::getIdLong, Function.identity()));
@@ -84,12 +196,18 @@ public final class TopHelpersService {
         return dataTableToString(topHelpersDataTable, includeIds);
     }
 
+    /**
+     * Visual representation of the given members name as it should be used for display purposes.
+     * 
+     * @param member to get name of, {@code null} will be represented with a placeholder
+     * @return name of the user for display purposes
+     */
     public static String getUsernameDisplay(@Nullable Member member) {
         return MessageUtils.abbreviate(member == null ? "UNKNOWN_USER" : member.getEffectiveName(),
                 MAX_USER_NAME_LIMIT);
     }
 
-    private static List<String> topHelperToDataRow(TopHelpersService.TopHelperResult topHelper,
+    private static List<String> topHelperToDataRow(TopHelperStats topHelper,
             @Nullable Member member, boolean includeIds) {
         String id = Long.toString(topHelper.authorId());
         String name = getUsernameDisplay(member);
@@ -106,7 +224,7 @@ public final class TopHelpersService {
             boolean includeIds) {
         List<ColumnSetting> settings = new ArrayList<>();
         if (includeIds) {
-            settings.add(new ColumnSetting("Id", HorizontalAlign.RIGHT));
+            settings.add(new ColumnSetting("ID", HorizontalAlign.RIGHT));
         }
         settings.add(new ColumnSetting("Name", HorizontalAlign.RIGHT));
         settings.add(new ColumnSetting("Message lengths", HorizontalAlign.RIGHT));
@@ -130,34 +248,5 @@ public final class TopHelpersService {
     }
 
     private record ColumnSetting(String headerName, HorizontalAlign alignment) {
-    }
-
-    public record TopHelperResult(long authorId, BigDecimal messageLengths) {
-    }
-
-    public record TimeRange(Instant start, Instant end, String description) {
-        public static TimeRange ofPreviousMonth() {
-            Month previousMonth = Instant.now().atZone(ZoneOffset.UTC).minusMonths(1).getMonth();
-            return TimeRange.ofMonth(previousMonth);
-        }
-
-        public static TimeRange ofMonth(Month atMonth) {
-            ZonedDateTime now = Instant.now().atZone(ZoneOffset.UTC);
-
-            int atYear = now.getYear();
-            // E.g. using November, while it is March 2022, should use November 2021
-            if (atMonth.compareTo(now.getMonth()) > 0) {
-                atYear--;
-            }
-            YearMonth atYearMonth = YearMonth.of(atYear, atMonth);
-
-            Instant start = atYearMonth.atDay(1).atTime(LocalTime.MIN).toInstant(ZoneOffset.UTC);
-            Instant end =
-                    atYearMonth.atEndOfMonth().atTime(LocalTime.MAX).toInstant(ZoneOffset.UTC);
-            String description = "%s %d"
-                .formatted(atMonth.getDisplayName(TextStyle.FULL_STANDALONE, Locale.US), atYear);
-
-            return new TimeRange(start, end, description);
-        }
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersService.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersService.java
@@ -136,7 +136,12 @@ public final class TopHelpersService {
     }
 
     public record TimeRange(Instant start, Instant end, String description) {
-        public static TimeRange fromMonth(Month atMonth) {
+        public static TimeRange ofPreviousMonth() {
+            Month previousMonth = Instant.now().atZone(ZoneOffset.UTC).minusMonths(1).getMonth();
+            return TimeRange.ofMonth(previousMonth);
+        }
+
+        public static TimeRange ofMonth(Month atMonth) {
             ZonedDateTime now = Instant.now().atZone(ZoneOffset.UTC);
 
             int atYear = now.getYear();

--- a/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersService.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersService.java
@@ -1,9 +1,17 @@
 package org.togetherjava.tjbot.features.tophelper;
 
-import org.jooq.Records;
-import org.jooq.impl.DSL;
+import com.github.freva.asciitable.AsciiTable;
+import com.github.freva.asciitable.Column;
+import com.github.freva.asciitable.ColumnData;
+import com.github.freva.asciitable.HorizontalAlign;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.utils.concurrent.Task;
 
 import org.togetherjava.tjbot.db.Database;
+import org.togetherjava.tjbot.features.utils.MessageUtils;
+
+import javax.annotation.Nullable;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -13,14 +21,20 @@ import java.time.YearMonth;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.TextStyle;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-
-import static org.togetherjava.tjbot.db.generated.tables.HelpChannelMessages.HELP_CHANNEL_MESSAGES;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 // TODO Javadoc everywhere
 public final class TopHelpersService {
     private static final int TOP_HELPER_LIMIT = 18;
+    private static final int MAX_USER_NAME_LIMIT = 15;
 
     private final Database database;
 
@@ -35,15 +49,87 @@ public final class TopHelpersService {
 
     public List<TopHelperResult> computeTopHelpersDescending(long guildId, Instant start,
             Instant end) {
-        return database.read(context -> context
-            .select(HELP_CHANNEL_MESSAGES.AUTHOR_ID, DSL.sum(HELP_CHANNEL_MESSAGES.MESSAGE_LENGTH))
-            .from(HELP_CHANNEL_MESSAGES)
-            .where(HELP_CHANNEL_MESSAGES.GUILD_ID.eq(guildId)
-                .and(HELP_CHANNEL_MESSAGES.SENT_AT.between(start, end)))
-            .groupBy(HELP_CHANNEL_MESSAGES.AUTHOR_ID)
-            .orderBy(DSL.two().desc())
-            .limit(TOP_HELPER_LIMIT)
-            .fetch(Records.mapping(TopHelperResult::new)));
+        // TODO Undo after testing!
+        /*
+         * return database.read(context -> context .select(HELP_CHANNEL_MESSAGES.AUTHOR_ID,
+         * DSL.sum(HELP_CHANNEL_MESSAGES.MESSAGE_LENGTH)) .from(HELP_CHANNEL_MESSAGES)
+         * .where(HELP_CHANNEL_MESSAGES.GUILD_ID.eq(guildId)
+         * .and(HELP_CHANNEL_MESSAGES.SENT_AT.between(start, end)))
+         * .groupBy(HELP_CHANNEL_MESSAGES.AUTHOR_ID) .orderBy(DSL.two().desc())
+         * .limit(TOP_HELPER_LIMIT) .fetch(Records.mapping(TopHelperResult::new)));
+         */
+        return List.of(new TopHelperResult(1014989258165072028L, BigDecimal.valueOf(500)),
+                new TopHelperResult(257500867568205824L, BigDecimal.valueOf(400)),
+                new TopHelperResult(238042761490595843L, BigDecimal.valueOf(300)),
+                new TopHelperResult(905767721814351892L, BigDecimal.valueOf(200)),
+                new TopHelperResult(157994153806921728L, BigDecimal.valueOf(100)));
+    }
+
+    public Task<List<Member>> retrieveTopHelperMembers(List<TopHelperResult> topHelpers,
+            Guild guild) {
+        List<Long> topHelperIds = topHelpers.stream().map(TopHelperResult::authorId).toList();
+        return guild.retrieveMembersByIds(topHelperIds);
+    }
+
+    public String asAsciiTable(Collection<TopHelperResult> topHelpers,
+            Collection<? extends Member> members, boolean includeIds) {
+        Map<Long, Member> userIdToMember =
+                members.stream().collect(Collectors.toMap(Member::getIdLong, Function.identity()));
+
+        List<List<String>> topHelpersDataTable = topHelpers.stream()
+            .map(topHelper -> topHelperToDataRow(topHelper,
+                    userIdToMember.get(topHelper.authorId()), includeIds))
+            .toList();
+
+        return dataTableToString(topHelpersDataTable, includeIds);
+    }
+
+    public static String getUsernameDisplay(@Nullable Member member) {
+        return MessageUtils.abbreviate(member == null ? "UNKNOWN_USER" : member.getEffectiveName(),
+                MAX_USER_NAME_LIMIT);
+    }
+
+    private static List<String> topHelperToDataRow(TopHelpersService.TopHelperResult topHelper,
+            @Nullable Member member, boolean includeIds) {
+        String id = Long.toString(topHelper.authorId());
+        String name = getUsernameDisplay(member);
+        String messageLengths = Long.toString(topHelper.messageLengths().longValue());
+
+        if (includeIds) {
+            return List.of(id, name, messageLengths);
+        } else {
+            return List.of(name, messageLengths);
+        }
+    }
+
+    private static String dataTableToString(Collection<List<String>> dataTable,
+            boolean includeIds) {
+        List<ColumnSetting> settings = new ArrayList<>();
+        if (includeIds) {
+            settings.add(new ColumnSetting("Id", HorizontalAlign.RIGHT));
+        }
+        settings.add(new ColumnSetting("Name", HorizontalAlign.RIGHT));
+        settings.add(new ColumnSetting("Message lengths", HorizontalAlign.RIGHT));
+        return dataTableToAsciiTable(dataTable, settings);
+    }
+
+    private static String dataTableToAsciiTable(Collection<List<String>> dataTable,
+            List<ColumnSetting> columnSettings) {
+        IntFunction<String> headerToAlignment = i -> columnSettings.get(i).headerName();
+        IntFunction<HorizontalAlign> indexToAlignment = i -> columnSettings.get(i).alignment();
+
+        IntFunction<ColumnData<List<String>>> indexToColumn =
+                i -> new Column().header(headerToAlignment.apply(i))
+                    .dataAlign(indexToAlignment.apply(i))
+                    .with(row -> row.get(i));
+
+        List<ColumnData<List<String>>> columns =
+                IntStream.range(0, columnSettings.size()).mapToObj(indexToColumn).toList();
+
+        return AsciiTable.getTable(AsciiTable.BASIC_ASCII_NO_DATA_SEPARATORS, dataTable, columns);
+    }
+
+    private record ColumnSetting(String headerName, HorizontalAlign alignment) {
     }
 
     public record TopHelperResult(long authorId, BigDecimal messageLengths) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersService.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tophelper/TopHelpersService.java
@@ -185,8 +185,7 @@ public final class TopHelpersService {
 
     private static String asAsciiTable(Collection<TopHelperStats> topHelpers,
             Collection<? extends Member> members, boolean includeIds) {
-        Map<Long, Member> userIdToMember =
-                members.stream().collect(Collectors.toMap(Member::getIdLong, Function.identity()));
+        Map<Long, Member> userIdToMember = mapUserIdToMember(members);
 
         List<List<String>> topHelpersDataTable = topHelpers.stream()
             .map(topHelper -> topHelperToDataRow(topHelper,
@@ -194,6 +193,16 @@ public final class TopHelpersService {
             .toList();
 
         return dataTableToString(topHelpersDataTable, includeIds);
+    }
+
+    /**
+     * Given a list of members, maps them by their user ID.
+     * 
+     * @param members the members to map
+     * @return a map of user ID to corresponding member
+     */
+    public static Map<Long, Member> mapUserIdToMember(Collection<? extends Member> members) {
+        return members.stream().collect(Collectors.toMap(Member::getIdLong, Function.identity()));
     }
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/features/tophelper/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tophelper/package-info.java
@@ -1,5 +1,5 @@
 /**
- * This packages offers all the functionality for the top-helpers command system. The core class is
+ * This packages offers all the functionality for the top-helpers system. The core class is
  * {@link org.togetherjava.tjbot.features.tophelper.TopHelpersCommand}.
  */
 @MethodsReturnNonnullByDefault

--- a/application/src/main/java/org/togetherjava/tjbot/features/utils/Guilds.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/utils/Guilds.java
@@ -3,6 +3,10 @@ package org.togetherjava.tjbot.features.utils;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.channel.attribute.IGuildChannelContainer;
+import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -52,5 +56,35 @@ public final class Guilds {
     public static boolean doesMemberNotHaveRole(Member member,
             Predicate<? super String> isRoleName) {
         return member.getRoles().stream().map(Role::getName).noneMatch(isRoleName);
+    }
+
+    /**
+     * Finds any text channel in the guild whose name matches the given predicate.
+     *
+     * @param guild guild to search the channel in
+     * @param isChannelName a predicate matching the name of the text channel to search
+     * @return the matched text channel, if any
+     */
+    public static Optional<TextChannel> findTextChannel(IGuildChannelContainer<GuildChannel> guild,
+            Predicate<? super String> isChannelName) {
+        return guild.getTextChannelCache()
+            .stream()
+            .filter(channel -> isChannelName.test(channel.getName()))
+            .findAny();
+    }
+
+    /**
+     * Finds any forum channel in the guild whose name matches the given predicate.
+     *
+     * @param guild guild to search the channel in
+     * @param isChannelName a predicate matching the name of the forum channel to search
+     * @return the matched forum channel, if any
+     */
+    public static Optional<ForumChannel> findForumChannel(
+            IGuildChannelContainer<GuildChannel> guild, Predicate<? super String> isChannelName) {
+        return guild.getForumChannelCache()
+            .stream()
+            .filter(channel -> isChannelName.test(channel.getName()))
+            .findAny();
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/utils/Guilds.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/utils/Guilds.java
@@ -1,0 +1,56 @@
+package org.togetherjava.tjbot.features.utils;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * Utility methods for working with {@link Guild}s.
+ * <p>
+ * This class is meant to contain all utility methods for {@link Guild}s that can be used on all
+ * other commands to avoid similar methods appearing everywhere.
+ */
+public final class Guilds {
+    private Guilds() {
+        throw new UnsupportedOperationException("Utility class, construction not supported");
+    }
+
+    /**
+     * Finds any role in the guild whose name matches the given predicate.
+     *
+     * @param guild guild to search the role in
+     * @param isRoleName a predicate matching the name of the role to search
+     * @return the matched role, if any
+     */
+    public static Optional<Role> findRole(Guild guild, Predicate<? super String> isRoleName) {
+        return guild.getRoles().stream().filter(role -> isRoleName.test(role.getName())).findAny();
+    }
+
+    /**
+     * Checks whether a given member has a role whose name matches a given predicate.
+     *
+     * @param member the member to check
+     * @param isRoleName a predicate matching the name of the role to search
+     * @return {@code true} if the member has a matching role, {@code false} otherwise
+     * @see #doesMemberNotHaveRole(Member, Predicate)
+     */
+    public static boolean hasMemberRole(Member member, Predicate<? super String> isRoleName) {
+        return member.getRoles().stream().map(Role::getName).anyMatch(isRoleName);
+    }
+
+    /**
+     * Checks whether a given member does not have a role whose name matches a given predicate.
+     *
+     * @param member the member to check
+     * @param isRoleName a predicate matching the name of the role to search
+     * @return {@code true} if the member does not have any matching role, {@code false} otherwise
+     * @see #hasMemberRole(Member, Predicate)
+     */
+    public static boolean doesMemberNotHaveRole(Member member,
+            Predicate<? super String> isRoleName) {
+        return member.getRoles().stream().map(Role::getName).noneMatch(isRoleName);
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/features/utils/MessageUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/utils/MessageUtils.java
@@ -19,7 +19,7 @@ import java.util.function.Supplier;
  * This class is meant to contain all utility methods for {@link Message} that can be used on all
  * other commands to avoid similar methods appearing everywhere.
  */
-public class MessageUtils {
+public final class MessageUtils {
     public static final int MAXIMUM_VISIBLE_EMBEDS = 25;
     public static final String ABBREVIATION = "...";
     private static final String CODE_FENCE_SYMBOL = "```";


### PR DESCRIPTION
## Motivation

Currently we do the monthly Top Helpers manually with the aid of `/top-helpers`, showing a list like this:

![current list](https://i.imgur.com/vdpMIax.png)

Everything beyond that is manual, i.e.:

* Clearing the current top helpers from the role
* Assigning the new top helpers to the role
* writing an announcement in `#hall-of-fame`

![hall-of-fame current](https://i.imgur.com/w2aux1V.png)

The problem with this is that, because its mostly manual work, we kept forgetting and skipping it for a few months already. Not good 😢

## Solution

This PR introduces a semi-automatic routine that does the Top Helper assignment and announcement automatically with minimal and simple investman by a human.

The routine starts on the 1st of each month at 12:00 o'clock (or can be started manually using `/top-helpers assign`) and creates a dialog in a trusted channel (e.g. `community-commands`).

The dialog proposes a list of Top Helpers (as known from the existing `/top-helpers` command, now renamed to `/top-helpers show`).

A trusted user can now select from this list everyone who should become Top Helper. The routine then continues automatically clearing the Top Helper role and assigning the role to the selected people.

Additionally, the routine then continues to ask if it should make a generic announcement (in `#hall-of-fame`) as well or if that should be skipped.

### Impressions

![flow](https://i.imgur.com/0lJhb2f.gif)

![hall-of-fame](https://i.imgur.com/cSfhnT0.png)

### Flexibility

The routine can be cancelled at any point in case needed by pressing the `Cancel` button. It can also be started outside of the normal schedule by using `/top-helpers assign`.

Adding users to the list of Top Helpers that were not proposed by the bot or otherwise modifying the list is possible by simply clicking `No` on the question for the generic announcement. Like, roll with the automatic assignment of the routine, dont send an automatic announcement and then edit the Role manually as we used to before this PR already. Then, if desired, simply send an announcement with the modified list yourself.

The last step with the generic announcement was made optional on purpose since a huge appeal of the "announcements made by a human" always was to include a funny image. We still want this to be possible, so if someone is in the mood to create such an image they can click on `No` and skip the generic announcement, writing one themselves. In practice however, people will often not have the time for this, so the generic announcement is a good way out, definitely better than no announcement.

## Config

This introduces a new block to the config:

```json
"topHelpers": {
  "rolePattern": "Top Helper.*",
  "assignmentChannelPattern": "community-commands",
  "announcementChannelPattern": "hall-of-fame"
}
```

Further, the patterns for the `Top Helper` role have been adjusted everywhere in the config from `Top Helpers .+` to `Top Helper.*`. This allows for renaming the role from e.g. `Top Helpers August` to `Top Helper`, while still being compatible with the current role name.

(this is a user suggestion with lots of upvotes, so it will likely be put in action soon anyways)

### Discord

So while at it, it is proposed (but not required) to rename the role `Top Helpers August` etc to `Top Helper`.

## Commands

The existing slashcommand `/top-helpers` was changed into two subcommands:

* `/top-helpers show`: shows the list of top helpers, i.e. what `/top-helpers` did already
* `/top-helpers assign`: manual trigger for the routine added in this PR

## Code

Most changes in this PR revolve around the addition of a new class called `TopHelpersAssignmentRoutine`, which deals with the entire dialog.

Some of the logic in this routine is shared with the existing slash command `TopHelpersCommand`, so a helper class was added to allow shared logic: `TopHelpersService`.

The service mostly deals with the actual computation of Top Helpers (using the DB), retrieval of user data (helper IDs to JDA `Member`) and visual presentation (ASCII table). This code is not new and merely moved from `TopHelpersCommand` over to `TopHelpersService`, sometimes with slight modifications to also fit the needs of `TopHelpersAssignmentRoutine`.

### `Schedule`

The routine needs the ability to execute "once a month at a fixed time". We already had similar code to enable that present in `ModAuditLogRoutine`. This code has been elevated from there to `Routine`, to allow others to use the logic as well.

I.e. while the methods `Schedule.atFixedRateFromNextFixedTime(...)` and `Schedule.atFixedHour(...)` are new, their code is not new and was part of `ModAuditLogRoutine` already.

### Slash Command (`TopHelpersCommand`)

The slash command stays mostly unchanged. Modifications include it now using sub-commands (see its constructor), simple routing code in `onSlashCommand` to determine which sub-command was triggered and in case of the new sub-command `show` it just forwards in `assignTopHelpers` to the routine `assignmentRoutine.startDialogFor(...)`.

To enable that, it got the routine as dependency at construction.

### Routine (`TopHelpersAssignmentRoutine`)

The code for this is mostly straightforward, albeit a bit annoying due to JDA not making it easy to create dialogs and constantly interrupting code-flow.

The method order goes from top to bottom to represent the flow of the routine, it should mostly read in a straightforward way without jumping around much.

#### Error Handling

Error handling is mostly similar but has slight differences. These mostly revolve around the fact whether there was already a message posted by the bot that can be edited or if a new message needs to be posted.

And if there was a message already, whether it includes buttons and similar that need to be cleared.

#### Remarks

A few things to highlight:

* progress during the routine is reported to the user by appending new lines to the existing message, e.g. `...editOriginal(message + "\n...")`
* each new step in the routine clears buttons and selection-menus of the previous step, e.g. `.setActionRow(...)` or also `setComponents()`
* the routine needs to use `componentIdInteractor` manually as it is not a traditional slash or context command. I.e. it can not extend from something like `SlashCommandAdapter` bringing component-ID logic out of the box and needs to instead implement `UserInteractor` manually. We did that already in the past with `ScamBlocker` in the same way.