### PR TITLE
feat: add support for specifying response schema to AI response

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptService.java
@@ -1,19 +1,22 @@
 package org.togetherjava.tjbot.features.chatgpt;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
-import com.openai.models.responses.Response;
-import com.openai.models.responses.ResponseCreateParams;
-import com.openai.models.responses.ResponseOutputText;
+import com.openai.core.JsonValue;
+import com.openai.models.responses.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.features.analytics.Metrics;
+import org.togetherjava.tjbot.features.chatgpt.schema.ResponseSchema;
 
 import javax.annotation.Nullable;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -23,6 +26,8 @@ import java.util.stream.Collectors;
 public class ChatGptService {
     private static final Logger logger = LoggerFactory.getLogger(ChatGptService.class);
     private static final Duration TIMEOUT = Duration.ofSeconds(90);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String DEFAULT_SCHEMA_NAME = "response";
 
     /** The maximum number of tokens allowed for the generated answer. */
     private static final int MAX_TOKENS = 1000;
@@ -74,7 +79,7 @@ public class ChatGptService {
                 Question: %s
                 """.formatted(contextText, question);
 
-        return sendPrompt(inputPrompt, chatModel);
+        return sendPrompt(inputPrompt, chatModel, null);
     }
 
     /**
@@ -90,7 +95,23 @@ public class ChatGptService {
      *      Tokens</a>.
      */
     public Optional<String> askRaw(String inputPrompt, ChatGptModel chatModel) {
-        return sendPrompt(inputPrompt, chatModel);
+        return sendPrompt(inputPrompt, chatModel, null);
+    }
+
+    /**
+     * Prompt ChatGPT with a raw prompt and receive a JSON response conforming to the given schema.
+     * <p>
+     * Uses OpenAI's structured outputs feature so the model is constrained to return JSON matching
+     * the supplied schema.
+     *
+     * @param inputPrompt The raw prompt to send to ChatGPT. Max is {@value MAX_TOKENS} tokens.
+     * @param chatModel The AI model to use for this request.
+     * @param schema The JSON schema the response must conform to.
+     * @return response from ChatGPT as a JSON string conforming to {@code schema}.
+     */
+    public Optional<String> askRaw(String inputPrompt, ChatGptModel chatModel,
+            ResponseSchema schema) {
+        return sendPrompt(inputPrompt, chatModel, schema);
     }
 
     /**
@@ -98,9 +119,11 @@ public class ChatGptService {
      *
      * @param prompt The prompt to send to ChatGPT.
      * @param chatModel The AI model to use for this request.
+     * @param schema Optional JSON schema constraining the model output; {@code null} for free-form.
      * @return response from ChatGPT as a String.
      */
-    private Optional<String> sendPrompt(String prompt, ChatGptModel chatModel) {
+    private Optional<String> sendPrompt(String prompt, ChatGptModel chatModel,
+            @Nullable ResponseSchema schema) {
         if (isDisabled) {
             logger.warn("ChatGPT request attempted but service is disabled");
             return Optional.empty();
@@ -109,11 +132,16 @@ public class ChatGptService {
         logger.debug("ChatGpt request: {}", prompt);
 
         try {
-            ResponseCreateParams params = ResponseCreateParams.builder()
+            ResponseCreateParams.Builder paramsBuilder = ResponseCreateParams.builder()
                 .model(chatModel.toChatModel())
                 .input(prompt)
-                .maxOutputTokens(MAX_TOKENS)
-                .build();
+                .maxOutputTokens(MAX_TOKENS);
+
+            if (schema != null) {
+                paramsBuilder.text(buildTextConfig(schema));
+            }
+
+            ResponseCreateParams params = paramsBuilder.build();
 
             Response chatGptResponse = openAIClient.responses().create(params);
             metrics.count("chatgpt-prompted");
@@ -141,5 +169,24 @@ public class ChatGptService {
                     runtimeException);
             return Optional.empty();
         }
+    }
+
+    private static ResponseTextConfig buildTextConfig(ResponseSchema schema) {
+        Map<String, Object> schemaMap =
+                OBJECT_MAPPER.convertValue(schema, new TypeReference<>() {});
+
+        ResponseFormatTextJsonSchemaConfig.Schema.Builder schemaBuilder =
+                ResponseFormatTextJsonSchemaConfig.Schema.builder();
+        schemaMap.forEach(
+                (key, value) -> schemaBuilder.putAdditionalProperty(key, JsonValue.from(value)));
+
+        ResponseFormatTextJsonSchemaConfig jsonSchemaConfig =
+                ResponseFormatTextJsonSchemaConfig.builder()
+                    .name(DEFAULT_SCHEMA_NAME)
+                    .strict(true)
+                    .schema(schemaBuilder.build())
+                    .build();
+
+        return ResponseTextConfig.builder().format(jsonSchemaConfig).build();
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/schema/Property.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/schema/Property.java
@@ -1,0 +1,117 @@
+package org.togetherjava.tjbot.features.chatgpt.schema;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a single property in an OpenAI JSON schema, used to describe the shape of one field
+ * inside a {@link ResponseSchema}.
+ * <p>
+ * The hierarchy is sealed and mirrors the JSON Schema specification supported by OpenAI's
+ * structured outputs:
+ * <ul>
+ * <li>{@link Primitive} – scalar values ({@code string}, {@code number}, {@code integer},
+ * {@code boolean}, {@code null}).</li>
+ * <li>{@link ArrayProperty} - an array whose elements conform to a nested {@link Property}.</li>
+ * <li>{@link ObjectProperty} - a nested object with its own {@code properties} and {@code required}
+ * list.</li>
+ * </ul>
+ * Prefer the static factory methods ({@link #of}, {@link #array}, {@link #object}) for readable
+ * construction.
+ *
+ * @see ResponseSchema
+ * @see <a href="https://platform.openai.com/docs/guides/structured-outputs">OpenAI Structured
+ *      Outputs</a>
+ */
+public sealed interface Property
+        permits Property.Primitive, Property.ArrayProperty, Property.ObjectProperty {
+
+    /**
+     * The JSON schema {@link Type} of this property.
+     *
+     * @return the type this property declares
+     */
+    Type type();
+
+    /**
+     * Creates a primitive property of the given scalar type.
+     *
+     * @param type a scalar type such as {@link Type#STRING} or {@link Type#INTEGER}
+     * @return a new {@link Primitive} property
+     */
+    static Primitive of(Type type) {
+        return new Primitive(type);
+    }
+
+    /**
+     * Creates an array property whose elements conform to the given item schema.
+     *
+     * @param items the schema each element must satisfy
+     * @return a new {@link ArrayProperty} of type {@link Type#ARRAY}
+     */
+    static ArrayProperty array(Property items) {
+        return new ArrayProperty(items);
+    }
+
+    /**
+     * Creates a nested object property with {@code additionalProperties} disabled, matching
+     * OpenAI's strict-mode requirement.
+     *
+     * @param properties the fields of the nested object, keyed by field name
+     * @param required the names of fields that must be present
+     * @return a new {@link ObjectProperty} of type {@link Type#OBJECT}
+     */
+    static ObjectProperty object(Map<String, Property> properties, List<String> required) {
+        return new ObjectProperty(properties, required, false);
+    }
+
+    /**
+     * A scalar property - anything that isn't an object or array.
+     *
+     * @param type the scalar JSON type
+     */
+    record Primitive(Type type) implements Property {
+    }
+
+    /**
+     * An array property describing a list of elements that all match {@link #items}.
+     *
+     * @param type always {@link Type#ARRAY}
+     * @param items the schema each element must satisfy
+     */
+    record ArrayProperty(Type type, Property items) implements Property {
+        /**
+         * Convenience constructor that fixes {@link #type} to {@link Type#ARRAY}.
+         *
+         * @param items the schema each element must satisfy
+         */
+        public ArrayProperty(Property items) {
+            this(Type.ARRAY, items);
+        }
+    }
+
+    /**
+     * A nested object property with its own field definitions. Mirrors the top-level
+     * {@link ResponseSchema} structure, allowing arbitrarily deep nesting.
+     *
+     * @param type always {@link Type#OBJECT}
+     * @param properties the fields of the nested object, keyed by field name
+     * @param required the names of fields that must be present
+     * @param additionalProperties whether fields beyond those declared in {@code properties} are
+     *        allowed; OpenAI's strict mode requires {@code false}
+     */
+    record ObjectProperty(Type type, Map<String, Property> properties, List<String> required,
+            boolean additionalProperties) implements Property {
+        /**
+         * Convenience constructor that fixes {@link #type} to {@link Type#OBJECT}.
+         *
+         * @param properties the fields of the nested object
+         * @param required the names of fields that must be present
+         * @param additionalProperties whether undeclared fields are allowed
+         */
+        public ObjectProperty(Map<String, Property> properties, List<String> required,
+                boolean additionalProperties) {
+            this(Type.OBJECT, properties, required, additionalProperties);
+        }
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/schema/ResponseSchema.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/schema/ResponseSchema.java
@@ -1,8 +1,5 @@
 package org.togetherjava.tjbot.features.chatgpt.schema;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.util.List;
 import java.util.Map;
 
@@ -19,32 +16,15 @@ import java.util.Map;
  * ResponseSchema schema = new ResponseSchema(Map.of("answer", Property.of(Type.STRING), "tags",
  *         Property.array(Property.of(Type.STRING))), List.of("answer", "tags"));
  * }</pre>
+ *
+ * @param type the JSON type — must be {@link Type#OBJECT} for a top-level schema
+ * @param properties the fields of the response object, keyed by field name
+ * @param required the names of fields the model must always include
+ * @param additionalProperties whether undeclared fields are allowed; strict mode requires
+ *        {@code false}
  */
-public class ResponseSchema {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private final Type type;
-    private final Map<String, Property> properties;
-    private final List<String> required;
-    private final boolean additionalProperties;
-
-    /**
-     * Creates a fully-specified schema. Most callers should prefer
-     * {@link #ResponseSchema(Map, List)}, which fixes {@code type} to {@link Type#OBJECT} and
-     * {@code additionalProperties} to {@code false} as OpenAI's strict mode requires.
-     *
-     * @param type the JSON type — must be {@link Type#OBJECT} for a top-level schema
-     * @param properties the fields of the response object, keyed by field name
-     * @param required the names of fields the model must always include
-     * @param additionalProperties whether undeclared fields are allowed; strict mode requires
-     *        {@code false}
-     */
-    public ResponseSchema(Type type, Map<String, Property> properties, List<String> required,
-            boolean additionalProperties) {
-        this.type = type;
-        this.properties = properties;
-        this.required = required;
-        this.additionalProperties = additionalProperties;
-    }
+public record ResponseSchema(Type type, Map<String, Property> properties, List<String> required,
+        boolean additionalProperties) {
 
     /**
      * Creates a strict-mode object schema: {@code type=object}, {@code additionalProperties=false}.
@@ -54,49 +34,5 @@ public class ResponseSchema {
      */
     public ResponseSchema(Map<String, Property> properties, List<String> required) {
         this(Type.OBJECT, properties, required, false);
-    }
-
-    /**
-     * Serializes this schema to its JSON representation, suitable for embedding as the
-     * {@code schema} value of an OpenAI {@code response_format.json_schema} block.
-     *
-     * @return the JSON string form of this schema
-     * @throws RuntimeException if Jackson fails to serialize (should not happen for valid input)
-     */
-    @Override
-    public String toString() {
-        try {
-            return OBJECT_MAPPER.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
-     * @return the declared JSON type (always {@link Type#OBJECT} for a valid top-level schema)
-     */
-    public Type type() {
-        return type;
-    }
-
-    /**
-     * @return the field definitions of the response object, keyed by field name
-     */
-    public Map<String, Property> properties() {
-        return properties;
-    }
-
-    /**
-     * @return the names of fields the model must always include in its response
-     */
-    public List<String> required() {
-        return required;
-    }
-
-    /**
-     * @return whether fields beyond those declared in {@link #properties} are permitted
-     */
-    public boolean additionalProperties() {
-        return additionalProperties;
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/schema/ResponseSchema.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/schema/ResponseSchema.java
@@ -1,0 +1,102 @@
+package org.togetherjava.tjbot.features.chatgpt.schema;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Top-level JSON schema describing the shape of a structured response from the OpenAI API.
+ * <p>
+ * Mirrors the {@code json_schema.schema} object that OpenAI's structured-outputs feature expects:
+ * an object schema with declared {@code properties}, a {@code required} list, and the
+ * {@code additionalProperties} flag (which must be {@code false} in strict mode).
+ * <p>
+ * Use {@link Property} (and its static factories) to build the {@code properties} map. Example:
+ *
+ * <pre>{@code
+ * ResponseSchema schema = new ResponseSchema(Map.of("answer", Property.of(Type.STRING), "tags",
+ *         Property.array(Property.of(Type.STRING))), List.of("answer", "tags"));
+ * }</pre>
+ */
+public class ResponseSchema {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private final Type type;
+    private final Map<String, Property> properties;
+    private final List<String> required;
+    private final boolean additionalProperties;
+
+    /**
+     * Creates a fully-specified schema. Most callers should prefer
+     * {@link #ResponseSchema(Map, List)}, which fixes {@code type} to {@link Type#OBJECT} and
+     * {@code additionalProperties} to {@code false} as OpenAI's strict mode requires.
+     *
+     * @param type the JSON type — must be {@link Type#OBJECT} for a top-level schema
+     * @param properties the fields of the response object, keyed by field name
+     * @param required the names of fields the model must always include
+     * @param additionalProperties whether undeclared fields are allowed; strict mode requires
+     *        {@code false}
+     */
+    public ResponseSchema(Type type, Map<String, Property> properties, List<String> required,
+            boolean additionalProperties) {
+        this.type = type;
+        this.properties = properties;
+        this.required = required;
+        this.additionalProperties = additionalProperties;
+    }
+
+    /**
+     * Creates a strict-mode object schema: {@code type=object}, {@code additionalProperties=false}.
+     *
+     * @param properties the fields of the response object, keyed by field name
+     * @param required the names of fields the model must always include
+     */
+    public ResponseSchema(Map<String, Property> properties, List<String> required) {
+        this(Type.OBJECT, properties, required, false);
+    }
+
+    /**
+     * Serializes this schema to its JSON representation, suitable for embedding as the
+     * {@code schema} value of an OpenAI {@code response_format.json_schema} block.
+     *
+     * @return the JSON string form of this schema
+     * @throws RuntimeException if Jackson fails to serialize (should not happen for valid input)
+     */
+    @Override
+    public String toString() {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * @return the declared JSON type (always {@link Type#OBJECT} for a valid top-level schema)
+     */
+    public Type type() {
+        return type;
+    }
+
+    /**
+     * @return the field definitions of the response object, keyed by field name
+     */
+    public Map<String, Property> properties() {
+        return properties;
+    }
+
+    /**
+     * @return the names of fields the model must always include in its response
+     */
+    public List<String> required() {
+        return required;
+    }
+
+    /**
+     * @return whether fields beyond those declared in {@link #properties} are permitted
+     */
+    public boolean additionalProperties() {
+        return additionalProperties;
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/schema/Type.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/schema/Type.java
@@ -1,0 +1,29 @@
+package org.togetherjava.tjbot.features.chatgpt.schema;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The JSON Schema primitive types supported by OpenAI's structured outputs. Each constant
+ * serializes to its lowercase form (e.g. {@code STRING} → {@code "string"}) via {@link #jsonValue},
+ * matching the JSON Schema specification.
+ */
+public enum Type {
+    STRING,
+    NUMBER,
+    INTEGER,
+    BOOLEAN,
+    OBJECT,
+    ARRAY,
+    NULL;
+
+    /**
+     * Returns the lowercase JSON representation of this type. Used by Jackson via
+     * {@link JsonValue}, so the enum serializes to {@code "string"} rather than {@code "STRING"}.
+     *
+     * @return the JSON Schema type name in lowercase
+     */
+    @JsonValue
+    public String jsonValue() {
+        return name().toLowerCase();
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/schema/package-info.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/schema/package-info.java
@@ -1,0 +1,7 @@
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package org.togetherjava.tjbot.features.chatgpt.schema;
+
+import org.togetherjava.tjbot.annotations.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -1,5 +1,6 @@
 package org.togetherjava.tjbot.features.moderation;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
@@ -12,13 +13,9 @@ import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
 import net.dv8tion.jda.api.entities.channel.forums.ForumTagSnowflake;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
-import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
-import net.dv8tion.jda.api.interactions.components.text.TextInput;
-import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
-import net.dv8tion.jda.api.interactions.modals.Modal;
 import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction;
@@ -33,10 +30,14 @@ import org.togetherjava.tjbot.features.CommandVisibility;
 import org.togetherjava.tjbot.features.MessageContextCommand;
 import org.togetherjava.tjbot.features.chatgpt.ChatGptModel;
 import org.togetherjava.tjbot.features.chatgpt.ChatGptService;
+import org.togetherjava.tjbot.features.chatgpt.schema.Property;
+import org.togetherjava.tjbot.features.chatgpt.schema.ResponseSchema;
+import org.togetherjava.tjbot.features.chatgpt.schema.Type;
 import org.togetherjava.tjbot.features.utils.StringDistances;
 
 import java.awt.Color;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -45,28 +46,25 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 /**
- * This command can be used to transfer questions asked in any channel to the helper forum. The user
- * is given the chance to edit details of the question and upon submitting, the original message
- * will be deleted and recreated in the helper forum. The original author is notified and redirected
- * to the new post.
+ * This command transfers a question asked in any channel to the helper forum. The AI generates the
+ * post title and selects the most fitting tag; the original message body is reused verbatim. On
+ * success the original message is deleted and its author is notified and redirected to the new
+ * post.
  */
 public final class TransferQuestionCommand extends BotCommandAdapter
         implements MessageContextCommand {
     private static final Logger logger = LoggerFactory.getLogger(TransferQuestionCommand.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String COMMAND_NAME = "transfer-question";
-    private static final String MODAL_TITLE_ID = "transferID";
-    private static final String MODAL_INPUT_ID = "transferQuestion";
-    private static final String MODAL_TAG = "tags";
     private static final int TITLE_MAX_LENGTH = 50;
     private static final Pattern TITLE_GUESS_COMPACT_REMOVAL_PATTERN = Pattern.compile("\\W");
     private static final int TITLE_MIN_LENGTH = 3;
     private static final Color EMBED_COLOR = new Color(50, 164, 168);
-    private static final int INPUT_MAX_LENGTH = Message.MAX_CONTENT_LENGTH;
-    private static final int INPUT_MIN_LENGTH = 3;
+
     private final Predicate<String> isHelpForumName;
     private final List<String> tags;
     private final ChatGptService chatGptService;
-
+    private final ResponseSchema transferSchema;
 
     /**
      * Creates a new instance.
@@ -82,6 +80,9 @@ public final class TransferQuestionCommand extends BotCommandAdapter
 
         tags = config.getHelpSystem().getCategories();
         this.chatGptService = chatGptService;
+        this.transferSchema = new ResponseSchema(
+                Map.of("title", Property.of(Type.STRING), "tag", Property.of(Type.STRING)),
+                List.of("title", "tag"));
     }
 
     @Override
@@ -90,88 +91,68 @@ public final class TransferQuestionCommand extends BotCommandAdapter
             return;
         }
 
-        String originalMessage = event.getTarget().getContentRaw();
-        String originalMessageId = event.getTarget().getId();
-        String originalChannelId = event.getTarget().getChannel().getId();
-        String authorId = event.getTarget().getAuthor().getId();
-        String mostCommonTag = tags.getFirst();
-
-        String chatGptTitleRequest =
-                "Summarize the following question into a concise title or heading not more than 5 words, remove quotations if any: %s"
-                    .formatted(originalMessage);
-        Optional<String> chatGptTitle =
-                chatGptService.ask(chatGptTitleRequest, null, ChatGptModel.FASTEST);
-        String title = chatGptTitle.orElse(createTitle(originalMessage));
-        if (title.startsWith("\"") && title.endsWith("\"")) {
-            title = title.substring(1, title.length() - 1);
-        }
-
-        if (title.length() > TITLE_MAX_LENGTH) {
-            title = title.substring(0, TITLE_MAX_LENGTH);
-        }
-
-        TextInput modalTitle = TextInput.create(MODAL_TITLE_ID, "Title", TextInputStyle.SHORT)
-            .setMaxLength(TITLE_MAX_LENGTH)
-            .setMinLength(TITLE_MIN_LENGTH)
-            .setPlaceholder("Describe the question in short")
-            .setValue(title)
-            .build();
-
-        TextInput.Builder modalInputBuilder =
-                TextInput.create(MODAL_INPUT_ID, "Question", TextInputStyle.PARAGRAPH)
-                    .setRequiredRange(INPUT_MIN_LENGTH, INPUT_MAX_LENGTH)
-                    .setPlaceholder("Contents of the question");
-
-        if (!isQuestionTooShort(originalMessage)) {
-            String trimmedMessage = getMessageUptoMaxLimit(originalMessage);
-            modalInputBuilder.setValue(trimmedMessage);
-        }
-
-        TextInput modalTag = TextInput.create(MODAL_TAG, "Most fitting tag", TextInputStyle.SHORT)
-            .setValue(mostCommonTag)
-            .setPlaceholder("Suitable tag for the question")
-            .build();
-
-        String modalComponentId =
-                generateComponentId(authorId, originalMessageId, originalChannelId);
-        Modal transferModal = Modal.create(modalComponentId, "Transfer this question")
-            .addActionRow(modalTitle)
-            .addActionRow(modalInputBuilder.build())
-            .addActionRow(modalTag)
-            .build();
-
-        event.replyModal(transferModal).queue();
-    }
-
-    @Override
-    public void onModalSubmitted(ModalInteractionEvent event, List<String> args) {
         event.deferReply(true).queue();
 
-        String authorId = args.getFirst();
-        String messageId = args.get(1);
-        String channelId = args.get(2);
-        ForumChannel helperForum = getHelperForum(event.getJDA());
+        Message message = event.getTarget();
+        String authorId = message.getAuthor().getId();
+        String messageId = message.getId();
+        String channelId = message.getChannelId();
+        String content = message.getContentRaw();
 
-        // Has been handled if original message was deleted by now.
-        // Deleted messages cause retrieveMessageById to fail.
+        AiTransferResult ai = askAi(content)
+            .orElseGet(() -> new AiTransferResult(createTitle(content), tags.getFirst()));
+        String title = sanitizeTitle(ai.title());
+        String tag = ai.tag();
+
         Consumer<Message> notHandledAction =
-                _ -> transferFlow(event, channelId, authorId, messageId);
+                _ -> transferFlow(event, channelId, authorId, messageId, title, tag, content);
 
         Consumer<Throwable> handledAction = failure -> {
             if (failure instanceof ErrorResponseException errorResponseException
                     && errorResponseException.getErrorResponse() == ErrorResponse.UNKNOWN_MESSAGE) {
-                alreadyHandled(event, helperForum);
+                alreadyHandled(event);
                 return;
             }
-            logger.warn("Unknown error occurred on modal submission during question transfer.",
-                    failure);
+            logger.warn("Unknown error occurred during question transfer.", failure);
         };
 
         event.getChannel().retrieveMessageById(messageId).queue(notHandledAction, handledAction);
     }
 
-    private void transferFlow(ModalInteractionEvent event, String channelId, String authorId,
-            String messageId) {
+    private Optional<AiTransferResult> askAi(String content) {
+        String prompt = """
+                Summarize the following question into a concise title (max 5 words, no quotes) \
+                and pick the single most fitting tag from this list: %s.
+
+                Question: %s
+                """.formatted(tags, content);
+
+        return chatGptService.askRaw(prompt, ChatGptModel.FAST, transferSchema)
+            .flatMap(this::parseAi);
+    }
+
+    private Optional<AiTransferResult> parseAi(String json) {
+        try {
+            return Optional.of(OBJECT_MAPPER.readValue(json, AiTransferResult.class));
+        } catch (Exception e) {
+            logger.warn("Failed to parse AI transfer response: {}", json, e);
+            return Optional.empty();
+        }
+    }
+
+    private static String sanitizeTitle(String raw) {
+        String title = raw;
+        if (title.startsWith("\"") && title.endsWith("\"")) {
+            title = title.substring(1, title.length() - 1);
+        }
+        if (title.length() > TITLE_MAX_LENGTH) {
+            title = title.substring(0, TITLE_MAX_LENGTH);
+        }
+        return title;
+    }
+
+    private void transferFlow(MessageContextInteractionEvent event, String channelId,
+            String authorId, String messageId, String title, String tag, String content) {
         Function<ForumPostData, WebhookMessageCreateAction<Message>> sendMessageToTransferrer =
                 post -> event.getHook()
                     .sendMessage("Transferred to %s"
@@ -179,7 +160,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
 
         event.getJDA()
             .retrieveUserById(authorId)
-            .flatMap(fetchedUser -> createForumPost(event, fetchedUser))
+            .flatMap(fetchedUser -> createForumPost(event, fetchedUser, title, tag, content))
             .flatMap(createdForumPost -> dmUser(event.getChannel(), createdForumPost,
                     event.getGuild())
                 .and(sendMessageToTransferrer.apply(createdForumPost)))
@@ -187,7 +168,8 @@ public final class TransferQuestionCommand extends BotCommandAdapter
             .queue();
     }
 
-    private void alreadyHandled(ModalInteractionEvent event, ForumChannel helperForum) {
+    private void alreadyHandled(MessageContextInteractionEvent event) {
+        ForumChannel helperForum = getHelperForum(event.getJDA());
         event.getHook()
             .sendMessage(
                     "It appears that someone else has already transferred this question. Kindly see %s for details."
@@ -216,30 +198,24 @@ public final class TransferQuestionCommand extends BotCommandAdapter
                 && titleCompact.length() <= TITLE_MAX_LENGTH;
     }
 
-    private RestAction<ForumPostData> createForumPost(ModalInteractionEvent event,
-            User originalUser) {
-        String originalMessage = event.getValue(MODAL_INPUT_ID).getAsString();
-
-        MessageEmbed embedForPost = makeEmbedForPost(originalUser, originalMessage);
+    private RestAction<ForumPostData> createForumPost(MessageContextInteractionEvent event,
+            User originalUser, String title, String tagQuery, String content) {
+        MessageEmbed embedForPost = makeEmbedForPost(originalUser, content);
 
         MessageCreateData forumMessage = new MessageCreateBuilder()
             .addContent("%s has a question:".formatted(originalUser.getAsMention()))
             .setEmbeds(embedForPost)
             .build();
 
-        String forumTitle = event.getValue(MODAL_TITLE_ID).getAsString();
-        String transferQuestionTag = event.getValue(MODAL_TAG).getAsString();
-
         ForumChannel questionsForum = getHelperForum(event.getJDA());
         String mostCommonTag = tags.getFirst();
 
-        String queryTag =
-                StringDistances.closestMatch(transferQuestionTag, tags).orElse(mostCommonTag);
+        String queryTag = StringDistances.closestMatch(tagQuery, tags).orElse(mostCommonTag);
 
         ForumTag tag = getTagOrDefault(questionsForum.getAvailableTagsByName(queryTag, true),
                 () -> questionsForum.getAvailableTagsByName(mostCommonTag, true).getFirst());
 
-        return questionsForum.createForumPost(forumTitle, forumMessage)
+        return questionsForum.createForumPost(title, forumMessage)
             .setTags(ForumTagSnowflake.fromId(tag.getId()))
             .map(createdPost -> new ForumPostData(createdPost, originalUser));
     }
@@ -299,16 +275,15 @@ public final class TransferQuestionCommand extends BotCommandAdapter
     private record ForumPostData(ForumPost forumPost, User author) {
     }
 
+    private record AiTransferResult(String title, String tag) {
+    }
+
     private boolean isBotMessageTransfer(User author) {
         return author.isBot();
     }
 
     private void handleBotMessageTransfer(MessageContextInteractionEvent event) {
         event.reply("Cannot transfer messages from a bot.").setEphemeral(true).queue();
-    }
-
-    private boolean isQuestionTooShort(String question) {
-        return question.length() < INPUT_MIN_LENGTH;
     }
 
     private boolean isInvalidForTransfer(MessageContextInteractionEvent event) {
@@ -319,11 +294,5 @@ public final class TransferQuestionCommand extends BotCommandAdapter
             return true;
         }
         return false;
-    }
-
-    private String getMessageUptoMaxLimit(String originalMessage) {
-        return originalMessage.length() > INPUT_MAX_LENGTH
-                ? originalMessage.substring(0, INPUT_MAX_LENGTH)
-                : originalMessage;
     }
 }


### PR DESCRIPTION
[contributing]: https://github.com/Together-Java/TJ-Bot/wiki/Contributing
[code_guidelines]: https://github.com/Together-Java/TJ-Bot/wiki/Code-Guidelines
[new_issue]: https://github.com/Together-Java/TJ-Bot/issues/new/choose

## Pull-request

- [X] I have read the [contributing guidelines][contributing].
- [X] I have read the [code guidelines][code_guidelines].
- [ ] I have created a relating [issue][new_issue].

### Changes

- [X] Existing code
- [X] New feature

Closes Issue: NaN

## Description

The OpenAI API supports structured JSON responses which we are currently not taking advantage of.

The way it works is that with each prompt, you can specify a schema and the API will respond with only that. This is useful in a fair bit of scenarios where we want structured output that we can parse in code. There are some places were we are trying to achieve this via prompt injection however we then gamble on the AI producing a response we want. 

Usage example:

```java
  ResponseSchema schema = new ResponseSchema(
          Map.of(
                  "summary", Property.of(Type.STRING),
                  "tags",    Property.array(Property.of(Type.STRING)),
                  "author",  Property.object(
                          Map.of(
                                  "name", Property.of(Type.STRING),
                                  "ts",  Property.of(Type.INTEGER)),
                          List.of("name", "ts"))),
          List.of("summary", "tags", "author"));

  Optional<String> json = chatGptService.askRaw(
          "Summarize this thread and extract its tags and author.",
          ChatGptModel.GPT_4_MINI,
          schema);
```

Example AI output:
```json
  {
    "summary": "User asks about generics in Java.",
    "tags": ["java", "generics", "type-erasure"],
    "author": { "name": "alice", "ts": 123456789 }
  }
```
