### PR TITLE
hotfix(DynamicVoiceChat): delay deleting `channelLeft` on history fetch

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/voicechat/DynamicVoiceChat.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/voicechat/DynamicVoiceChat.java
@@ -20,6 +20,7 @@ import org.togetherjava.tjbot.config.DynamicVoiceChatConfig;
 import org.togetherjava.tjbot.features.VoiceReceiverAdapter;
 
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Handles dynamic voice channel creation and deletion based on user activity.
@@ -30,6 +31,7 @@ import java.util.Optional;
  */
 public final class DynamicVoiceChat extends VoiceReceiverAdapter {
     private static final Logger logger = LoggerFactory.getLogger(DynamicVoiceChat.class);
+    private static final long DELETE_VOICE_CHANNEL_ACTION_DELAY_MS = 500L;
 
     private final VoiceChatCleanupStrategy voiceChatCleanupStrategy;
     private final DynamicVoiceChatConfig dynamicVoiceChannelConfig;
@@ -87,13 +89,14 @@ public final class DynamicVoiceChat extends VoiceReceiverAdapter {
                 return;
             }
 
-            channelLeft.asVoiceChannel().getHistory().retrievePast(2).queue(messages -> {
+            channelLeft.asVoiceChannel().getHistory().retrievePast(2).onSuccess(messages -> {
                 if (messages.size() > 1) {
                     archiveDynamicVoiceChannel(channelLeft);
                 } else {
-                    channelLeft.delete().queue();
+                    channelLeft.delete()
+                        .queueAfter(DELETE_VOICE_CHANNEL_ACTION_DELAY_MS, TimeUnit.MILLISECONDS);
                 }
-            });
+            }).queue();
         }
     }
 


### PR DESCRIPTION
By letting the JDA asynchornously retrieve the voice channel history and figure out if we are going to delete the channel in question without making sure one finishes before the other gets executed, we receive this:

    RestAction queue returned failure: [ErrorResponseException] 10003:
    Unknown Channel net.dv8tion.jda.api.exceptions.ContextException
        at net.dv8tion.jda.api.exceptions.ContextException.here(ContextException.java:54)
        at net.dv8tion.jda.api.requests.Request.<init>(Request.java:78)
        at net.dv8tion.jda.internal.requests.RestActionImpl.queue(RestActionImpl.java:203)
        at net.dv8tion.jda.api.requests.RestAction.queue(RestAction.java:577)
        at org.togetherjava.tjbot.features.voicechat.DynamicVoiceChat.handleVoiceChannelLeave(DynamicVoiceChat.java:84)
        at org.togetherjava.tjbot.features.voicechat.DynamicVoiceChat.onVoiceUpdate(DynamicVoiceChat.java:68)
        at org.togetherjava.tjbot.features.system.BotCore.lambda$onGuildVoiceUpdate$1(BotCore.java:306)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:186)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:214)

Delay deleting `channelLeft` channel by 500ms and use `RestAction#onSuccess` to make sure that the channel history request is done _first_ and completely, before we move on to deleting the channel.