### PR TITLE
Hotfix: Don't care about reactions in the Quotes Board itself

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/basic/QuoteBoardForwarder.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/basic/QuoteBoardForwarder.java
@@ -89,7 +89,7 @@ public final class QuoteBoardForwarder extends MessageReceiverAdapter {
             return;
         }
 
-        TextChannel boardChannel = boardChannelOptional.get();
+        TextChannel boardChannel = boardChannelOptional.orElseThrow();
 
         if (boardChannel.getId().equals(event.getChannel().getId())) {
             logger.debug("Someone tried to react with the react emoji to the quotes channel.");


### PR DESCRIPTION
Great, we recently made a quotes board, and if a message gets 5 stars, then it's added to the quotes board.  What happens if someone reacts from _within_ the quotes board itself?

Add an additional condition so that message reaction additions are not counted within this feature if the reaction is in the quotes board itself.