### PR TITLE
pre-commit: run sonarlintMain task

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -44,6 +44,14 @@ if [ "$spotlessExitCode" -ne 0 ]; then
   exit "$spotlessExitCode"
 fi
 
+echo "**Running Sonarlint checks**"
+./gradlew sonarlintMain
+sonarlintExitCode=$?
+if [ "$sonarlintExitCode" -ne 0 ]; then
+  pop_stash
+  exit "$sonarlintMain"
+fi
+
 # Spotless possibly found changes, apply them, excluding untracked files
 git add -u
 


### PR DESCRIPTION
Recently thanks to a surge in new contributors, it has been observed that many of their commits contain code that does not pass Sonarlint checks. This results in the CI checks failing, and contributors have to push new commits to address the Sonarlint complaints.

Introduce a new pre-commit hook procedure that also runs Sonarlint right before a commit gets created, which should exit with a non-zero status code so that the commit does not get made if it does not pass Sonarlint checks.

Running Sonarlint checks is a passive task - in other words, it does not take the initiative of editing the code in order to make it pass the tests, so it's safe to call the Gradle task by just calling

```bash
./gradlew sonarlintMain
```

Hopefully with this we get less unexpected failures on our CI pipeline and more motivated contributors.