### PR TITLE
feat: explicit allow list of channels for quotes board

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -222,7 +222,14 @@
             "⭐": 1.0,
 
             "youtube:1464573182206804010": 0.0
-        }
+        },
+        "allowChannels": [
+            "chit-chat",
+            "career-talk",
+            "geek-speek",
+            "expert-java-talk",
+            "ai-talk"
+        ]
     },
     "roleApplicationSystem": {
         "submissionsChannelPattern": "staff-applications",

--- a/application/src/main/java/org/togetherjava/tjbot/config/QuoteBoardConfig.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/QuoteBoardConfig.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.LogManager;
 
 import org.togetherjava.tjbot.features.basic.QuoteBoardForwarder;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -18,7 +19,8 @@ public record QuoteBoardConfig(
         @JsonProperty(value = "channel", required = true) String channel,
         @JsonProperty(value = "botEmoji", required = true) String botEmoji,
         @JsonProperty(value = "defaultEmojiScore", required = true) float defaultEmojiScore,
-        @JsonProperty(value = "emojiScores", required = true) Map<String, Float> emojiScores) {
+        @JsonProperty(value = "emojiScores", required = true) Map<String, Float> emojiScores,
+        @JsonProperty(value = "allowChannels", required = true) List<String> allowChannels) {
 
     /**
      * Creates a QuoteBoardConfig.

--- a/application/src/main/java/org/togetherjava/tjbot/features/basic/QuoteBoardForwarder.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/basic/QuoteBoardForwarder.java
@@ -59,6 +59,11 @@ public final class QuoteBoardForwarder extends MessageReceiverAdapter {
         logger.debug("Received MessageReactionAddEvent: messageId={}, channelId={}, userId={}",
                 event.getMessageId(), event.getChannel().getId(), event.getUserId());
 
+        if (!config.allowChannels().contains(event.getChannel().getName())) {
+            logger.debug("Skipping as reaction occurred in non-whitelisted channel");
+            return;
+        }
+
         final long guildId = event.getGuild().getIdLong();
 
         Optional<TextChannel> boardChannelOptional = findQuoteBoardChannel(event.getJDA(), guildId);


### PR DESCRIPTION
## Description

With the addition of allowing quote board to trigger on any type of emoji, the quotes board is now triggering on all channels e.g. #server-suggestions. This is problematic as we'll now get false positives and over triggering of quotes.

This PR adds an explicit allow list for channels that this can trigger on. Opted for an allow list vs. blacklist as a blacklist requires more maintaince long term while an allow list is easier and shorter to maintain. 