### PR TITLE
VoiceReceiverAdapter.java: add default missing doc

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/VoiceReceiverAdapter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/VoiceReceiverAdapter.java
@@ -9,7 +9,11 @@ import net.dv8tion.jda.api.events.guild.voice.GuildVoiceVideoEvent;
 import java.util.regex.Pattern;
 
 /**
- * Default implementation of {@link VoiceReceiver}.
+ * Adapter implementation of a {@link VoiceReceiver}. A new receiver can then be registered by
+ * adding it to {@link Features}.
+ * <p>
+ * {@link #onVoiceUpdate(GuildVoiceUpdateEvent)} like the other provided methods can be overridden
+ * if desired. The default implementation is empty, the adapter will not react to such events.
  */
 public class VoiceReceiverAdapter implements VoiceReceiver {
 


### PR DESCRIPTION
# Why
Sonarlint wants every public class to have a JavaDoc.