### PR TITLE
fix: double fire when channel is deleted

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/voicechat/DynamicVoiceChat.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/voicechat/DynamicVoiceChat.java
@@ -99,8 +99,12 @@ public final class DynamicVoiceChat extends VoiceReceiverAdapter {
                 if (messages.size() > 1) {
                     archiveDynamicVoiceChannel(channelLeft);
                 } else {
-                    channelLeft.delete().queue();
                     deletedChannels.put(channelId, true);
+                    try {
+                        channelLeft.delete().queue();
+                    } catch (Exception _) {
+                        // Ignore
+                    }
                 }
             });
         }


### PR DESCRIPTION
## Description

* Cache deleted channels for 5 mins to avoid double fire. 
* Check if member is bot inside onVoiceUpdate