### PR TITLE
Quotes board: Allow reactions with any emoji

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -195,9 +195,34 @@
         "pollIntervalInMinutes": 10
     },
     "quoteBoardConfig": {
-        "minimumReactionsToTrigger": 5,
+        "minimumScoreToTrigger": 5.0,
         "channel": "quotes",
-        "reactionEmoji": "⭐"
+        "botEmoji": "⭐",
+        "defaultEmojiScore": 0.5,
+        "emojiScores": {
+            "😬": -0.5,
+            "💔": -0.5,
+            "😐": -0.5,
+            "😊": -0.5,
+            "🖕": -0.5,
+            "👎": -0.5,
+            "💩": -0.5,
+            "🤢": -0.5,
+            "🤮": -0.5,
+            "🤬": -0.5,
+            "😡": -0.5,
+            "😒": -0.5,
+            "🤨": -0.5,
+
+            "🇷🇺": 0.0,
+            "🇵🇸": 0.0,
+            "🇮🇱": 0.0,
+            "🏳️‍🌈": 0.0,
+
+            "⭐": 1.0,
+
+            "youtube:1464573182206804010": 0.0
+        }
     },
     "memberCountCategoryPattern": "Info",
     "topHelpers": {

--- a/application/src/main/java/org/togetherjava/tjbot/config/QuoteBoardConfig.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/QuoteBoardConfig.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 @JsonRootName("quoteBoardConfig")
 public record QuoteBoardConfig(
         @JsonProperty(value = "minimumScoreToTrigger", required = true) float minimumScoreToTrigger,
-        @JsonProperty(required = true) String channel,
+        @JsonProperty(value = "channel", required = true) String channel,
         @JsonProperty(value = "botEmoji", required = true) String botEmoji,
         @JsonProperty(value = "defaultEmojiScore", required = true) float defaultEmojiScore,
         @JsonProperty(value = "emojiScores", required = true) Map<String, Float> emojiScores) {
@@ -25,8 +25,9 @@ public record QuoteBoardConfig(
      *
      * @param minimumScoreToTrigger the minimum amount of reaction score for a message to be quoted
      * @param channel the pattern for the board channel
-     * @param defaultEmojiScore the default score of an emoji if it's not in the emojiScores map
      * @param botEmoji the emoji with which the bot will mark quoted messages
+     * @param defaultEmojiScore the default score of an emoji if it's not in the emojiScores map
+     * @param emojiScores a map of each emoji's custom score
      */
     public QuoteBoardConfig {
         if (minimumScoreToTrigger <= 0) {

--- a/application/src/main/java/org/togetherjava/tjbot/config/QuoteBoardConfig.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/QuoteBoardConfig.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.LogManager;
 
 import org.togetherjava.tjbot.features.basic.QuoteBoardForwarder;
 
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -13,31 +14,35 @@ import java.util.Objects;
  */
 @JsonRootName("quoteBoardConfig")
 public record QuoteBoardConfig(
-        @JsonProperty(value = "minimumReactionsToTrigger", required = true) int minimumReactions,
+        @JsonProperty(value = "minimumScoreToTrigger", required = true) float minimumScoreToTrigger,
         @JsonProperty(required = true) String channel,
-        @JsonProperty(value = "reactionEmoji", required = true) String reactionEmoji) {
+        @JsonProperty(value = "botEmoji", required = true) String botEmoji,
+        @JsonProperty(value = "defaultEmojiScore", required = true) float defaultEmojiScore,
+        @JsonProperty(value = "emojiScores", required = true) Map<String, Float> emojiScores) {
 
     /**
      * Creates a QuoteBoardConfig.
      *
-     * @param minimumReactions the minimum amount of reactions
+     * @param minimumScoreToTrigger the minimum amount of reaction score for a message to be quoted
      * @param channel the pattern for the board channel
-     * @param reactionEmoji the emoji with which users should react to
+     * @param defaultEmojiScore the default score of an emoji if it's not in the emojiScores map
+     * @param botEmoji the emoji with which the bot will mark quoted messages
      */
     public QuoteBoardConfig {
-        if (minimumReactions <= 0) {
-            throw new IllegalArgumentException("minimumReactions must be greater than zero");
+        if (minimumScoreToTrigger <= 0) {
+            throw new IllegalArgumentException("minimumScoreToTrigger must be greater than zero");
         }
         Objects.requireNonNull(channel);
         if (channel.isBlank()) {
             throw new IllegalArgumentException("channel must not be empty or blank");
         }
-        Objects.requireNonNull(reactionEmoji);
-        if (reactionEmoji.isBlank()) {
+        Objects.requireNonNull(botEmoji);
+        if (botEmoji.isBlank()) {
             throw new IllegalArgumentException("reactionEmoji must not be empty or blank");
         }
+        Objects.requireNonNull(emojiScores);
         LogManager.getLogger(QuoteBoardConfig.class)
             .debug("Quote-Board configs loaded: minimumReactions={}, channel='{}', reactionEmoji='{}'",
-                    minimumReactions, channel, reactionEmoji);
+                    minimumScoreToTrigger, channel, botEmoji);
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/basic/QuoteBoardForwarder.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/basic/QuoteBoardForwarder.java
@@ -6,6 +6,7 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
+import net.dv8tion.jda.api.entities.emoji.EmojiUnion;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.requests.RestAction;
 import org.slf4j.Logger;
@@ -36,7 +37,7 @@ import java.util.regex.Pattern;
 public final class QuoteBoardForwarder extends MessageReceiverAdapter {
 
     private static final Logger logger = LoggerFactory.getLogger(QuoteBoardForwarder.class);
-    private final Emoji triggerReaction;
+    private final Emoji botEmoji;
     private final Predicate<String> isQuoteBoardChannelName;
     private final QuoteBoardConfig config;
 
@@ -48,7 +49,7 @@ public final class QuoteBoardForwarder extends MessageReceiverAdapter {
      */
     public QuoteBoardForwarder(Config config) {
         this.config = config.getQuoteBoardConfig();
-        this.triggerReaction = Emoji.fromUnicode(this.config.reactionEmoji());
+        this.botEmoji = Emoji.fromUnicode(this.config.botEmoji());
 
         this.isQuoteBoardChannelName = Pattern.compile(this.config.channel()).asMatchPredicate();
     }
@@ -60,21 +61,8 @@ public final class QuoteBoardForwarder extends MessageReceiverAdapter {
 
         final MessageReaction messageReaction = event.getReaction();
 
-        if (!messageReaction.getEmoji().equals(triggerReaction)) {
-            logger.debug("Reaction emoji '{}' does not match trigger emoji '{}'. Ignoring.",
-                    messageReaction.getEmoji(), triggerReaction);
-            return;
-        }
-
         if (hasAlreadyForwardedMessage(event.getJDA(), messageReaction)) {
             logger.debug("Message has already been forwarded by the bot. Skipping.");
-            return;
-        }
-
-        long reactionCount = messageReaction.retrieveUsers().stream().count();
-        if (reactionCount < config.minimumReactions()) {
-            logger.debug("Reaction count {} is less than minimum required {}. Skipping.",
-                    reactionCount, config.minimumReactions());
             return;
         }
 
@@ -96,21 +84,27 @@ public final class QuoteBoardForwarder extends MessageReceiverAdapter {
             return;
         }
 
-        logger.debug("Forwarding message to quote board channel: {}", boardChannel.getName());
+        event.retrieveMessage().queue(message -> {
+            float emojiScore = calculateMessageScore(message.getReactions());
 
-        event.retrieveMessage()
-            .queue(message -> markAsProcessed(message).flatMap(v -> message.forwardTo(boardChannel))
+            if (emojiScore < config.minimumScoreToTrigger()) {
+                return;
+            }
+
+            logger.debug("Attempting to forward message to quote board channel: {}",
+                    boardChannel.getName());
+
+            markAsProcessed(message).flatMap(_ -> message.forwardTo(boardChannel))
                 .queue(_ -> logger.debug("Message forwarded to quote board channel: {}",
-                        boardChannel.getName())),
-
-                    e -> logger.warn(
-                            "Unknown error while attempting to retrieve and forward message for quote-board, message is ignored.",
-                            e));
-
+                        boardChannel.getName()),
+                        e -> logger.warn(
+                                "Unknown error while attempting to retrieve and forward message for quote-board, message is ignored.",
+                                e));
+        });
     }
 
     private RestAction<Void> markAsProcessed(Message message) {
-        return message.addReaction(triggerReaction);
+        return message.addReaction(botEmoji);
     }
 
     /**
@@ -146,12 +140,25 @@ public final class QuoteBoardForwarder extends MessageReceiverAdapter {
      * Checks a {@link MessageReaction} to see if the bot has reacted to it.
      */
     private boolean hasAlreadyForwardedMessage(JDA jda, MessageReaction messageReaction) {
-        if (!triggerReaction.equals(messageReaction.getEmoji())) {
+        if (!botEmoji.equals(messageReaction.getEmoji())) {
             return false;
         }
 
         return messageReaction.retrieveUsers()
             .parallelStream()
             .anyMatch(user -> jda.getSelfUser().getIdLong() == user.getIdLong());
+    }
+
+    private float calculateMessageScore(List<MessageReaction> reactions) {
+        return (float) reactions.stream()
+            .mapToDouble(reaction -> reaction.getCount() * getEmojiScore(reaction.getEmoji()))
+            .sum();
+    }
+
+    private float getEmojiScore(EmojiUnion emoji) {
+        float defaultScore = config.defaultEmojiScore();
+        String reactionCode = emoji.getAsReactionCode();
+
+        return config.emojiScores().getOrDefault(reactionCode, defaultScore);
     }
 }


### PR DESCRIPTION
# Problem

Recently from the [server suggestions](https://discord.com/channels/272761734820003841/480829495486447627/1464256506617659554), many people have been slightly upset that the only reaction emoji considered for adding to the quotes board is the default star emoji.

Some members have suggested specific additional emojis to be considered, [others](https://ptb.discord.com/channels/272761734820003841/1464328383864242392/1464343398893752414) suggested that the star emoji should have a weight of `1.0` while the rest of the emojis should have a weight of `0.5`. While both solutions can work, all emojis can have a custom weight for the purpose of customizability.

# Solution

Introduce a scoring concept for each emoji, configurable for each particular one, and provide the ability to set a default value if an emoji is not defined in the configuration file.

For those who are wondering, _any_ kind of emoji that Discord can handle is able to be added in the configuration, including custom emojis in the server.  JDA can keep track of those.

For adding a unicode emoji, the actual unicode value has to be provided, like it has been done in `config.json.template`.

For adding a guild emoji, a "code" for the emoji has to be provided, for instance:

    youtube:1464573182206804010

Which stands for the friendly name of the emoji, a colon right after, and finally the ID of the custom emoji.

The "config.json.template" is _NOT_ exhaustive, more emojis have to be added and some others removed according to preference.


# Configuration changes

## quoteBoardConfig
| Property 	| Description 	| Type 	| Default 	|
|---	|---	|---	|---	|
| `quoteBoardConfig.minimumScoreToTrigger` 	| The minimum amount of reaction score for a message to be quoted. 	| float 	| `5.0` 	|
| `quoteBoardConfig.channel` 	| The pattern for the board channel. 	| String 	| `"quotes"` 	|
| `quoteBoardConfig.botEmoji` 	| The emoji with which the bot will mark quoted messages. 	| String 	| `⭐` 	|
| `quoteBoardConfig.defaultEmojiScore` 	| The default score of an emoji if it's not in the emojiScores map. 	| float 	| `0.5` 	|
| `quoteBoardConfig.emojiScores` 	| A map of each emoji's custom score. 	| Map<String, Float> 	|  _see below_ 	|

## emojiScores Map
⚠️ Note: This is just an example for you to get an idea of how you could utilize this configuration property and you are _encouraged_ to edit it to the server's needs.
```json
{
  "😬": -0.5,
  "💔": -0.5,
  "🖕": -0.5,
  "👎": -0.5,
  "🤨": -0.5,

  "🇷🇺": 0.0,
  "🇵🇸": 0.0,
  "🇮🇱": 0.0,

  "⭐": 1.0,

  /* Custom emoji */
  "youtube:1464573182206804010": 0.0
}
