### PR TITLE
Hotfix: Synchronize archive channel permissions with category

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/voicechat/DynamicVoiceChat.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/voicechat/DynamicVoiceChat.java
@@ -150,6 +150,7 @@ public final class DynamicVoiceChat extends VoiceReceiverAdapter {
 
         archiveCategoryOptional.ifPresent(archiveCategory -> restActionChain
             .and(channelManager.setParent(archiveCategory))
+            .and(channelManager.sync(archiveCategory))
             .queue(_ -> voiceChatCleanupStrategy.cleanup(archiveCategory.getVoiceChannels()),
                     err -> logger.error("Could not archive dynamic voice chat", err)));
     }


### PR DESCRIPTION
Archives are being seen by ordinary members because the channels have no permissions being set properly.