### PR TITLE
Detect attachment scam regardless of case (jpg vs JPG)

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/Attachment.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/Attachment.java
@@ -2,6 +2,7 @@ package org.togetherjava.tjbot.features.moderation.scam;
 
 import net.dv8tion.jda.api.entities.Message;
 
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
@@ -10,7 +11,9 @@ record Attachment(String fileName) {
             Set.of("jpg", "jpeg", "png", "gif", "webp", "tiff", "svg", "apng");
 
     boolean isImage() {
-        return getFileExtension().map(IMAGE_EXTENSIONS::contains).orElse(false);
+        return getFileExtension().map(ext -> ext.toLowerCase(Locale.US))
+            .map(IMAGE_EXTENSIONS::contains)
+            .orElse(false);
     }
 
     private Optional<String> getFileExtension() {

--- a/application/src/test/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetectorTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetectorTest.java
@@ -211,6 +211,23 @@ final class ScamDetectorTest {
     }
 
     @Test
+    @DisplayName("Messages containing suspicious attachments are flagged even if extensions are upper-case (jpg vs JPG)")
+    void detectsSuspiciousAttachmentsRegardlessOfCase() {
+        // GIVEN an empty message containing suspicious attachments with mixed case for extensions
+        String content = "";
+        List<Message.Attachment> attachments =
+                List.of(createImageAttachmentMock("1.JPG"), createImageAttachmentMock("2.JPG"),
+                        createImageAttachmentMock("3.jpg"), createImageAttachmentMock("4.jpg"));
+        Message message = createMessageMock(content, attachments);
+
+        // WHEN analyzing it
+        boolean isScamResult = scamDetector.isScam(message);
+
+        // THEN flags it as scam
+        assertTrue(isScamResult);
+    }
+
+    @Test
     @DisplayName("Suspicious messages send by trusted users are not flagged")
     void ignoreTrustedUser() {
         // GIVEN a scam message send by a trusted user


### PR DESCRIPTION
We recently had a case in PROD where someone posted attachment-based scam that went undetected.

The message looked like this:

![scam](https://i.imgur.com/JI0LTZr.png)

The reason was that our code compared file extensions case-sensitive. For example only attachments like `1.jpg` are detected as image (and hence contribute to the scam check). Attachments like `1.JPG` bypassed it.

Simple fix. Also added a unit test.