### PR TITLE
Feature/leaderboard command

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/Features.java
@@ -38,6 +38,7 @@ import org.togetherjava.tjbot.features.help.MarkHelpThreadCloseInDBRoutine;
 import org.togetherjava.tjbot.features.help.PinnedNotificationRemover;
 import org.togetherjava.tjbot.features.jshell.JShellCommand;
 import org.togetherjava.tjbot.features.jshell.JShellEval;
+import org.togetherjava.tjbot.features.leaderboard.LeaderboardCommand;
 import org.togetherjava.tjbot.features.mathcommands.TeXCommand;
 import org.togetherjava.tjbot.features.mathcommands.wolframalpha.WolframAlphaCommand;
 import org.togetherjava.tjbot.features.mediaonly.MediaOnlyChannelListener;
@@ -202,6 +203,7 @@ public class Features {
         features.add(new AuditCommand(actionsStore));
         features.add(new MuteCommand(actionsStore, config));
         features.add(new UnmuteCommand(actionsStore, config));
+        features.add(new LeaderboardCommand(config));
         features.add(new TopHelpersCommand(topHelpersService, topHelpersAssignmentRoutine));
         features.add(new RoleSelectCommand());
         features.add(new NoteCommand(actionsStore));

--- a/application/src/main/java/org/togetherjava/tjbot/features/leaderboard/LeaderboardCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/leaderboard/LeaderboardCommand.java
@@ -1,0 +1,146 @@
+package org.togetherjava.tjbot.features.leaderboard;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.togetherjava.tjbot.config.Config;
+import org.togetherjava.tjbot.features.CommandVisibility;
+import org.togetherjava.tjbot.features.SlashCommandAdapter;
+import org.togetherjava.tjbot.features.tophelper.TopHelpersService;
+import org.togetherjava.tjbot.features.utils.Colors;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.regex.Pattern;
+
+/**
+ * Implements the {@code /leaderboard} slash command, which displays the all-time top helpers
+ * leaderboard by reading the hall-of-fame channel history.
+ */
+public final class LeaderboardCommand extends SlashCommandAdapter {
+    private static final Logger logger = LoggerFactory.getLogger(LeaderboardCommand.class);
+
+    private static final String COMMAND_NAME = "leaderboard";
+    private static final int TOP_LIMIT = 10;
+    private static final int HISTORY_LIMIT = 500;
+
+    private static final String MEDAL_FIRST = "🥇";
+    private static final String MEDAL_SECOND = "🥈";
+    private static final String MEDAL_THIRD = "🥉";
+    private static final String BULLET = "▸";
+
+    private final Config config;
+
+    public LeaderboardCommand(Config config) {
+        super(COMMAND_NAME, "Show the all-time top helpers leaderboard", CommandVisibility.GUILD);
+        this.config = config;
+    }
+
+    @Override
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
+        Guild guild = event.getGuild();
+        if (guild == null) {
+            event.reply("This command can only be used inside a server.")
+                .setEphemeral(true)
+                .queue();
+            return;
+        }
+
+        event.deferReply().queue();
+
+        Pattern channelPattern =
+                Pattern.compile(config.getTopHelpers().getAnnouncementChannelPattern());
+        TextChannel hallOfFame = guild.getTextChannels()
+            .stream()
+            .filter(channel -> channelPattern.matcher(channel.getName()).find())
+            .findFirst()
+            .orElse(null);
+
+        if (hallOfFame == null) {
+            event.getHook().editOriginal("Could not find the hall of fame channel.").queue();
+            return;
+        }
+
+        hallOfFame.getIterableHistory().takeAsync(HISTORY_LIMIT).thenAccept(messages -> {
+            Map<Long, Integer> winsByUser = countWins(messages);
+
+            List<Map.Entry<Long, Integer>> sorted = winsByUser.entrySet()
+                .stream()
+                .sorted(Map.Entry.<Long, Integer>comparingByValue(Comparator.reverseOrder()))
+                .limit(TOP_LIMIT)
+                .toList();
+
+            if (sorted.isEmpty()) {
+                event.getHook().editOriginal("No top helper data found.").queue();
+                return;
+            }
+
+            List<Long> ids = sorted.stream().map(Map.Entry::getKey).toList();
+
+            guild.retrieveMembersByIds(ids).onSuccess(members -> {
+                Map<Long, Member> memberById = TopHelpersService.mapUserIdToMember(members);
+
+                StringJoiner description = new StringJoiner("\n");
+                for (int i = 0; i < sorted.size(); i++) {
+                    Map.Entry<Long, Integer> entry = sorted.get(i);
+                    Member member = memberById.get(entry.getKey());
+                    String name = TopHelpersService.getUsernameDisplay(member);
+                    int wins = entry.getValue();
+                    description.add("%s **%s** — %d month%s".formatted(rankPrefix(i), name, wins,
+                            wins == 1 ? "" : "s"));
+                }
+
+                EmbedBuilder embed = new EmbedBuilder().setTitle("🏆 Top Helpers — Hall of Fame")
+                    .setDescription(description.toString())
+                    .setColor(Colors.SUCCESS_COLOR)
+                    .setFooter("Times awarded Top Helper");
+
+                event.getHook().editOriginalEmbeds(embed.build()).queue();
+
+            }).onError(error -> {
+                logger.error("Failed to retrieve members for leaderboard", error);
+                event.getHook()
+                    .editOriginal("Failed to load member data, please try again.")
+                    .queue();
+            });
+
+        }).exceptionally(error -> {
+            logger.error("Failed to read hall of fame channel", error);
+            event.getHook().editOriginal("Failed to read the hall of fame channel.").queue();
+            return null;
+        });
+    }
+
+    private static Map<Long, Integer> countWins(List<Message> messages) {
+        Map<Long, Integer> wins = new HashMap<>();
+        for (Message message : messages) {
+            String content = message.getContentRaw();
+            if (!content.toLowerCase().contains("top helper")) {
+                continue;
+            }
+            for (User user : message.getMentions().getUsers()) {
+                wins.merge(user.getIdLong(), 1, Integer::sum);
+            }
+        }
+        return wins;
+    }
+
+    private static String rankPrefix(int zeroBasedIndex) {
+        return switch (zeroBasedIndex) {
+            case 0 -> MEDAL_FIRST;
+            case 1 -> MEDAL_SECOND;
+            case 2 -> MEDAL_THIRD;
+            default -> BULLET + " #" + (zeroBasedIndex + 1);
+        };
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/features/leaderboard/LeaderboardCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/leaderboard/LeaderboardCommand.java
@@ -7,6 +7,7 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.InteractionHook;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,11 +17,13 @@ import org.togetherjava.tjbot.features.SlashCommandAdapter;
 import org.togetherjava.tjbot.features.tophelper.TopHelpersService;
 import org.togetherjava.tjbot.features.utils.Colors;
 
+import java.time.OffsetDateTime;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 /**
@@ -40,6 +43,9 @@ public final class LeaderboardCommand extends SlashCommandAdapter {
     private static final String BULLET = "▸";
 
     private final Config config;
+
+    private final Map<Long, Map<Long, Integer>> winsByGuild = new ConcurrentHashMap<>();
+    private final Map<Long, OffsetDateTime> lastFetchedPerGuild = new ConcurrentHashMap<>();
 
     public LeaderboardCommand(Config config) {
         super(COMMAND_NAME, "Show the all-time top helpers leaderboard", CommandVisibility.GUILD);
@@ -71,58 +77,87 @@ public final class LeaderboardCommand extends SlashCommandAdapter {
             return;
         }
 
-        hallOfFame.getIterableHistory().takeAsync(HISTORY_LIMIT).thenAccept(messages -> {
-            Map<Long, Integer> winsByUser = countWins(messages);
+        long guildId = guild.getIdLong();
+        InteractionHook hook = event.getHook();
 
-            List<Map.Entry<Long, Integer>> sorted = winsByUser.entrySet()
-                .stream()
-                .sorted(Map.Entry.<Long, Integer>comparingByValue(Comparator.reverseOrder()))
-                .limit(TOP_LIMIT)
-                .toList();
+        if (!winsByGuild.containsKey(guildId)) {
+            hallOfFame.getIterableHistory().takeAsync(HISTORY_LIMIT).thenAccept(messages -> {
+                Map<Long, Integer> wins = new HashMap<>();
+                countWinsInto(messages, wins);
+                winsByGuild.put(guildId, new ConcurrentHashMap<>(wins));
 
-            if (sorted.isEmpty()) {
-                event.getHook().editOriginal("No top helper data found.").queue();
-                return;
-            }
-
-            List<Long> ids = sorted.stream().map(Map.Entry::getKey).toList();
-
-            guild.retrieveMembersByIds(ids).onSuccess(members -> {
-                Map<Long, Member> memberById = TopHelpersService.mapUserIdToMember(members);
-
-                StringJoiner description = new StringJoiner("\n");
-                for (int i = 0; i < sorted.size(); i++) {
-                    Map.Entry<Long, Integer> entry = sorted.get(i);
-                    Member member = memberById.get(entry.getKey());
-                    String name = TopHelpersService.getUsernameDisplay(member);
-                    int wins = entry.getValue();
-                    description.add("%s **%s** — %d month%s".formatted(rankPrefix(i), name, wins,
-                            wins == 1 ? "" : "s"));
+                if (!messages.isEmpty()) {
+                    lastFetchedPerGuild.put(guildId, messages.getFirst().getTimeCreated());
                 }
 
-                EmbedBuilder embed = new EmbedBuilder().setTitle("🏆 Top Helpers — Hall of Fame")
-                    .setDescription(description.toString())
-                    .setColor(Colors.SUCCESS_COLOR)
-                    .setFooter("Times awarded Top Helper");
-
-                event.getHook().editOriginalEmbeds(embed.build()).queue();
-
-            }).onError(error -> {
-                logger.error("Failed to retrieve members for leaderboard", error);
-                event.getHook()
-                    .editOriginal("Failed to load member data, please try again.")
-                    .queue();
+                sendLeaderboard(guild, wins, hook);
+            }).exceptionally(error -> {
+                logger.error("Failed to read hall of fame channel", error);
+                hook.editOriginal("Failed to read the hall of fame channel.").queue();
+                return null;
             });
+        } else {
+            OffsetDateTime lastFetched = lastFetchedPerGuild.get(guildId);
+            Map<Long, Integer> cachedWins = winsByGuild.get(guildId);
 
-        }).exceptionally(error -> {
-            logger.error("Failed to read hall of fame channel", error);
-            event.getHook().editOriginal("Failed to read the hall of fame channel.").queue();
-            return null;
+            hallOfFame.getIterableHistory()
+                .takeWhileAsync(HISTORY_LIMIT, msg -> msg.getTimeCreated().isAfter(lastFetched))
+                .thenAccept(newMessages -> {
+                    if (!newMessages.isEmpty()) {
+                        countWinsInto(newMessages, cachedWins);
+                        lastFetchedPerGuild.put(guildId, newMessages.getFirst().getTimeCreated());
+                    }
+                    sendLeaderboard(guild, cachedWins, hook);
+                })
+                .exceptionally(error -> {
+                    logger.error("Failed to read hall of fame channel", error);
+                    hook.editOriginal("Failed to read the hall of fame channel.").queue();
+                    return null;
+                });
+        }
+    }
+
+    private void sendLeaderboard(Guild guild, Map<Long, Integer> wins, InteractionHook hook) {
+        List<Map.Entry<Long, Integer>> sorted = wins.entrySet()
+            .stream()
+            .sorted(Map.Entry.<Long, Integer>comparingByValue(Comparator.reverseOrder()))
+            .limit(TOP_LIMIT)
+            .toList();
+
+        if (sorted.isEmpty()) {
+            hook.editOriginal("No top helper data found.").queue();
+            return;
+        }
+
+        List<Long> ids = sorted.stream().map(Map.Entry::getKey).toList();
+
+        guild.retrieveMembersByIds(ids).onSuccess(members -> {
+            Map<Long, Member> memberById = TopHelpersService.mapUserIdToMember(members);
+
+            StringJoiner description = new StringJoiner("\n");
+            for (int i = 0; i < sorted.size(); i++) {
+                Map.Entry<Long, Integer> entry = sorted.get(i);
+                Member member = memberById.get(entry.getKey());
+                String name = TopHelpersService.getUsernameDisplay(member);
+                int winCount = entry.getValue();
+                description.add("%s **%s** — %d month%s".formatted(rankPrefix(i), name, winCount,
+                        winCount == 1 ? "" : "s"));
+            }
+
+            EmbedBuilder embed = new EmbedBuilder().setTitle("🏆 Top Helpers — Hall of Fame")
+                .setDescription(description.toString())
+                .setColor(Colors.SUCCESS_COLOR)
+                .setFooter("Times awarded Top Helper");
+
+            hook.editOriginalEmbeds(embed.build()).queue();
+
+        }).onError(error -> {
+            logger.error("Failed to retrieve members for leaderboard", error);
+            hook.editOriginal("Failed to load member data, please try again.").queue();
         });
     }
 
-    private static Map<Long, Integer> countWins(List<Message> messages) {
-        Map<Long, Integer> wins = new HashMap<>();
+    private static void countWinsInto(List<Message> messages, Map<Long, Integer> wins) {
         for (Message message : messages) {
             String content = message.getContentRaw();
             if (!content.toLowerCase().contains("top helper")) {
@@ -132,7 +167,6 @@ public final class LeaderboardCommand extends SlashCommandAdapter {
                 wins.merge(user.getIdLong(), 1, Integer::sum);
             }
         }
-        return wins;
     }
 
     private static String rankPrefix(int zeroBasedIndex) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/leaderboard/LeaderboardCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/leaderboard/LeaderboardCommand.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -54,13 +55,7 @@ public final class LeaderboardCommand extends SlashCommandAdapter {
 
     @Override
     public void onSlashCommand(SlashCommandInteractionEvent event) {
-        Guild guild = event.getGuild();
-        if (guild == null) {
-            event.reply("This command can only be used inside a server.")
-                .setEphemeral(true)
-                .queue();
-            return;
-        }
+        Guild guild = Objects.requireNonNull(event.getGuild());
 
         event.deferReply().queue();
 
@@ -73,7 +68,10 @@ public final class LeaderboardCommand extends SlashCommandAdapter {
             .orElse(null);
 
         if (hallOfFame == null) {
-            event.getHook().editOriginal("Could not find the hall of fame channel.").queue();
+            event.getHook()
+                .editOriginal(
+                        "Could not find channel matching '%s'.".formatted(channelPattern.pattern()))
+                .queue();
             return;
         }
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/leaderboard/LeaderboardCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/leaderboard/LeaderboardCommand.java
@@ -17,12 +17,12 @@ import org.togetherjava.tjbot.features.SlashCommandAdapter;
 import org.togetherjava.tjbot.features.tophelper.TopHelpersService;
 import org.togetherjava.tjbot.features.utils.Colors;
 
-import java.time.OffsetDateTime;
+import java.time.Instant;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
@@ -45,7 +45,7 @@ public final class LeaderboardCommand extends SlashCommandAdapter {
     private final Config config;
 
     private final Map<Long, Map<Long, Integer>> winsByGuild = new ConcurrentHashMap<>();
-    private final Map<Long, OffsetDateTime> lastFetchedPerGuild = new ConcurrentHashMap<>();
+    private final Map<Long, Instant> lastFetchedPerGuild = new ConcurrentHashMap<>();
 
     public LeaderboardCommand(Config config) {
         super(COMMAND_NAME, "Show the all-time top helpers leaderboard", CommandVisibility.GUILD);
@@ -80,47 +80,38 @@ public final class LeaderboardCommand extends SlashCommandAdapter {
         long guildId = guild.getIdLong();
         InteractionHook hook = event.getHook();
 
-        if (!winsByGuild.containsKey(guildId)) {
-            hallOfFame.getIterableHistory().takeAsync(HISTORY_LIMIT).thenAccept(messages -> {
-                Map<Long, Integer> wins = new HashMap<>();
-                countWinsInto(messages, wins);
-                winsByGuild.put(guildId, new ConcurrentHashMap<>(wins));
+        Map<Long, Integer> cachedWins =
+                winsByGuild.computeIfAbsent(guildId, _ -> new ConcurrentHashMap<>());
+        Instant lastFetched = lastFetchedPerGuild.get(guildId);
 
-                if (!messages.isEmpty()) {
-                    lastFetchedPerGuild.put(guildId, messages.getFirst().getTimeCreated());
-                }
+        fetchNewMessages(hallOfFame, lastFetched).thenAccept(newMessages -> {
+            if (!newMessages.isEmpty()) {
+                countWinsInto(newMessages, cachedWins);
+                lastFetchedPerGuild.put(guildId,
+                        newMessages.getFirst().getTimeCreated().toInstant());
+            }
+            sendLeaderboard(guild, cachedWins, hook);
+        }).exceptionally(error -> {
+            logger.error("Failed to read hall of fame channel", error);
+            hook.editOriginal("Failed to read the hall of fame channel.").queue();
+            return null;
+        });
+    }
 
-                sendLeaderboard(guild, wins, hook);
-            }).exceptionally(error -> {
-                logger.error("Failed to read hall of fame channel", error);
-                hook.editOriginal("Failed to read the hall of fame channel.").queue();
-                return null;
-            });
-        } else {
-            OffsetDateTime lastFetched = lastFetchedPerGuild.get(guildId);
-            Map<Long, Integer> cachedWins = winsByGuild.get(guildId);
-
-            hallOfFame.getIterableHistory()
-                .takeWhileAsync(HISTORY_LIMIT, msg -> msg.getTimeCreated().isAfter(lastFetched))
-                .thenAccept(newMessages -> {
-                    if (!newMessages.isEmpty()) {
-                        countWinsInto(newMessages, cachedWins);
-                        lastFetchedPerGuild.put(guildId, newMessages.getFirst().getTimeCreated());
-                    }
-                    sendLeaderboard(guild, cachedWins, hook);
-                })
-                .exceptionally(error -> {
-                    logger.error("Failed to read hall of fame channel", error);
-                    hook.editOriginal("Failed to read the hall of fame channel.").queue();
-                    return null;
-                });
+    private static CompletableFuture<List<Message>> fetchNewMessages(TextChannel channel,
+            Instant lastFetched) {
+        if (lastFetched == null) {
+            return channel.getIterableHistory().takeAsync(HISTORY_LIMIT);
         }
+        return channel.getIterableHistory()
+            .takeWhileAsync(HISTORY_LIMIT,
+                    msg -> msg.getTimeCreated().toInstant().isAfter(lastFetched));
     }
 
     private void sendLeaderboard(Guild guild, Map<Long, Integer> wins, InteractionHook hook) {
         List<Map.Entry<Long, Integer>> sorted = wins.entrySet()
             .stream()
-            .sorted(Map.Entry.<Long, Integer>comparingByValue(Comparator.reverseOrder()))
+            .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
             .limit(TOP_LIMIT)
             .toList();
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/leaderboard/LeaderboardCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/leaderboard/LeaderboardCommand.java
@@ -37,20 +37,23 @@ public final class LeaderboardCommand extends SlashCommandAdapter {
     private static final String COMMAND_NAME = "leaderboard";
     private static final int TOP_LIMIT = 10;
     private static final int HISTORY_LIMIT = 500;
+    private static final String TOP_HELPER_KEYWORD = "top helper";
+    private static final String LEADERBOARD_TITLE = "Top Helpers — Hall of Fame";
 
     private static final String MEDAL_FIRST = "🥇";
     private static final String MEDAL_SECOND = "🥈";
     private static final String MEDAL_THIRD = "🥉";
     private static final String BULLET = "▸";
 
-    private final Config config;
+    private final Pattern announcementChannelPattern;
 
     private final Map<Long, Map<Long, Integer>> winsByGuild = new ConcurrentHashMap<>();
     private final Map<Long, Instant> lastFetchedPerGuild = new ConcurrentHashMap<>();
 
     public LeaderboardCommand(Config config) {
         super(COMMAND_NAME, "Show the all-time top helpers leaderboard", CommandVisibility.GUILD);
-        this.config = config;
+        this.announcementChannelPattern =
+                Pattern.compile(config.getTopHelpers().getAnnouncementChannelPattern());
     }
 
     @Override
@@ -59,18 +62,16 @@ public final class LeaderboardCommand extends SlashCommandAdapter {
 
         event.deferReply().queue();
 
-        Pattern channelPattern =
-                Pattern.compile(config.getTopHelpers().getAnnouncementChannelPattern());
         TextChannel hallOfFame = guild.getTextChannels()
             .stream()
-            .filter(channel -> channelPattern.matcher(channel.getName()).find())
+            .filter(channel -> announcementChannelPattern.matcher(channel.getName()).find())
             .findFirst()
             .orElse(null);
 
         if (hallOfFame == null) {
             event.getHook()
-                .editOriginal(
-                        "Could not find channel matching '%s'.".formatted(channelPattern.pattern()))
+                .editOriginal("Could not find channel matching `%s`."
+                    .formatted(announcementChannelPattern.pattern()))
                 .queue();
             return;
         }
@@ -133,7 +134,7 @@ public final class LeaderboardCommand extends SlashCommandAdapter {
                         winCount == 1 ? "" : "s"));
             }
 
-            EmbedBuilder embed = new EmbedBuilder().setTitle("🏆 Top Helpers — Hall of Fame")
+            EmbedBuilder embed = new EmbedBuilder().setTitle("🏆 " + LEADERBOARD_TITLE)
                 .setDescription(description.toString())
                 .setColor(Colors.SUCCESS_COLOR)
                 .setFooter("Times awarded Top Helper");
@@ -149,7 +150,8 @@ public final class LeaderboardCommand extends SlashCommandAdapter {
     private static void countWinsInto(List<Message> messages, Map<Long, Integer> wins) {
         for (Message message : messages) {
             String content = message.getContentRaw();
-            if (!content.toLowerCase().contains("top helper")) {
+            if (!content.toLowerCase().contains(TOP_HELPER_KEYWORD)
+                    || content.contains(LEADERBOARD_TITLE)) {
                 continue;
             }
             for (User user : message.getMentions().getUsers()) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/leaderboard/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/leaderboard/package-info.java
@@ -1,0 +1,4 @@
+@MethodsReturnNonnullByDefault
+package org.togetherjava.tjbot.features.leaderboard;
+
+import org.togetherjava.tjbot.annotations.MethodsReturnNonnullByDefault;


### PR DESCRIPTION
 ### What
Adds a `/leaderboard` command that displays the all-time top helpers. It reads the hall-of-fame channel history, finds messages that mention top helpers, counts how many times each user was awarded, and shows the top 10 ranked with medals.

### How
Reads the hall-of-fame channel history, filters messages containing "top helper", extracts mentioned users via `getMentions()`, counts wins per user and shows the top 10 in an embed.

<img width="563" height="160" alt="Screenshot From 2026-05-26 21-56-39" src="https://github.com/user-attachments/assets/0602a637-58d1-4bb5-8fc0-29b085ebbc4f" />

### Edge cases 
- Channel not found: yes, returns "Could not find the hall of fame channel."
- No messages in channel: yes, `sorted.isEmpty()` catches it, then returns "No top helper data found."
- Messages exist but none contain "top helper": yes, the same `sorted.isEmpty()` check covers it.
- Multiple users in one message: yes, the getMentions().getUsers() loop handles multiple mentions per message.

<img width="423" height="100" alt="Screenshot From 2026-05-27 15-32-30" src="https://github.com/user-attachments/assets/da04e7d0-1702-4244-bfc3-301d8ffd2170" />
<img width="423" height="100" alt="Screenshot From 2026-05-27 15-32-54" src="https://github.com/user-attachments/assets/68ac57e6-563e-4a8e-850d-fb15501cb798" />
<img width="483" height="190" alt="Screenshot From 2026-05-27 15-42-14" src="https://github.com/user-attachments/assets/b77d6335-8fbe-49d1-9b0d-e44673122a2a" />

NOTE: Channel not found and Messages exist but none contain "top helper" returns the same output "No top helper data found."

