### PR TITLE
Updating scam detector for new scam and false positives

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -40,7 +40,7 @@
             "whatsapp",
             "crypto",
             "^claim",
-            "teen",
+            "^teen$",
             "adobe",
             "^hack$",
             "hacks",

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/TokenAnalyse.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/TokenAnalyse.java
@@ -5,6 +5,8 @@ import org.togetherjava.tjbot.features.utils.StringDistances;
 
 import java.net.URI;
 import java.util.Locale;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 /**
  * Analyzes a given text token. Populates various metrics regarding the token possibly being
@@ -14,6 +16,10 @@ import java.util.Locale;
  * {@link #analyze(String, AnalyseResults)}.
  */
 final class TokenAnalyse {
+    // Tokens like: "org.schema.game.common.data.world.Sector.access$200(Sector.java:120)"
+    private static final Predicate<String> IS_STACKTRACE_TOKEN =
+            Pattern.compile("(org|com|de|dev)(\\.[^.()]+){4,15}\\([^.()]+\\.java:\\d+\\)")
+                .asMatchPredicate();
     private final ScamBlockerConfig config;
 
     TokenAnalyse(ScamBlockerConfig config) {
@@ -27,7 +33,7 @@ final class TokenAnalyse {
      * @param results metrics representing how suspicious the token is
      */
     void analyze(String token, AnalyseResults results) {
-        if (token.isBlank()) {
+        if (token.isBlank() || IS_STACKTRACE_TOKEN.test(token)) {
             return;
         }
 

--- a/application/src/test/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetectorTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/features/moderation/scam/ScamDetectorTest.java
@@ -546,6 +546,19 @@ final class ScamDetectorTest {
                         https://learn.microsoft.com/en-us/powershell/scripting/discover-powershell?view=powershell-7.5
                         What makes PowerShell unique is that it accepts and returns .NET objects, rather than text.
                         because of that, but well it says that it returns .NET objects not that the commands are from .NET,
-                        but well as i said i use cmd.exe because i do not know .NET nor powershell""");
+                        but well as i said i use cmd.exe because i do not know .NET nor powershell""",
+                """
+                        Exception in thread "ServerEntityWriterThread"
+                        java.lang.NoSuchMethodError: org.schema.game.common.controller.rails.RailRelation.isLocked()Z
+                        at org.schema.game.common.controller.rails.RailController.getDockedTag(RailController.java:2686)
+                        at org.schema.game.common.controller.rails.RailController.getTag(RailController.java:2652)
+                        at org.schema.game.common.controller.SegmentController.toTagStructure(SegmentController.java:2813)
+                        at org.schema.game.common.data.EntityFileTools.write(EntityFileTools.java:57)
+                        at org.schema.game.server.controller.GameServerController.writeEntity(GameServerController.java:2938)
+                        at org.schema.game.common.data.world.Sector.writeSingle(Sector.java:2570)
+                        at org.schema.game.common.data.world.Sector.writeEntity(Sector.java:2546)
+                        at org.schema.game.common.data.world.Sector.access$200(Sector.java:120)
+                        at org.schema.game.common.data.world.Sector$3.run(Sector.java:2665)
+                        at org.schema.schine.network.server.ServerEntityWriterThread.run(ServerEntityWriterThread.java:74)""");
     }
 }


### PR DESCRIPTION
Adjusted the scam detector to deal with new real scam and false positives.

## Config ##

The config was changed:
```java
// sus keywords
"teen" -> "^teen$"
"hack" -> "^hack$", "hacks"

// domain whitelist
"store.steampowered.com",
"help.steampowered.com",
"learn.microsoft.com"
```
changes have already been executed on DEV and MASTER, so the bot doesnt need to be updated anymore.