### PR TITLE
Made GitHub cache update async and fixed cache refresh check. Fixes #…

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/github/GitHubCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/github/GitHubCommand.java
@@ -4,6 +4,8 @@ import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInterac
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import org.kohsuke.github.GHIssue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.togetherjava.tjbot.features.CommandVisibility;
 import org.togetherjava.tjbot.features.SlashCommandAdapter;
@@ -17,13 +19,10 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.ToIntFunction;
 import java.util.regex.Matcher;
 import java.util.stream.Stream;
-import java.util.concurrent.CompletableFuture;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Slash command (/github-search) used to search for an issue in one of the repositories listed in


### PR DESCRIPTION
Fixes: 
1. Made updateCache() async to avoid blocking.
2. Added null-safe default for autocompleteGHIssueCache as asked.

Also did: 
1. Added null-safe default for lastCacheUpdate (Instant.EPOCH) to prevent NPE.
2. Fixed cache refresh logic by using isBefore (only refresh when stale).

