### PR TITLE
build: include git-describe version as part of the bot in /ping command

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -93,3 +93,23 @@ application {
     mainClass = 'org.togetherjava.tjbot.Application'
     applicationDefaultJvmArgs = ["--enable-native-access=ALL-UNNAMED"]
 }
+
+def generatedBuildPropertiesDir = file("build/resources/main/")
+tasks.register('generateBuildProperties') {
+    def outputFile = new File(generatedBuildPropertiesDir, "build.properties")
+
+    doLast {
+        if (!generatedBuildPropertiesDir.exists()) {
+            generatedBuildPropertiesDir.mkdirs()
+        }
+        def props = new Properties()
+        props['app.git-version'] = version
+        props['app.build-date'] = new Date().format('yyyy-MM-dd HH:mm:ss:S z')
+
+        outputFile.withWriter { writer ->
+            props.store(writer, null)
+        }
+    }
+}
+
+processResources.dependsOn generateBuildProperties

--- a/application/src/main/java/org/togetherjava/tjbot/Application.java
+++ b/application/src/main/java/org/togetherjava/tjbot/Application.java
@@ -17,9 +17,11 @@ import org.togetherjava.tjbot.logging.LogMarkers;
 import org.togetherjava.tjbot.logging.discord.DiscordLogging;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.SQLException;
+import java.util.Properties;
 
 /**
  * Main class of the application. Use {@link #main(String[])} to start an instance of it.
@@ -34,6 +36,8 @@ public class Application {
 
     private static final Logger logger = LoggerFactory.getLogger(Application.class);
     private static final String DEFAULT_CONFIG_PATH = "config.json";
+    private static final String DEFAULT_BUILD_PROPERTIES_PATH = "build.properties";
+    private static final Properties BUILD_PROPERTIES = new Properties();
 
     /**
      * Starts the application.
@@ -56,6 +60,20 @@ public class Application {
             logger.error("Unable to load the configuration file from path '{}'",
                     configPath.toAbsolutePath(), e);
             return;
+        }
+
+        try (InputStream input = Application.class.getClassLoader()
+            .getResourceAsStream(DEFAULT_BUILD_PROPERTIES_PATH)) {
+            if (input == null) {
+                logger.warn(
+                        "Unable to find {} file, you might not see properties like the git commit of this build",
+                        DEFAULT_BUILD_PROPERTIES_PATH);
+            } else {
+                BUILD_PROPERTIES.load(input);
+            }
+        } catch (IOException e) {
+            logger.error("Exception while trying to load {} file", DEFAULT_BUILD_PROPERTIES_PATH,
+                    e);
         }
 
         Thread.setDefaultUncaughtExceptionHandler(Application::onUncaughtException);
@@ -120,4 +138,7 @@ public class Application {
         logger.error("Unknown error in thread {}.", failingThread.getName(), failure);
     }
 
+    public static Properties getBuildProperties() {
+        return BUILD_PROPERTIES;
+    }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/basic/PingCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/basic/PingCommand.java
@@ -2,8 +2,11 @@ package org.togetherjava.tjbot.features.basic;
 
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 
+import org.togetherjava.tjbot.Application;
 import org.togetherjava.tjbot.features.CommandVisibility;
 import org.togetherjava.tjbot.features.SlashCommandAdapter;
+
+import java.util.Properties;
 
 /**
  * Implementation of an example command to illustrate how to respond to a user.
@@ -25,6 +28,11 @@ public final class PingCommand extends SlashCommandAdapter {
      */
     @Override
     public void onSlashCommand(SlashCommandInteractionEvent event) {
-        event.reply("Pong!").queue();
+        Properties buildProperties = Application.getBuildProperties();
+        String response = "Pong! Running on version %s (%s)".formatted(
+                buildProperties.getProperty("app.git-version"),
+                buildProperties.getProperty("app.build-date"));
+
+        event.reply(response).queue();
     }
 }

--- a/application/src/test/java/org/togetherjava/tjbot/features/basic/PingCommandTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/features/basic/PingCommandTest.java
@@ -4,10 +4,12 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import org.togetherjava.tjbot.features.SlashCommand;
 import org.togetherjava.tjbot.jda.JdaTester;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 
 final class PingCommandTest {
@@ -35,6 +37,8 @@ final class PingCommandTest {
         SlashCommandInteractionEvent event = triggerSlashCommand();
 
         // THEN the bot replies with pong
-        verify(event).reply("Pong!");
+        ArgumentCaptor<String> replyMessageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(event).reply(replyMessageCaptor.capture());
+        assertTrue(replyMessageCaptor.getValue().startsWith("Pong!"));
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,12 @@ repositories {
     mavenCentral()
 }
 
+def gitDescribeOutput = providers.exec {
+    commandLine("git", "describe", "--tags")
+}.standardOutput.asText.get().trim()
+
 group 'org.togetherjava'
-version '1.0-SNAPSHOT'
+version gitDescribeOutput
 
 ext {
     jooqVersion = '3.20.5'


### PR DESCRIPTION
It is uncertain on which version the bot is running in production, and those with a lack of access to the production infrastructure have almost no way to get such information.

Expand the "/ping" slash command to actually mention which version it is running as well as the date on which it was built, more specfifically it now says:

    > Pong! Running on version v1.2.3-g1a2b3c (2026-02-28)

That way we don't have to approach the lucky few folks with access and badger them with primitive questions. :)