### PR TITLE
fix: rss failures with exponential blacklist

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/rss/FailureState.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/rss/FailureState.java
@@ -1,0 +1,6 @@
+package org.togetherjava.tjbot.features.rss;
+
+import java.time.ZonedDateTime;
+
+record FailureState(int count, ZonedDateTime lastFailure) {
+}

--- a/application/src/main/java/org/togetherjava/tjbot/features/rss/RSSHandlerRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/rss/RSSHandlerRoutine.java
@@ -72,9 +72,6 @@ import static org.togetherjava.tjbot.db.generated.tables.RssFeed.RSS_FEED;
  */
 public final class RSSHandlerRoutine implements Routine {
 
-    private record FailureState(int count, ZonedDateTime lastFailure) {
-    }
-
     private static final Logger logger = LoggerFactory.getLogger(RSSHandlerRoutine.class);
     private static final int MAX_CONTENTS = 1000;
     private static final ZonedDateTime ZONED_TIME_MIN =


### PR DESCRIPTION
context: error logs being spammed by intermittent 404 status code on rss feed urls

<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/7bff3cbc-955f-4e6d-9b24-d77d810f0b58" />


failed rss feed urls are marked as blacklisted upto 24 hours, if it's a dead url it notifies with error log for admin to remove it.

How the fix works

* Failed RSS feed URLs are tracked in an in-memory cache along with their failure count and last failure timestamp.

* Each failure triggers an exponential backoff before the next retry: 1h, 2h, 4h, 8h, 16h, capped at 24 hours maximum.

* While a URL is within its backoff window, it is skipped and not fetched.

* If a fetch succeeds, the failure state is removed from cache and the URL resumes normal polling.

* Cache entries automatically expire after 7 days, preventing stale failures from persisting indefinitely.

* If a feed fails 15 times, it is considered potentially dead and an error is logged to notify admins to remove it from configuration.