### PR TITLE
Support Video Preview in RSS Feeds

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -187,6 +187,7 @@
             }
         ],
         "fallbackChannelPattern": "java-news-and-changes",
+        "videoLinkPattern": "http(s)?://www\\.youtube.com.*",
         "pollIntervalInMinutes": 10
     },
     "memberCountCategoryPattern": "Info",

--- a/application/src/main/java/org/togetherjava/tjbot/config/RSSFeedsConfig.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/RSSFeedsConfig.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 public record RSSFeedsConfig(@JsonProperty(value = "feeds", required = true) List<RSSFeed> feeds,
         @JsonProperty(value = "fallbackChannelPattern",
                 required = true) String fallbackChannelPattern,
+        @JsonProperty(value = "videoLinkPattern", required = true) String videoLinkPattern,
         @JsonProperty(value = "pollIntervalInMinutes", required = true) int pollIntervalInMinutes) {
 
     /**
@@ -23,6 +24,8 @@ public record RSSFeedsConfig(@JsonProperty(value = "feeds", required = true) Lis
      *
      * @param feeds The list of RSS feeds to subscribe to.
      * @param fallbackChannelPattern The pattern used to identify the fallback text channel to use.
+     * @param videoLinkPattern pattern determining if a link is a video. It is then posted in a way
+     *        to support Discord video embeds.
      * @param pollIntervalInMinutes The interval (in minutes) for polling the RSS feeds for updates.
      * @throws NullPointerException if any of the parameters (feeds or fallbackChannelPattern) are
      *         null
@@ -30,5 +33,6 @@ public record RSSFeedsConfig(@JsonProperty(value = "feeds", required = true) Lis
     public RSSFeedsConfig {
         Objects.requireNonNull(feeds);
         Objects.requireNonNull(fallbackChannelPattern);
+        Objects.requireNonNull(videoLinkPattern);
     }
 }


### PR DESCRIPTION
Closes #1301.

Our RSS feeds so far have always been posted as embed. But embeds dont have Discord-embedded video previews:

![so far](https://i.imgur.com/O0BAcbl.png)

This fixes it by posting videos as normal messages instead:

![now](https://i.imgur.com/H4liwOh.png)

Non-videos are still posted as embed.

## Config Changes

This adds to `rssConfig`:

```json
"videoLinkPattern": "http(s)?://www\\.youtube.com.*",
```