### PR TITLE
Adds "this-is-scam" message context command

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/Features.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/Features.java
@@ -53,6 +53,7 @@ import org.togetherjava.tjbot.features.moderation.NoteCommand;
 import org.togetherjava.tjbot.features.moderation.QuarantineCommand;
 import org.togetherjava.tjbot.features.moderation.RejoinModerationRoleListener;
 import org.togetherjava.tjbot.features.moderation.ReportCommand;
+import org.togetherjava.tjbot.features.moderation.ThisIsScamCommand;
 import org.togetherjava.tjbot.features.moderation.TransferQuestionCommand;
 import org.togetherjava.tjbot.features.moderation.UnbanCommand;
 import org.togetherjava.tjbot.features.moderation.UnmuteCommand;
@@ -191,6 +192,7 @@ public class Features {
 
         // Message context commands
         features.add(new TransferQuestionCommand(config, chatGptService));
+        features.add(new ThisIsScamCommand(config, actionsStore));
 
         // User context commands
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
@@ -190,22 +190,20 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
         String content = target.getContentStripped();
         String description = content.isBlank() ? "(message had no text content)" : content;
 
+        String attachmentText = "_none_";
         List<Message.Attachment> attachments = target.getAttachments();
         if (!attachments.isEmpty()) {
-            String attachmentInfo = attachments.stream()
+            attachmentText = attachments.stream()
                 .map(Message.Attachment::getFileName)
-                .collect(Collectors.joining("\n"));
-            description += """
-
-
-                    Attachments:
-                    """ + attachmentInfo;
+                .collect(Collectors.joining("\n- ", "\n- ", ""));
         }
 
         description += """
 
 
-                [Go to message](%s)""".formatted(target.getJumpUrl());
+                Attachments: %s
+                [Go to message](%s)
+                """.formatted(attachmentText, target.getJumpUrl());
         return description;
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
@@ -61,16 +61,16 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
     private static final Duration USER_COMMAND_COOLDOWN = Duration.ofMinutes(1);
     private static final Color AMBIENT_COLOR = Color.decode("#CFBFF5");
 
+    private final Config config;
+    private final ModerationActionsStore actionsStore;
+    private final Predicate<String> isModAuditLogChannel;
+
     private final Cache<Long, Instant> reportedMessageToTimestamp =
             Caffeine.newBuilder().maximumSize(10_000).expireAfterWrite(Duration.ofDays(1)).build();
     private final Cache<Long, Instant> userToLastCommandUse = Caffeine.newBuilder()
         .maximumSize(10_000)
         .expireAfterWrite(USER_COMMAND_COOLDOWN)
         .build();
-
-    private final Config config;
-    private final ModerationActionsStore actionsStore;
-    private final Predicate<String> isModAuditLogChannel;
 
     /**
      * Creates a new instance.
@@ -96,7 +96,7 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
             return;
         }
 
-        Optional<TextChannel> modAuditLog = getModAuditLogChannel(event);
+        Optional<TextChannel> modAuditLog = findModAuditLogChannel(event);
         if (modAuditLog.isEmpty()) {
             event.reply(FAILED_MESSAGE).setEphemeral(true).queue();
             return;
@@ -114,9 +114,9 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
     }
 
     private boolean handleIsOnCooldown(MessageContextInteractionEvent event) {
-        Instant lastCommandUse = userToLastCommandUse.getIfPresent(event.getUser().getIdLong());
-        Runnable isNotOnCooldownAction =
-                () -> userToLastCommandUse.put(event.getUser().getIdLong(), Instant.now());
+        long userId = event.getUser().getIdLong();
+        Instant lastCommandUse = userToLastCommandUse.getIfPresent(userId);
+        Runnable isNotOnCooldownAction = () -> userToLastCommandUse.put(userId, Instant.now());
 
         if (lastCommandUse == null) {
             isNotOnCooldownAction.run();
@@ -147,7 +147,7 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
         return false;
     }
 
-    private Optional<TextChannel> getModAuditLogChannel(MessageContextInteractionEvent event) {
+    private Optional<TextChannel> findModAuditLogChannel(MessageContextInteractionEvent event) {
         Guild guild = Objects.requireNonNull(event.getGuild());
         Optional<TextChannel> modAuditLogChannel =
                 Guilds.findTextChannel(guild, isModAuditLogChannel);
@@ -181,20 +181,26 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
                     Button.danger(generateComponentId(args), "No"));
     }
 
-    @SuppressWarnings("squid:S3457") // %n is wrong, markdown must use \n
     private static String createDescription(Message target) {
         String content = target.getContentStripped();
-        String description = content.isBlank() ? "(empty message)" : content;
+        String description = content.isBlank() ? "(message had no text content)" : content;
 
         List<Message.Attachment> attachments = target.getAttachments();
         if (!attachments.isEmpty()) {
             String attachmentInfo = attachments.stream()
                 .map(Message.Attachment::getFileName)
                 .collect(Collectors.joining("\n"));
-            description += "\n\nAttachments:\n" + attachmentInfo;
+            description += """
+
+
+                    Attachments:
+                    """ + attachmentInfo;
         }
 
-        description += "\n\n[Go to message](%s)".formatted(target.getJumpUrl());
+        description += """
+
+
+                [Go to message](%s)""".formatted(target.getJumpUrl());
         return description;
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
@@ -182,6 +182,7 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
                     Button.danger(generateComponentId(args), "No"));
     }
 
+    @SuppressWarnings("squid:S3457") // %n is wrong, markdown must use \n
     private static String createDescription(Message target) {
         String content = target.getContentStripped();
         String description = content.isBlank() ? "(empty message)" : content;

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
@@ -285,7 +285,7 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
                         This means you can no longer interact with anyone in the server until you have been unquarantined again.
 
                         Potentially your account got compromised.
-                        After you regained control of your account make sure you secure it properly, for example using 2FA.
+                        After you regained control of your account make sure you secure it properly, for example by using 2FA.
                         You can then join back our server and contact the mods to get unquarantined.""";
 
         return ModerationUtils.sendModActionDm(ModerationUtils.getModActionEmbed(guild,

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
@@ -27,6 +27,7 @@ import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.features.BotCommandAdapter;
 import org.togetherjava.tjbot.features.CommandVisibility;
 import org.togetherjava.tjbot.features.MessageContextCommand;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 import org.togetherjava.tjbot.features.utils.Guilds;
 import org.togetherjava.tjbot.features.utils.MessageUtils;
 import org.togetherjava.tjbot.logging.LogMarkers;
@@ -62,7 +63,6 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
     private static final String FAILED_MESSAGE =
             "Sorry, there was an issue forwarding your scam report to the moderators. We are investigating.";
     private static final Duration USER_COMMAND_COOLDOWN = Duration.ofMinutes(1);
-    private static final Color AMBIENT_COLOR = Color.decode("#CFBFF5");
 
     private final Config config;
     private final ModerationActionsStore actionsStore;
@@ -173,7 +173,7 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
                     MessageUtils.abbreviate(description, MessageEmbed.DESCRIPTION_MAX_LENGTH))
             .setAuthor(author.getName(), null, author.getEffectiveAvatarUrl())
             .setTimestamp(message.getTimeCreated())
-            .setColor(AMBIENT_COLOR)
+            .setColor(AmbientColors.MODERATION_SCAM)
             .setFooter("%s - account age %d days".formatted(author.getId(), accountAgeDays))
             .build();
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
@@ -15,7 +15,6 @@ import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionE
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.exceptions.ErrorHandler;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
-import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.requests.ErrorResponse;
@@ -217,10 +216,7 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
         List<MessageEmbed> embeds = new ArrayList<>(event.getMessage().getEmbeds());
         embeds.add(resultEmbed);
 
-        List<Button> disabledButtons =
-                event.getMessage().getButtons().stream().map(Button::asDisabled).toList();
-
-        event.editMessageEmbeds(embeds).setComponents(ActionRow.of(disabledButtons)).queue();
+        event.editMessageEmbeds(embeds).setComponents().queue();
 
         if (!isScam) {
             return;

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
@@ -281,8 +281,12 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
     private RestAction<Boolean> sendQuarantineDm(User target, Guild guild) {
         String description =
                 """
-                        Hey there, sorry to tell you but unfortunately you have been put under quarantine.
-                        This means you can no longer interact with anyone in the server until you have been unquarantined again.""";
+                        Hey there, sorry to tell you but unfortunately you have been put under quarantine after sending scam.
+                        This means you can no longer interact with anyone in the server until you have been unquarantined again.
+
+                        Potentially your account got compromised.
+                        After you regained control of your account make sure you secure it properly, for example using 2FA.
+                        You can then join back our server and contact the mods to get unquarantined.""";
 
         return ModerationUtils.sendModActionDm(ModerationUtils.getModActionEmbed(guild,
                 ACTION_TITLE, description, ACTION_REASON, true), target);

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
@@ -175,10 +175,11 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
 
         long guildId = message.getGuild().getIdLong();
         long authorId = author.getIdLong();
-        String componentId = generateComponentId(String.valueOf(guildId), String.valueOf(authorId));
+        String[] args = {String.valueOf(guildId), String.valueOf(authorId)};
 
         return auditChannel.sendMessageEmbeds(reportEmbed)
-            .addActionRow(Button.success(componentId, "Yes"), Button.danger(componentId, "No"));
+            .addActionRow(Button.success(generateComponentId(args), "Yes"),
+                    Button.danger(generateComponentId(args), "No"));
     }
 
     private static String createDescription(Message target) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
@@ -1,0 +1,302 @@
+package org.togetherjava.tjbot.features.moderation;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.exceptions.ErrorHandler;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.components.ActionRow;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
+import net.dv8tion.jda.api.requests.ErrorResponse;
+import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.togetherjava.tjbot.config.Config;
+import org.togetherjava.tjbot.features.BotCommandAdapter;
+import org.togetherjava.tjbot.features.CommandVisibility;
+import org.togetherjava.tjbot.features.MessageContextCommand;
+import org.togetherjava.tjbot.features.utils.Guilds;
+import org.togetherjava.tjbot.features.utils.MessageUtils;
+import org.togetherjava.tjbot.logging.LogMarkers;
+
+import java.awt.Color;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Allows users to report a message as potential scam. Moderators can confirm the report from the
+ * audit log, causing the author to be quarantined plus message history getting deleted.
+ */
+public final class ThisIsScamCommand extends BotCommandAdapter implements MessageContextCommand {
+    private static final Logger logger = LoggerFactory.getLogger(ThisIsScamCommand.class);
+
+    private static final String COMMAND_NAME = "this-is-scam";
+
+    private static final String ACTION_TITLE = "Quarantine";
+    private static final String ACTION_REASON = "Message was reported and confirmed as scam";
+
+    private static final String FAILED_MESSAGE =
+            "Sorry, there was an issue forwarding your scam report to the moderators. We are investigating.";
+    private static final Duration USER_COMMAND_COOLDOWN = Duration.ofMinutes(1);
+    private static final Color AMBIENT_COLOR = Color.decode("#CFBFF5");
+
+    private final Cache<Long, Instant> reportedMessageToTimestamp =
+            Caffeine.newBuilder().maximumSize(10_000).expireAfterWrite(Duration.ofDays(1)).build();
+    private final Cache<Long, Instant> userToLastCommandUse = Caffeine.newBuilder()
+        .maximumSize(10_000)
+        .expireAfterWrite(USER_COMMAND_COOLDOWN)
+        .build();
+
+    private final Config config;
+    private final ModerationActionsStore actionsStore;
+    private final Predicate<String> isModAuditLogChannel;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param config to resolve the moderation audit log channel and quarantined role
+     * @param actionsStore used to store issued quarantine actions
+     */
+    public ThisIsScamCommand(Config config, ModerationActionsStore actionsStore) {
+        super(Commands.message(COMMAND_NAME), CommandVisibility.GUILD);
+
+        this.config = Objects.requireNonNull(config);
+        this.actionsStore = Objects.requireNonNull(actionsStore);
+        isModAuditLogChannel =
+                Pattern.compile(config.getModAuditLogChannelPattern()).asMatchPredicate();
+    }
+
+    @Override
+    public void onMessageContext(MessageContextInteractionEvent event) {
+        if (handleIsOnCooldown(event)) {
+            return;
+        }
+        if (handleWasAlreadyReportedMessage(event)) {
+            return;
+        }
+
+        Optional<TextChannel> modAuditLog = getModAuditLogChannel(event);
+        if (modAuditLog.isEmpty()) {
+            event.reply(FAILED_MESSAGE).setEphemeral(true).queue();
+            return;
+        }
+
+        Message message = event.getTarget();
+        reportToMods(message, modAuditLog.orElseThrow()).mapToResult().map(result -> {
+            if (result.isFailure()) {
+                logger.warn("Unable to forward a scam report to the mod audit log channel.",
+                        result.getFailure());
+                return FAILED_MESSAGE;
+            }
+            return "Thank you for your report, a moderator will take care of it 👍";
+        }).flatMap(response -> event.reply(response).setEphemeral(true)).queue();
+    }
+
+    private boolean handleIsOnCooldown(MessageContextInteractionEvent event) {
+        Instant lastCommandUse = userToLastCommandUse.getIfPresent(event.getUser().getIdLong());
+        Runnable isNotOnCooldownAction =
+                () -> userToLastCommandUse.put(event.getUser().getIdLong(), Instant.now());
+
+        if (lastCommandUse == null) {
+            isNotOnCooldownAction.run();
+            return false;
+        }
+        Instant momentCooldownEnds = lastCommandUse.plus(USER_COMMAND_COOLDOWN);
+        if (Instant.now().isAfter(momentCooldownEnds)) {
+            isNotOnCooldownAction.run();
+            return false;
+        }
+
+        event.reply("You just reported message as scam, please wait a bit.")
+            .setEphemeral(true)
+            .queue();
+        return true;
+    }
+
+    private boolean handleWasAlreadyReportedMessage(MessageContextInteractionEvent event) {
+        long messageId = event.getTarget().getIdLong();
+        if (reportedMessageToTimestamp.getIfPresent(messageId) != null) {
+            event.reply("This message was already reported as potential scam.")
+                .setEphemeral(true)
+                .queue();
+            return true;
+        }
+
+        reportedMessageToTimestamp.put(messageId, Instant.now());
+        return false;
+    }
+
+    private Optional<TextChannel> getModAuditLogChannel(MessageContextInteractionEvent event) {
+        Guild guild = Objects.requireNonNull(event.getGuild());
+        Optional<TextChannel> modAuditLogChannel =
+                Guilds.findTextChannel(guild, isModAuditLogChannel);
+        if (modAuditLogChannel.isEmpty()) {
+            logger.warn(
+                    "Cannot find the designated mod audit log channel in guild '{}' with the pattern '{}'",
+                    guild.getId(), config.getModAuditLogChannelPattern());
+        }
+        return modAuditLogChannel;
+    }
+
+    private MessageCreateAction reportToMods(Message message, TextChannel auditChannel) {
+        User author = message.getAuthor();
+        String description = createDescription(message);
+
+        MessageEmbed reportEmbed = new EmbedBuilder().setTitle("Is this Scam?")
+            .setDescription(
+                    MessageUtils.abbreviate(description, MessageEmbed.DESCRIPTION_MAX_LENGTH))
+            .setAuthor(author.getName(), null, author.getEffectiveAvatarUrl())
+            .setTimestamp(message.getTimeCreated())
+            .setColor(AMBIENT_COLOR)
+            .setFooter(author.getId())
+            .build();
+
+        long guildId = message.getGuild().getIdLong();
+        long authorId = author.getIdLong();
+        String componentId = generateComponentId(String.valueOf(guildId), String.valueOf(authorId));
+
+        return auditChannel.sendMessageEmbeds(reportEmbed)
+            .addActionRow(Button.success(componentId, "Yes"), Button.danger(componentId, "No"));
+    }
+
+    private static String createDescription(Message target) {
+        String content = target.getContentStripped();
+        String description = content.isBlank() ? "(empty message)" : content;
+
+        List<Message.Attachment> attachments = target.getAttachments();
+        if (!attachments.isEmpty()) {
+            String attachmentInfo = attachments.stream()
+                .map(Message.Attachment::getFileName)
+                .collect(Collectors.joining("\n"));
+            description += "\n\nAttachments:\n" + attachmentInfo;
+        }
+
+        description += "\n\n[Go to message](%s)".formatted(target.getJumpUrl());
+        return description;
+    }
+
+    @Override
+    public void onButtonClick(ButtonInteractionEvent event, List<String> args) {
+        long guildId = Long.parseLong(args.get(0));
+        long targetId = Long.parseLong(args.get(1));
+
+        ButtonStyle clickedStyle = event.getButton().getStyle();
+        boolean isScam = clickedStyle == ButtonStyle.SUCCESS;
+
+        MessageEmbed resultEmbed = new EmbedBuilder()
+            .setDescription(
+                    isScam ? "This is scam. The user was quarantined and messages were deleted."
+                            : "This is not scam, no action executed.")
+            .setColor(isScam ? Color.GREEN : Color.RED)
+            .build();
+
+        List<MessageEmbed> embeds = new ArrayList<>(event.getMessage().getEmbeds());
+        embeds.add(resultEmbed);
+
+        List<Button> disabledButtons =
+                event.getMessage().getButtons().stream().map(Button::asDisabled).toList();
+
+        event.editMessageEmbeds(embeds).setComponents(ActionRow.of(disabledButtons)).queue();
+
+        if (!isScam) {
+            return;
+        }
+
+        Guild guild = Objects.requireNonNull(event.getJDA().getGuildById(guildId));
+        Member moderator = Objects.requireNonNull(event.getMember());
+
+        ErrorHandler errorHandler = new ErrorHandler()
+            .handle(ErrorResponse.UNKNOWN_USER, failure -> logger.debug(LogMarkers.SENSITIVE,
+                    "Attempted to handle user-reported scam, but user '{}' does not exist anymore.",
+                    targetId))
+            .handle(ErrorResponse.UNKNOWN_MEMBER, failure -> logger.debug(LogMarkers.SENSITIVE,
+                    "Attempted to handle user-reported scam, but user '{}' is not a member of guild '{}' anymore.",
+                    targetId, guildId));
+
+        guild.retrieveMemberById(targetId)
+            .queue(target -> handleConfirmedScam(guild, target, moderator, event), errorHandler);
+    }
+
+    private void handleConfirmedScam(Guild guild, Member target, Member moderator,
+            ButtonInteractionEvent event) {
+        if (!handleCanQuarantineAndBan(guild, target, event)) {
+            return;
+        }
+
+        Consumer<? super Void> onSuccess = _ -> {
+        };
+        Consumer<? super Throwable> onFailure = failure -> logger.warn(LogMarkers.SENSITIVE,
+                "Failed to finish user-reported scam handling for user '{}' in guild '{}'.",
+                target.getId(), guild.getId(), failure);
+
+        sendQuarantineDm(target.getUser(), guild)
+            .flatMap(hasSentDm -> quarantineUser(guild, target, moderator))
+            .flatMap(_ -> deleteMessagesByBanAndUnban(guild, target.getUser()))
+            .queue(onSuccess, onFailure);
+    }
+
+    private boolean handleCanQuarantineAndBan(Guild guild, Member target,
+            ButtonInteractionEvent event) {
+        Member bot = guild.getSelfMember();
+        Member moderator = Objects.requireNonNull(event.getMember());
+        Role quarantinedRole = ModerationUtils.getQuarantinedRole(guild, config).orElse(null);
+
+        return ModerationUtils.handleRoleChangeChecks(quarantinedRole, "quarantine", target, bot,
+                moderator, guild, ACTION_REASON, event)
+                && ModerationUtils.handleHasBotPermissions("ban", Permission.BAN_MEMBERS, bot,
+                        guild, event);
+    }
+
+    private RestAction<Boolean> sendQuarantineDm(User target, Guild guild) {
+        String description =
+                """
+                        Hey there, sorry to tell you but unfortunately you have been put under quarantine.
+                        This means you can no longer interact with anyone in the server until you have been unquarantined again.""";
+
+        return ModerationUtils.sendModActionDm(ModerationUtils.getModActionEmbed(guild,
+                ACTION_TITLE, description, ACTION_REASON, true), target);
+    }
+
+    private RestAction<Void> quarantineUser(Guild guild, Member target, Member moderator) {
+        logger.info(LogMarkers.SENSITIVE,
+                "'{}' ({}) quarantined the user '{}' ({}) in guild '{}' for reason '{}'.",
+                moderator.getUser().getName(), moderator.getId(), target.getUser().getName(),
+                target.getId(), guild.getName(), ACTION_REASON);
+
+        actionsStore.addAction(guild.getIdLong(), moderator.getIdLong(), target.getIdLong(),
+                ModerationAction.QUARANTINE, null, ACTION_REASON);
+
+        return guild
+            .addRoleToMember(target,
+                    ModerationUtils.getQuarantinedRole(guild, config).orElseThrow())
+            .reason(ACTION_REASON);
+    }
+
+    private RestAction<Void> deleteMessagesByBanAndUnban(Guild guild, User target) {
+        return guild.ban(target, 1, TimeUnit.DAYS)
+            .reason(ACTION_REASON)
+            .flatMap(_ -> guild.unban(target).reason(ACTION_REASON));
+    }
+}

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
@@ -34,6 +34,9 @@ import org.togetherjava.tjbot.logging.LogMarkers;
 import java.awt.Color;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -162,6 +165,8 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
     private MessageCreateAction reportToMods(Message message, TextChannel auditChannel) {
         User author = message.getAuthor();
         String description = createDescription(message);
+        long accountAgeDays = ChronoUnit.DAYS.between(author.getTimeCreated(),
+                OffsetDateTime.now(ZoneOffset.UTC));
 
         MessageEmbed reportEmbed = new EmbedBuilder().setTitle("Is this Scam?")
             .setDescription(
@@ -169,7 +174,7 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
             .setAuthor(author.getName(), null, author.getEffectiveAvatarUrl())
             .setTimestamp(message.getTimeCreated())
             .setColor(AMBIENT_COLOR)
-            .setFooter(author.getId())
+            .setFooter("%s - account age %d days".formatted(author.getId(), accountAgeDays))
             .build();
 
         long guildId = message.getGuild().getIdLong();

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
@@ -128,7 +128,7 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
             return false;
         }
 
-        event.reply("You just reported message as scam, please wait a bit.")
+        event.reply("You just reported a message as scam, please wait a bit.")
             .setEphemeral(true)
             .queue();
         return true;

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -267,7 +267,7 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
             .setTitle(reportTitle)
             .setAuthor(author.getName(), null, avatarOrDefaultUrl)
             .setTimestamp(event.getMessage().getTimeCreated())
-            .setColor(AmbientColors.SCAM_BLOCKER)
+            .setColor(AmbientColors.MODERATION_SCAM)
             .setFooter(author.getId())
             .build();
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/utils/AmbientColors.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/utils/AmbientColors.java
@@ -23,12 +23,12 @@ public final class AmbientColors {
     public static final Color MODERATION = Color.decode("#895FE8");
     public static final Color MODERATION_AUDIT_ACTION = Color.decode("#4FC3F7");
     public static final Color MODERATION_AUDIT_LOG = Color.decode("#3788AC");
+    public static final Color MODERATION_SCAM = Color.decode("#CFBFF5");
     public static final Color MODMAIL = Color.BLACK;
     public static final Color PURGE_CONFIRMATION = Color.RED;
     public static final Color QUESTION_TRANSFER = Color.decode("#32A4A8");
     public static final Color REMINDER = Color.decode("#F7F492");
     public static final Color ROLE_MANAGEMENT = Color.decode("#18DD88");
-    public static final Color SCAM_BLOCKER = Color.decode("#CFBFF5");
     public static final Color TAGS = Color.decode("#FA8072");
     public static final Color WOLFRAM_ALPHA = Color.decode("#4290F5");
 


### PR DESCRIPTION
## Overview

This adds a new message context command (**right click message**) called `this-is-scam`. It acts as the primary way for users to report scam to mods.

Mods then get presented a quick way to handle the scam properly by automatically deleting all messages from the user and putting them under quarantine through a single button press!

<img width="563" height="473" alt="grafik" src="https://github.com/user-attachments/assets/54a5cb4a-4891-44b1-b2c5-80839c9dc679" />

Internally this works by **quarantine, ban (delete messages from one day), unban** in that order. The user ends up being kicked out of the guild (due to the ban) but can immediately rejoin (due to the unban), but remains **quarantined**.

## Other

The following extra situations are handled gracefully via in-memory caches:

* multiple users report the same message as scam: only one is being processed
* a user tries to abuse the command by using it constantly: users are on cooldown for 1 minute

Also, an appropriate entry in the audit-log of the user (`/audit`) is created.

Attachments are spelled out so it becomes easier for devs later on to edit `ScamBlocker` accordingly.

## Code

The integration is minimal and simple, just a straightforward single class is added `ThisIsScamCommand.java`, thats it. No config changes, everything easy.

## Impressions

### Context Menu
<img width="1084" height="406" alt="grafik" src="https://github.com/user-attachments/assets/8e1a5dd1-6133-414a-8b3d-e1c034c6e922" />

### Response
<img width="769" height="226" alt="grafik" src="https://github.com/user-attachments/assets/27642700-0a50-4af7-9bd0-04739fd81fa4" />

### What mods see
<img width="406" height="341" alt="grafik" src="https://github.com/user-attachments/assets/f709dbfc-8bb8-42fc-9751-8946e037a59b" />

<img width="412" height="372" alt="grafik" src="https://github.com/user-attachments/assets/467776b5-539a-4936-a314-faa641e5b513" />

### No scam

<img width="413" height="409" alt="grafik" src="https://github.com/user-attachments/assets/58ee4ef9-d441-4453-8fd3-74071ca40ab3" />

### Yes scam

<img width="615" height="399" alt="grafik" src="https://github.com/user-attachments/assets/8d9c1845-d7ed-4ae0-9d4b-46c874a7b544" />

### DM

<img width="912" height="495" alt="grafik" src="https://github.com/user-attachments/assets/f2a3287a-12ae-4140-8225-33a6b878f967" />

### Quarantined

<img width="710" height="773" alt="grafik" src="https://github.com/user-attachments/assets/6e091107-aefd-40ba-8e01-67145ff24b74" />

### Audit Log

<img width="473" height="269" alt="grafik" src="https://github.com/user-attachments/assets/aab98d4e-9485-48c4-98b4-0d6263bf19ce" />

### Edge cases

<img width="620" height="222" alt="grafik" src="https://github.com/user-attachments/assets/454cccbd-963e-4785-92f6-616979fb95e9" />

<img width="588" height="209" alt="grafik" src="https://github.com/user-attachments/assets/51422009-efe5-4aa7-9427-71cf7567d5b9" />

### Error
<img width="901" height="147" alt="grafik" src="https://github.com/user-attachments/assets/3eea4a15-1a6f-4402-ba9b-87c052697e1a" />
