### PR TITLE
hotfix(DynamicVoiceChat): Don't care about bots connecting in voice chats

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/voicechat/DynamicVoiceChat.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/voicechat/DynamicVoiceChat.java
@@ -5,6 +5,7 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.MessageHistory;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.Category;
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel;
@@ -45,6 +46,13 @@ public final class DynamicVoiceChat extends VoiceReceiverAdapter {
 
     @Override
     public void onVoiceUpdate(@NotNull GuildVoiceUpdateEvent event) {
+        Member member = event.getMember();
+        User user = member.getUser();
+
+        if (user.isBot()) {
+            return;
+        }
+
         AudioChannelUnion channelJoined = event.getChannelJoined();
         AudioChannelUnion channelLeft = event.getChannelLeft();
 


### PR DESCRIPTION
We don't want bots like VC Transcribe to have their own private dynamic rooms.

Make it so that we shouldn't care about them.