### PR TITLE
Fix: audit message being empty for attachment-only scam posts (#1300)

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -257,7 +257,7 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
                 .collect(Collectors.joining(", "));
             content += "%s(The message has %d attachment%s: %s)".formatted(
                     content.isBlank() ? "" : "\n", attachments.size(),
-                    attachments.size() > 1 ? "s " : " ", attachmentInfo);
+                    attachments.size() > 1 ? "s " : "", attachmentInfo);
         }
         MessageEmbed embed = new EmbedBuilder().setDescription(content)
             .setTitle(reportTitle)

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -255,8 +255,9 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
             String attachmentInfo = attachments.stream()
                 .map(Message.Attachment::getFileName)
                 .collect(Collectors.joining(", "));
-            content += (content.isEmpty() ? "" : " ") + "and " + attachments.size() + " attachment"
-                    + (attachments.size() > 1 ? "s " : " ") + "(" + attachmentInfo + ")";
+            content += "%s(The message has %d attachment%s: %s)".formatted(
+                    content.isBlank() ? "" : "\n", attachments.size(),
+                    attachments.size() > 1 ? "s " : " ", attachmentInfo);
         }
         MessageEmbed embed = new EmbedBuilder().setDescription(content)
             .setTitle(reportTitle)

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -48,6 +48,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Listener that receives all sent messages from channels, checks them for scam and takes
@@ -247,9 +248,20 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
 
         User author = event.getAuthor();
         String avatarOrDefaultUrl = author.getEffectiveAvatarUrl();
+        String content = event.getMessage().getContentStripped();
+        List<Message.Attachment> attachments = event.getMessage().getAttachments();
 
+        if (!attachments.isEmpty()) {
+            String attachmentInfo = attachments.stream()
+                    .map(Message.Attachment::getFileName)
+                    .collect(Collectors.joining(", "));
+            content += (content.isEmpty() ? "" : " ")
+                    + "and " + attachments.size() + " attachment"
+                    + (attachments.size() > 1 ? "s " : " ")
+                    + "(" + attachmentInfo + ")";
+        }
         MessageEmbed embed =
-                new EmbedBuilder().setDescription(event.getMessage().getContentStripped())
+                new EmbedBuilder().setDescription(content)
                     .setTitle(reportTitle)
                     .setAuthor(author.getName(), null, avatarOrDefaultUrl)
                     .setTimestamp(event.getMessage().getTimeCreated())

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -253,21 +253,18 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
 
         if (!attachments.isEmpty()) {
             String attachmentInfo = attachments.stream()
-                    .map(Message.Attachment::getFileName)
-                    .collect(Collectors.joining(", "));
-            content += (content.isEmpty() ? "" : " ")
-                    + "and " + attachments.size() + " attachment"
-                    + (attachments.size() > 1 ? "s " : " ")
-                    + "(" + attachmentInfo + ")";
+                .map(Message.Attachment::getFileName)
+                .collect(Collectors.joining(", "));
+            content += (content.isEmpty() ? "" : " ") + "and " + attachments.size() + " attachment"
+                    + (attachments.size() > 1 ? "s " : " ") + "(" + attachmentInfo + ")";
         }
-        MessageEmbed embed =
-                new EmbedBuilder().setDescription(content)
-                    .setTitle(reportTitle)
-                    .setAuthor(author.getName(), null, avatarOrDefaultUrl)
-                    .setTimestamp(event.getMessage().getTimeCreated())
-                    .setColor(AMBIENT_COLOR)
-                    .setFooter(author.getId())
-                    .build();
+        MessageEmbed embed = new EmbedBuilder().setDescription(content)
+            .setTitle(reportTitle)
+            .setAuthor(author.getName(), null, avatarOrDefaultUrl)
+            .setTimestamp(event.getMessage().getTimeCreated())
+            .setColor(AMBIENT_COLOR)
+            .setFooter(author.getId())
+            .build();
 
         MessageCreateBuilder messageBuilder = new MessageCreateBuilder().setEmbeds(embed);
         if (!confirmDialog.isEmpty()) {


### PR DESCRIPTION
Fixed #1300 