### PR TITLE
hotfix(RSSHandlerRoutine): resolve java:S121

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/rss/RSSHandlerRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/rss/RSSHandlerRoutine.java
@@ -465,8 +465,9 @@ public final class RSSHandlerRoutine implements Routine {
 
     private boolean isBackingOff(String url) {
         FailureState state = circuitBreaker.getIfPresent(url);
-        if (state == null)
+        if (state == null) {
             return false;
+        }
 
         long waitHours = calculateWaitHours(state.count());
         ZonedDateTime retryAt = state.lastFailure().plusHours(waitHours);


### PR DESCRIPTION
While analyzing the code, SonarQube is rightfully complaining about:

```Control structures should use curly braces.```

Fix this by simply adding curly braces to the if statement.