### PR TITLE
Fixes /reminder list fails if no reminders

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/reminder/ReminderCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/reminder/ReminderCommand.java
@@ -219,6 +219,7 @@ public final class ReminderCommand extends SlashCommandAdapter {
             List<PendingRemindersRecord> pendingReminders, int pageToShow) {
         // 12 reminders, 10 per page, ceil(12 / 10) = 2
         int totalPages = Math.ceilDiv(pendingReminders.size(), REMINDERS_PER_PAGE);
+        totalPages = Math.max(1, totalPages);
 
         pageToShow = Math.clamp(pageToShow, 1, totalPages);
 


### PR DESCRIPTION
Fixes the `/reminder list` issue and returns the expected result of:

<img width="135" height="61" alt="Screenshot 2025-11-28 at 15 46 33" src="https://github.com/user-attachments/assets/783cea3d-1880-44e0-872b-47ebe0c72d8f" />

Closes #1350 
