### PR TITLE
Fixes quotation marks in titles on /transfer

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -100,10 +100,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
                     .formatted(originalMessage);
         Optional<String> chatGptTitle = chatGptService.ask(chatGptTitleRequest, null);
         String title = chatGptTitle.orElse(createTitle(originalMessage));
-
-        // Fix
         title = title.replaceAll("^[\"']|[\"']$", "");
-        //
 
         if (title.length() > TITLE_MAX_LENGTH) {
             title = title.substring(0, TITLE_MAX_LENGTH);


### PR DESCRIPTION
Added a regex to remove the quotation marks in the begging and in the end of the title (single or double).

Fixes and closes #1134