### PR TITLE
Fix dead links in ChatGPT responses (#1276)

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpSystemHelper.java
@@ -29,6 +29,7 @@ import org.togetherjava.tjbot.features.chatgpt.ChatGptModel;
 import org.togetherjava.tjbot.features.chatgpt.ChatGptService;
 import org.togetherjava.tjbot.features.componentids.ComponentIdInteractor;
 import org.togetherjava.tjbot.features.utils.Guilds;
+import org.togetherjava.tjbot.features.utils.LinkDetection;
 
 import java.awt.Color;
 import java.time.Instant;
@@ -41,6 +42,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -57,6 +59,7 @@ import static org.togetherjava.tjbot.features.utils.MessageUtils.mentionGuildSla
 public final class HelpSystemHelper {
     private static final Logger logger = LoggerFactory.getLogger(HelpSystemHelper.class);
     private static final ChatGptModel CHAT_GPT_MODEL = ChatGptModel.FAST;
+    private static final String BROKEN_LINK_REPLACEMENT = "(broken link removed)";
 
     static final Color AMBIENT_COLOR = new Color(255, 255, 165);
 
@@ -74,6 +77,7 @@ public final class HelpSystemHelper {
 
     private final Database database;
     private final ChatGptService chatGptService;
+    private final Function<String, CompletableFuture<String>> brokenLinkReplacer;
     private static final int MAX_QUESTION_LENGTH = 200;
     private static final int MIN_QUESTION_LENGTH = 10;
     private static final String CHATGPT_FAILURE_MESSAGE =
@@ -87,9 +91,16 @@ public final class HelpSystemHelper {
      * @param chatGptService the service used to ask ChatGPT questions via the API.
      */
     public HelpSystemHelper(Config config, Database database, ChatGptService chatGptService) {
+        this(config, database, chatGptService,
+                answer -> LinkDetection.replaceBrokenLinks(answer, BROKEN_LINK_REPLACEMENT));
+    }
+
+    HelpSystemHelper(Config config, Database database, ChatGptService chatGptService,
+            Function<String, CompletableFuture<String>> brokenLinkReplacer) {
         HelpSystemConfig helpConfig = config.getHelpSystem();
         this.database = database;
         this.chatGptService = chatGptService;
+        this.brokenLinkReplacer = brokenLinkReplacer;
 
         isTagManageRole = Pattern.compile(config.getTagManageRolePattern()).asMatchPredicate();
         helpForumPattern = helpConfig.getHelpForumPattern();
@@ -188,6 +199,7 @@ public final class HelpSystemHelper {
     public MessageEmbed generateGptResponseEmbed(String answer, SelfUser selfUser, String title,
             ChatGptModel model) {
         String responseByGptFooter = "- AI generated response using %s model".formatted(model);
+        String sanitizedAnswer = sanitizeBrokenLinks(answer);
 
         int embedTitleLimit = MessageEmbed.TITLE_MAX_LENGTH;
         String capitalizedTitle = Character.toUpperCase(title.charAt(0)) + title.substring(1);
@@ -199,10 +211,19 @@ public final class HelpSystemHelper {
         return new EmbedBuilder()
             .setAuthor(selfUser.getName(), null, selfUser.getEffectiveAvatarUrl())
             .setTitle(titleForEmbed)
-            .setDescription(answer)
+            .setDescription(sanitizedAnswer)
             .setColor(Color.pink)
             .setFooter(responseByGptFooter)
             .build();
+    }
+
+    private String sanitizeBrokenLinks(String answer) {
+        try {
+            return brokenLinkReplacer.apply(answer).join();
+        } catch (RuntimeException runtimeException) {
+            logger.debug("Failed to replace broken links in ChatGPT response", runtimeException);
+            return answer;
+        }
     }
 
     private Button generateDismissButton(ComponentIdInteractor componentIdInteractor, String id) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpSystemHelper.java
@@ -43,6 +43,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -82,6 +83,8 @@ public final class HelpSystemHelper {
     private static final int MIN_QUESTION_LENGTH = 10;
     private static final String CHATGPT_FAILURE_MESSAGE =
             "You can use %s to ask ChatGPT about your question while you wait for a human to respond.";
+    private static final int LINK_CHECK_TIMEOUT_SECONDS = 10;
+
 
     /**
      * Creates a new instance.
@@ -219,7 +222,9 @@ public final class HelpSystemHelper {
 
     private String sanitizeBrokenLinks(String answer) {
         try {
-            return brokenLinkReplacer.apply(answer).join();
+            return brokenLinkReplacer.apply(answer)
+                .orTimeout(LINK_CHECK_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .join();
         } catch (RuntimeException runtimeException) {
             logger.debug("Failed to replace broken links in ChatGPT response", runtimeException);
             return answer;

--- a/application/src/test/java/org/togetherjava/tjbot/features/help/HelpSystemHelperTest.java
+++ b/application/src/test/java/org/togetherjava/tjbot/features/help/HelpSystemHelperTest.java
@@ -1,0 +1,87 @@
+package org.togetherjava.tjbot.features.help;
+
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.SelfUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.togetherjava.tjbot.config.Config;
+import org.togetherjava.tjbot.config.HelpSystemConfig;
+import org.togetherjava.tjbot.db.Database;
+import org.togetherjava.tjbot.db.generated.tables.HelpThreads;
+import org.togetherjava.tjbot.features.chatgpt.ChatGptModel;
+import org.togetherjava.tjbot.features.chatgpt.ChatGptService;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+final class HelpSystemHelperTest {
+    private static final String ORIGINAL_ANSWER = """
+            Useful links:
+            - https://broken.example
+            - https://working.example
+            """;
+    private static final String SANITIZED_ANSWER = """
+            Useful links:
+            - (broken link removed)
+            - https://working.example
+            """;
+    private HelpSystemHelper helper;
+    private SelfUser selfUser;
+
+    @BeforeEach
+    void setUp() {
+        Config config = mock(Config.class);
+        HelpSystemConfig helpSystemConfig = mock(HelpSystemConfig.class);
+        when(config.getHelpSystem()).thenReturn(helpSystemConfig);
+        when(config.getTagManageRolePattern()).thenReturn("tag-manage");
+        when(helpSystemConfig.getHelpForumPattern()).thenReturn("questions");
+        when(helpSystemConfig.getCategories()).thenReturn(List.of("java"));
+        when(helpSystemConfig.getCategoryRoleSuffix()).thenReturn(" helper");
+
+        Database database = Database.createMemoryDatabase(HelpThreads.HELP_THREADS);
+        ChatGptService chatGptService = mock(ChatGptService.class);
+        helper = new HelpSystemHelper(config, database, chatGptService, answer -> CompletableFuture
+            .completedFuture(answer.replace("https://broken.example", "(broken link removed)")));
+
+        selfUser = mock(SelfUser.class);
+        when(selfUser.getName()).thenReturn("TJ-Bot");
+        when(selfUser.getEffectiveAvatarUrl()).thenReturn("https://example.com/avatar.png");
+    }
+
+    @Test
+    @DisplayName("Replaces broken links before building AI response embed")
+    void replacesBrokenLinksInGeneratedEmbed() {
+        MessageEmbed embed = helper.generateGptResponseEmbed(ORIGINAL_ANSWER, selfUser,
+                "example question", ChatGptModel.FAST);
+
+        assertEquals(SANITIZED_ANSWER, embed.getDescription());
+    }
+
+    @Test
+    @DisplayName("Keeps original answer if broken-link replacement fails")
+    void keepsOriginalAnswerWhenReplacementFails() {
+        Config config = mock(Config.class);
+        HelpSystemConfig helpSystemConfig = mock(HelpSystemConfig.class);
+        when(config.getHelpSystem()).thenReturn(helpSystemConfig);
+        when(config.getTagManageRolePattern()).thenReturn("tag-manage");
+        when(helpSystemConfig.getHelpForumPattern()).thenReturn("questions");
+        when(helpSystemConfig.getCategories()).thenReturn(List.of("java"));
+        when(helpSystemConfig.getCategoryRoleSuffix()).thenReturn(" helper");
+
+        Database database = Database.createMemoryDatabase(HelpThreads.HELP_THREADS);
+        ChatGptService chatGptService = mock(ChatGptService.class);
+        HelpSystemHelper failingHelper = new HelpSystemHelper(config, database, chatGptService,
+                _ -> CompletableFuture.failedFuture(new IllegalStateException("boom")));
+
+        MessageEmbed embed = failingHelper.generateGptResponseEmbed(ORIGINAL_ANSWER, selfUser,
+                "example question", ChatGptModel.FAST);
+
+        assertEquals(ORIGINAL_ANSWER, embed.getDescription());
+    }
+}


### PR DESCRIPTION
Closes #1276

### What was done
- Integrated LinkDetection.replaceDeadLinks() (added in #1366) into HelpSystemHelper#generateGptResponseEmbed(). The replacement runs before the embed is built, so both the auto-AI response in help threads and /chatgpt command are covered since they share the same embed builder.
- If the link check fails (e.g. network error), the original answer is kept as-is - no broken behavior.
- Added two unit tests in HelpSystemHelperTest: one verifying dead link replacement, one verifying fallback when replacement fails.

### Approach
The issue proposes two options: ideally sending the response immediately and then editing it after async link checking, or as a fallback - replacing links before sending.

### Current (fallback) flow:
post created → ChatGPT generates answer → dead links replaced → embed built → embed sent to Discord

### Ideal flow (not implemented):
post created → ChatGPT generates answer → embed sent immediately → links checked in the background → already-sent message edited with clean links

The fallback was chosen because it keeps the change in one place (HelpSystemHelper) and is easy to test. The ideal flow would require mixing two different async mechanisms: checking links uses Java's CompletableFuture (because it makes plain HTTP requests to external sites — JDA is not involved here at all), while sending and editing Discord messages uses JDA's RestAction. These two do not compose directly, so some extra glue code is needed to chain them together correctly.