### PR TITLE
Centralize ambient colors

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/basic/RoleSelectCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/basic/RoleSelectCommand.java
@@ -25,8 +25,8 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.features.CommandVisibility;
 import org.togetherjava.tjbot.features.SlashCommandAdapter;
 import org.togetherjava.tjbot.features.componentids.Lifespan;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 
-import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -61,8 +61,6 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
     private static final String TITLE_OPTION = "title";
     private static final String DESCRIPTION_OPTION = "description";
     private static final String ROLE_OPTION = "selectable-role";
-
-    private static final Color AMBIENT_COLOR = new Color(24, 221, 136, 255);
 
     private static final int OPTIONAL_ROLES_AMOUNT = 22;
 
@@ -275,7 +273,7 @@ public final class RoleSelectCommand extends SlashCommandAdapter {
     private static MessageEmbed createEmbed(String title, CharSequence description) {
         return new EmbedBuilder().setTitle(title)
             .setDescription(description)
-            .setColor(AMBIENT_COLOR)
+            .setColor(AmbientColors.ROLE_MANAGEMENT)
             .build();
     }
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/bookmarks/BookmarksListRemoveHandler.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/bookmarks/BookmarksListRemoveHandler.java
@@ -17,6 +17,7 @@ import net.dv8tion.jda.api.interactions.components.selections.SelectOption;
 import net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu;
 
 import org.togetherjava.tjbot.db.generated.tables.records.BookmarksRecord;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 import org.togetherjava.tjbot.features.utils.MessageUtils;
 
 import java.awt.Color;
@@ -95,11 +96,11 @@ final class BookmarksListRemoveHandler {
         switch (requestType) {
             case LIST -> {
                 title = "Bookmarks List";
-                color = BookmarksSystem.COLOR_SUCCESS;
+                color = AmbientColors.BOOKMARK_SUCCESS;
             }
             case REMOVE -> {
                 title = "Remove Bookmarks";
-                color = BookmarksSystem.COLOR_WARNING;
+                color = AmbientColors.BOOKMARK_WARNING;
             }
             default -> throw new IllegalArgumentException("Unknown request type: " + requestType);
         }

--- a/application/src/main/java/org/togetherjava/tjbot/features/bookmarks/BookmarksSystem.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/bookmarks/BookmarksSystem.java
@@ -9,6 +9,7 @@ import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.records.BookmarksRecord;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 
 import javax.annotation.Nullable;
 
@@ -33,10 +34,6 @@ public final class BookmarksSystem {
     static final int MAX_BOOKMARK_COUNT_PER_USER = 500;
     static final int MAX_NOTE_LENGTH = 150;
     private static final Duration REMOVE_BOOKMARKS_AFTER_LEAVE_DELAY = Duration.ofDays(7);
-
-    static final Color COLOR_SUCCESS = new Color(166, 218, 149);
-    static final Color COLOR_WARNING = new Color(245, 169, 127);
-    static final Color COLOR_FAILURE = new Color(238, 153, 160);
 
     private final Database database;
     private final Predicate<String> isHelpForumName;
@@ -131,15 +128,15 @@ public final class BookmarksSystem {
     }
 
     static MessageEmbed createSuccessEmbed(String content) {
-        return createColoredEmbed(content, COLOR_SUCCESS);
+        return createColoredEmbed(content, AmbientColors.BOOKMARK_SUCCESS);
     }
 
     static MessageEmbed createWarningEmbed(String content) {
-        return createColoredEmbed(content, COLOR_WARNING);
+        return createColoredEmbed(content, AmbientColors.BOOKMARK_WARNING);
     }
 
     static MessageEmbed createFailureEmbed(String content) {
-        return createColoredEmbed(content, COLOR_FAILURE);
+        return createColoredEmbed(content, AmbientColors.BOOKMARK_FAILURE);
     }
 
 }

--- a/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptProgressEmbed.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/chatgpt/ChatGptProgressEmbed.java
@@ -5,7 +5,8 @@ import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.SelfUser;
 import net.dv8tion.jda.api.interactions.InteractionHook;
 
-import java.awt.Color;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -104,7 +105,7 @@ final class ChatGptProgressEmbed implements ChatGptProgressListener {
             .setAuthor(selfUser.getName(), null, selfUser.getEffectiveAvatarUrl())
             .setTitle(title)
             .setDescription(String.join("\n", currentLines))
-            .setColor(Color.gray)
+            .setColor(AmbientColors.CHAT_GPT_PROGRESS)
             .setFooter("One moment, putting an answer together for you.")
             .build();
     }

--- a/application/src/main/java/org/togetherjava/tjbot/features/code/CodeMessageHandler.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/code/CodeMessageHandler.java
@@ -26,7 +26,6 @@ import org.togetherjava.tjbot.features.utils.MessageUtils;
 
 import javax.annotation.Nullable;
 
-import java.awt.Color;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -49,8 +48,6 @@ public final class CodeMessageHandler extends MessageReceiverAdapter implements 
     private static final Logger logger = LoggerFactory.getLogger(CodeMessageHandler.class);
 
     private static final String DELETE_CUE = "delete";
-
-    static final Color AMBIENT_COLOR = Color.decode("#FDFD96");
 
     private final ComponentIdInteractor componentIdInteractor;
     private final Metrics metrics;

--- a/application/src/main/java/org/togetherjava/tjbot/features/code/FormatCodeCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/code/FormatCodeCommand.java
@@ -3,6 +3,7 @@ package org.togetherjava.tjbot.features.code;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 import org.togetherjava.tjbot.features.utils.CodeFence;
 import org.togetherjava.tjbot.formatter.Formatter;
 
@@ -29,7 +30,7 @@ final class FormatCodeCommand implements CodeAction {
 
         return new EmbedBuilder().setTitle("Formatted code")
             .setDescription(formattedCodeFence.toMarkdown())
-            .setColor(CodeMessageHandler.AMBIENT_COLOR)
+            .setColor(AmbientColors.CODE)
             .build();
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/GuildLeaveCloseThreadListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/GuildLeaveCloseThreadListener.java
@@ -8,6 +8,7 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.features.EventReceiver;
 import org.togetherjava.tjbot.features.analytics.Metrics;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 
 /**
  * Remove all thread channels associated to a user when they leave the guild.
@@ -31,7 +32,7 @@ public final class GuildLeaveCloseThreadListener extends ListenerAdapter impleme
     public void onGuildMemberRemove(GuildMemberRemoveEvent event) {
         MessageEmbed embed = new EmbedBuilder().setTitle("OP left")
             .setDescription("Closing thread...")
-            .setColor(HelpSystemHelper.AMBIENT_COLOR)
+            .setColor(AmbientColors.HELP)
             .build();
 
         event.getGuild()

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpSystemHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpSystemHelper.java
@@ -28,9 +28,9 @@ import org.togetherjava.tjbot.features.chatgpt.ChatGptCommand;
 import org.togetherjava.tjbot.features.chatgpt.ChatGptModel;
 import org.togetherjava.tjbot.features.chatgpt.ChatGptService;
 import org.togetherjava.tjbot.features.componentids.ComponentIdInteractor;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 import org.togetherjava.tjbot.features.utils.Guilds;
 
-import java.awt.Color;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -57,8 +57,6 @@ import static org.togetherjava.tjbot.features.utils.MessageUtils.mentionGuildSla
 public final class HelpSystemHelper {
     private static final Logger logger = LoggerFactory.getLogger(HelpSystemHelper.class);
     private static final ChatGptModel CHAT_GPT_MODEL = ChatGptModel.FAST;
-
-    static final Color AMBIENT_COLOR = new Color(255, 255, 165);
 
     private final Predicate<String> isTagManageRole;
     private final Predicate<String> isHelpForumName;
@@ -200,7 +198,7 @@ public final class HelpSystemHelper {
             .setAuthor(selfUser.getName(), null, selfUser.getEffectiveAvatarUrl())
             .setTitle(titleForEmbed)
             .setDescription(answer)
-            .setColor(Color.pink)
+            .setColor(AmbientColors.HELP_CHAT_GPT_RESPONSE)
             .setFooter(responseByGptFooter)
             .build();
     }

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadAutoArchiver.java
@@ -20,6 +20,7 @@ import org.togetherjava.tjbot.features.UserInteractionType;
 import org.togetherjava.tjbot.features.UserInteractor;
 import org.togetherjava.tjbot.features.componentids.ComponentIdGenerator;
 import org.togetherjava.tjbot.features.componentids.ComponentIdInteractor;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -154,7 +155,7 @@ public final class HelpThreadAutoArchiver implements Routine, UserInteractor {
 
                             With enough info, someone knows the answer for sure 👍"""
                         .formatted(linkHowToAsk))
-            .setColor(HelpSystemHelper.AMBIENT_COLOR)
+            .setColor(AmbientColors.HELP)
             .build();
 
         handleArchiveFlow(threadChannel, embed);

--- a/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/help/HelpThreadCommand.java
@@ -21,6 +21,7 @@ import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.features.CommandVisibility;
 import org.togetherjava.tjbot.features.SlashCommandAdapter;
 import org.togetherjava.tjbot.features.analytics.Metrics;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -209,7 +210,7 @@ public final class HelpThreadCommand extends SlashCommandAdapter {
         refreshCooldownFor(Subcommand.CLOSE, helpThread);
 
         MessageEmbed embed = new EmbedBuilder().setDescription("Closed the thread.")
-            .setColor(HelpSystemHelper.AMBIENT_COLOR)
+            .setColor(AmbientColors.HELP)
             .build();
 
         event.replyEmbeds(embed).flatMap(_ -> helpThread.getManager().setArchived(true)).queue();

--- a/application/src/main/java/org/togetherjava/tjbot/features/jshell/renderer/ResultRenderer.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/jshell/renderer/ResultRenderer.java
@@ -7,10 +7,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.togetherjava.tjbot.features.jshell.backend.dto.JShellResult;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 
 import javax.annotation.Nullable;
-
-import java.awt.Color;
 
 /**
  * Allows to render JShell results.
@@ -44,7 +43,7 @@ public class ResultRenderer {
         logger.error("Couldn't render JShell result {} ", result);
         return new EmbedBuilder()
             .setTitle("Couldn't render the result, please contact a moderator.")
-            .setColor(Color.RED)
+            .setColor(AmbientColors.JSHELL_RENDER_FAILURE)
             .build();
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/mathcommands/wolframalpha/WolframAlphaHandler.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/mathcommands/wolframalpha/WolframAlphaHandler.java
@@ -20,8 +20,8 @@ import org.togetherjava.tjbot.features.mathcommands.wolframalpha.api.RelatedExam
 import org.togetherjava.tjbot.features.mathcommands.wolframalpha.api.SubPod;
 import org.togetherjava.tjbot.features.mathcommands.wolframalpha.api.Tip;
 import org.togetherjava.tjbot.features.mathcommands.wolframalpha.api.Tips;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 
-import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -42,7 +42,6 @@ import java.util.stream.Collectors;
 final class WolframAlphaHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(WolframAlphaHandler.class);
     private static final XmlMapper XML = new XmlMapper();
-    private static final Color AMBIENT_COLOR = Color.decode("#4290F5");
     private static final String SERVICE_NAME = "Wolfram|Alpha";
     /**
      * WolframAlpha API endpoint for regular users (web frontend).
@@ -210,7 +209,7 @@ final class WolframAlphaHandler {
     private HandlerResponse responseOf(CharSequence text) {
         MessageEmbed embed = new EmbedBuilder().setTitle(buildTitle(), userApiQuery)
             .setDescription(text)
-            .setColor(AMBIENT_COLOR)
+            .setColor(AmbientColors.WOLFRAM_ALPHA)
             .build();
 
         return new HandlerResponse(List.of(embed), List.of());
@@ -221,7 +220,7 @@ final class WolframAlphaHandler {
         List<MessageEmbed> embeds = new ArrayList<>();
         embeds.add(new EmbedBuilder().setTitle(buildTitle(), userApiQuery)
             .setDescription(text)
-            .setColor(AMBIENT_COLOR)
+            .setColor(AmbientColors.WOLFRAM_ALPHA)
             .build());
 
         List<Attachment> attachments = new ArrayList<>(tiles.size());
@@ -231,7 +230,7 @@ final class WolframAlphaHandler {
             String tileTitle = "result%d.%s".formatted(i, WolframAlphaImages.IMAGE_FORMAT);
 
             attachments.add(new Attachment(tileTitle, WolframAlphaImages.imageToBytes(tile)));
-            embeds.add(new EmbedBuilder().setColor(AMBIENT_COLOR)
+            embeds.add(new EmbedBuilder().setColor(AmbientColors.WOLFRAM_ALPHA)
                 .setImage("attachment://" + tileTitle)
                 .build());
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/mediaonly/MediaOnlyChannelListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/mediaonly/MediaOnlyChannelListener.java
@@ -12,8 +12,8 @@ import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.features.MessageReceiverAdapter;
 import org.togetherjava.tjbot.features.analytics.Metrics;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 
-import java.awt.Color;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -112,7 +112,7 @@ public final class MediaOnlyChannelListener extends MessageReceiverAdapter {
 
         MessageEmbed originalMessageEmbed =
                 new EmbedBuilder().setDescription(originalMessageContent)
-                    .setColor(Color.ORANGE)
+                    .setColor(AmbientColors.MEDIA_WARNING)
                     .build();
 
         return new MessageCreateBuilder().setContent(message.getAuthor().getAsMention()

--- a/application/src/main/java/org/togetherjava/tjbot/features/messages/MessageCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/messages/MessageCommand.java
@@ -19,8 +19,8 @@ import org.slf4j.LoggerFactory;
 
 import org.togetherjava.tjbot.features.CommandVisibility;
 import org.togetherjava.tjbot.features.SlashCommandAdapter;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 
-import java.awt.Color;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
@@ -51,8 +51,6 @@ public final class MessageCommand extends SlashCommandAdapter {
     private static final String CONTENT_DESCRIPTION = "the content of the message";
     static final String EDIT_MESSAGE_ID_OPTION = "edit-message-id";
     private static final String EDIT_MESSAGE_ID_DESCRIPTION = "the id of the message to edit";
-
-    private static final Color AMBIENT_COLOR = new Color(24, 109, 221, 255);
 
     private static final String CONTENT_FILE_NAME = "content.md";
 
@@ -180,7 +178,7 @@ public final class MessageCommand extends SlashCommandAdapter {
         event.getHook()
             .editOriginalEmbeds(new EmbedBuilder().setTitle("Success")
                 .setDescription("Successfully %s message.".formatted(action.getActionVerbPast()))
-                .setColor(MessageCommand.AMBIENT_COLOR)
+                .setColor(AmbientColors.MESSAGE_MANAGEMENT)
                 .build())
             .queue();
     }

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ModerationUtils.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ModerationUtils.java
@@ -18,12 +18,12 @@ import org.slf4j.LoggerFactory;
 
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.features.moderation.modmail.ModMailCommand;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 import org.togetherjava.tjbot.features.utils.Guilds;
 import org.togetherjava.tjbot.features.utils.MessageUtils;
 
 import javax.annotation.Nullable;
 
-import java.awt.Color;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
@@ -50,11 +50,6 @@ public class ModerationUtils {
      * user as option for selection.
      */
     static final String PERMANENT_DURATION = "permanent";
-    /**
-     * The ambient color used by moderation actions, often used to streamline the color theme of
-     * embeds.
-     */
-    public static final Color AMBIENT_COLOR = Color.decode("#895FE8");
 
     /**
      * Checks whether the given reason is valid. If not, it will handle the situation and respond to
@@ -299,7 +294,7 @@ public class ModerationUtils {
         return new EmbedBuilder().setAuthor(author.getName(), null, avatarOrDefaultUrl)
             .setDescription(description)
             .setTimestamp(Instant.now())
-            .setColor(AMBIENT_COLOR)
+            .setColor(AmbientColors.MODERATION)
             .build();
     }
 
@@ -391,7 +386,7 @@ public class ModerationUtils {
                     .setTitle(actionTitle)
                     .setDescription(description)
                     .addField("Reason", reason, false)
-                    .setColor(ModerationUtils.AMBIENT_COLOR);
+                    .setColor(AmbientColors.MODERATION);
 
         if (!showModmailAdvice) {
             return new CompletedRestAction<>(guild.getJDA(), modActionEmbed);

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ReportCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ReportCommand.java
@@ -25,9 +25,9 @@ import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.features.BotCommandAdapter;
 import org.togetherjava.tjbot.features.CommandVisibility;
 import org.togetherjava.tjbot.features.MessageContextCommand;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 import org.togetherjava.tjbot.features.utils.MessageUtils;
 
-import java.awt.Color;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -48,7 +48,6 @@ public final class ReportCommand extends BotCommandAdapter implements MessageCon
     private static final String REPORT_REASON_INPUT_ID = "reportReason";
     private static final int COOLDOWN_DURATION_VALUE = 3;
     private static final ChronoUnit COOLDOWN_DURATION_UNIT = ChronoUnit.MINUTES;
-    private static final Color AMBIENT_COLOR = Color.BLACK;
     private final Cache<Long, Instant> authorToLastReportInvocation = createCooldownCache();
     private final Predicate<String> modMailChannelNamePredicate;
     private final Predicate<String> configModGroupPattern;
@@ -174,12 +173,12 @@ public final class ReportCommand extends BotCommandAdapter implements MessageCon
                     MessageEmbed.DESCRIPTION_MAX_LENGTH))
             .setAuthor(reportedMessage.authorName, null, reportedMessage.authorAvatarUrl)
             .setTimestamp(reportedMessage.timestamp)
-            .setColor(AMBIENT_COLOR)
+            .setColor(AmbientColors.MODMAIL)
             .build();
 
         MessageEmbed reportReasonEmbed = new EmbedBuilder().setTitle("Reason")
             .setDescription(reportReason)
-            .setColor(AMBIENT_COLOR)
+            .setColor(AmbientColors.MODMAIL)
             .build();
 
         MessageCreateAction message =

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/TransferQuestionCommand.java
@@ -33,9 +33,9 @@ import org.togetherjava.tjbot.features.chatgpt.ChatGptService;
 import org.togetherjava.tjbot.features.chatgpt.schema.Property;
 import org.togetherjava.tjbot.features.chatgpt.schema.ResponseSchema;
 import org.togetherjava.tjbot.features.chatgpt.schema.Type;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 import org.togetherjava.tjbot.features.utils.StringDistances;
 
-import java.awt.Color;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -59,7 +59,6 @@ public final class TransferQuestionCommand extends BotCommandAdapter
     private static final int TITLE_MAX_LENGTH = 50;
     private static final Pattern TITLE_GUESS_COMPACT_REMOVAL_PATTERN = Pattern.compile("\\W");
     private static final int TITLE_MIN_LENGTH = 3;
-    private static final Color EMBED_COLOR = new Color(50, 164, 168);
 
     private final Predicate<String> isHelpForumName;
     private final List<String> tags;
@@ -268,7 +267,7 @@ public final class TransferQuestionCommand extends BotCommandAdapter
 
         return new EmbedBuilder().setAuthor(originalUser.getName(), null, avatarOrDefaultUrl)
             .setDescription(originalMessage)
-            .setColor(EMBED_COLOR)
+            .setColor(AmbientColors.QUESTION_TRANSFER)
             .build();
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/attachment/BlacklistedAttachmentListener.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/attachment/BlacklistedAttachmentListener.java
@@ -14,9 +14,9 @@ import org.togetherjava.tjbot.features.MessageReceiverAdapter;
 import org.togetherjava.tjbot.features.analytics.Metrics;
 import org.togetherjava.tjbot.features.moderation.audit.ModAuditLogWriter;
 import org.togetherjava.tjbot.features.moderation.modmail.ModMailCommand;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 import org.togetherjava.tjbot.features.utils.MessageUtils;
 
-import java.awt.Color;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.UnaryOperator;
@@ -97,7 +97,7 @@ public final class BlacklistedAttachmentListener extends MessageReceiverAdapter 
             String dmMessageContent) {
         MessageEmbed originalMessageEmbed =
                 new EmbedBuilder().setDescription(originalMessageContent)
-                    .setColor(Color.ORANGE)
+                    .setColor(AmbientColors.MEDIA_WARNING)
                     .build();
         return new MessageCreateBuilder().setContent(dmMessageContent)
             .setEmbeds(originalMessageEmbed)

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/audit/AuditCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/audit/AuditCommand.java
@@ -25,6 +25,7 @@ import org.togetherjava.tjbot.features.moderation.ActionRecord;
 import org.togetherjava.tjbot.features.moderation.ModerationAction;
 import org.togetherjava.tjbot.features.moderation.ModerationActionsStore;
 import org.togetherjava.tjbot.features.moderation.ModerationUtils;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 
 import javax.annotation.Nullable;
 
@@ -145,7 +146,7 @@ public final class AuditCommand extends SlashCommandAdapter {
         return new EmbedBuilder().setTitle("Audit log of **%s**".formatted(user.getName()))
             .setAuthor(user.getName(), null, avatarOrDefaultUrl)
             .setDescription(createSummaryMessageDescription(actions))
-            .setColor(ModerationUtils.AMBIENT_COLOR);
+            .setColor(AmbientColors.MODERATION);
     }
 
     private static String createSummaryMessageDescription(Collection<ActionRecord> actions) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/audit/ModAuditLogRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/audit/ModAuditLogRoutine.java
@@ -24,10 +24,10 @@ import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.ModAuditLogGuildProcess;
 import org.togetherjava.tjbot.features.Routine;
 import org.togetherjava.tjbot.features.moderation.ModerationUtils;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 
 import javax.annotation.Nullable;
 
-import java.awt.Color;
 import java.time.Instant;
 import java.time.temporal.TemporalAccessor;
 import java.util.Collection;
@@ -50,7 +50,6 @@ public final class ModAuditLogRoutine implements Routine {
     private static final Logger logger = LoggerFactory.getLogger(ModAuditLogRoutine.class);
     private static final int CHECK_AUDIT_LOG_START_HOUR = 4;
     private static final int CHECK_AUDIT_LOG_EVERY_HOURS = 8;
-    private static final Color AMBIENT_COLOR = Color.decode("#4FC3F7");
 
     private final Database database;
     private final Config config;
@@ -277,7 +276,7 @@ public final class ModAuditLogRoutine implements Routine {
             return new EmbedBuilder().setAuthor(author.getName(), null, avatarOrDefaultUrl)
                 .setDescription(description)
                 .setTimestamp(timestamp)
-                .setColor(AMBIENT_COLOR)
+                .setColor(AmbientColors.MODERATION_AUDIT_ACTION)
                 .build();
         }
     }

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/audit/ModAuditLogWriter.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/audit/ModAuditLogWriter.java
@@ -10,11 +10,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.togetherjava.tjbot.config.Config;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 import org.togetherjava.tjbot.features.utils.Guilds;
 
 import javax.annotation.Nullable;
 
-import java.awt.Color;
 import java.nio.charset.StandardCharsets;
 import java.time.temporal.TemporalAccessor;
 import java.util.Optional;
@@ -29,8 +29,6 @@ import java.util.regex.Pattern;
  * to log an entry.
  */
 public final class ModAuditLogWriter {
-    private static final Color EMBED_COLOR = Color.decode("#3788AC");
-
     private static final Logger logger = LoggerFactory.getLogger(ModAuditLogWriter.class);
 
     private final Config config;
@@ -68,7 +66,7 @@ public final class ModAuditLogWriter {
         EmbedBuilder embedBuilder = new EmbedBuilder().setTitle(title)
             .setDescription(description)
             .setTimestamp(timestamp)
-            .setColor(EMBED_COLOR);
+            .setColor(AmbientColors.MODERATION_AUDIT_LOG);
         if (author != null) {
             embedBuilder.setAuthor(author.getName(), null, author.getAvatarUrl());
         }

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/modmail/ModMailCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/modmail/ModMailCommand.java
@@ -25,9 +25,9 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.features.CommandVisibility;
 import org.togetherjava.tjbot.features.SlashCommandAdapter;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 import org.togetherjava.tjbot.features.utils.DiscordClientAction;
 
-import java.awt.Color;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -51,7 +51,6 @@ public final class ModMailCommand extends SlashCommandAdapter {
     private static final String OPTION_GUILD = "server";
     private static final int COOLDOWN_DURATION_VALUE = 30;
     private static final ChronoUnit COOLDOWN_DURATION_UNIT = ChronoUnit.MINUTES;
-    private static final Color AMBIENT_COLOR = Color.BLACK;
     private final Cache<Long, Instant> authorToLastModMailInvocation = createCooldownCache();
     private final Predicate<String> modMailChannelNamePredicate;
     private final Predicate<String> configModGroupPattern;
@@ -210,7 +209,7 @@ public final class ModMailCommand extends SlashCommandAdapter {
         return new EmbedBuilder().setTitle("Modmail")
             .setAuthor(authorTag, null, authorAvatar)
             .setDescription(userMessage)
-            .setColor(AMBIENT_COLOR)
+            .setColor(AmbientColors.MODMAIL)
             .build();
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/scam/ScamBlocker.java
@@ -34,11 +34,11 @@ import org.togetherjava.tjbot.features.moderation.ModerationAction;
 import org.togetherjava.tjbot.features.moderation.ModerationActionsStore;
 import org.togetherjava.tjbot.features.moderation.ModerationUtils;
 import org.togetherjava.tjbot.features.moderation.modmail.ModMailCommand;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 import org.togetherjava.tjbot.features.utils.Guilds;
 import org.togetherjava.tjbot.features.utils.MessageUtils;
 import org.togetherjava.tjbot.logging.LogMarkers;
 
-import java.awt.Color;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
@@ -60,7 +60,6 @@ import java.util.stream.Collectors;
  */
 public final class ScamBlocker extends MessageReceiverAdapter implements UserInteractor {
     private static final Logger logger = LoggerFactory.getLogger(ScamBlocker.class);
-    private static final Color AMBIENT_COLOR = Color.decode("#CFBFF5");
     private static final Set<ScamBlockerConfig.Mode> MODES_WITH_IMMEDIATE_DELETION =
             EnumSet.of(ScamBlockerConfig.Mode.AUTO_DELETE_BUT_APPROVE_QUARANTINE,
                     ScamBlockerConfig.Mode.AUTO_DELETE_AND_QUARANTINE);
@@ -268,7 +267,7 @@ public final class ScamBlocker extends MessageReceiverAdapter implements UserInt
             .setTitle(reportTitle)
             .setAuthor(author.getName(), null, avatarOrDefaultUrl)
             .setTimestamp(event.getMessage().getTimeCreated())
-            .setColor(AMBIENT_COLOR)
+            .setColor(AmbientColors.SCAM_BLOCKER)
             .setFooter(author.getId())
             .build();
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/purge/PurgeHelper.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/purge/PurgeHelper.java
@@ -9,7 +9,8 @@ import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.awt.Color;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
+
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -33,8 +34,9 @@ final class PurgeHelper {
      */
     static void sendConfirmationDialog(IReplyCallback event, String title, String description,
             String confirmComponentId, String cancelComponentId) {
-        EmbedBuilder embed =
-                new EmbedBuilder().setTitle(title).setDescription(description).setColor(Color.RED);
+        EmbedBuilder embed = new EmbedBuilder().setTitle(title)
+            .setDescription(description)
+            .setColor(AmbientColors.PURGE_CONFIRMATION);
 
         event.replyEmbeds(embed.build())
             .setEphemeral(true)

--- a/application/src/main/java/org/togetherjava/tjbot/features/reminder/RemindRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/reminder/RemindRoutine.java
@@ -14,10 +14,10 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.records.PendingRemindersRecord;
 import org.togetherjava.tjbot.features.Routine;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 
 import javax.annotation.Nullable;
 
-import java.awt.Color;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
@@ -34,7 +34,6 @@ import static org.togetherjava.tjbot.db.generated.Tables.PENDING_REMINDERS;
  */
 public final class RemindRoutine implements Routine {
     static final Logger logger = LoggerFactory.getLogger(RemindRoutine.class);
-    static final Color AMBIENT_COLOR = Color.decode("#F7F492");
     private static final int SCHEDULE_INTERVAL_SECONDS = 30;
     private final Database database;
     private static final int MAX_FAILURE_RETRY = 3;
@@ -116,7 +115,7 @@ public final class RemindRoutine implements Routine {
             .setDescription(content)
             .setFooter("reminder from")
             .setTimestamp(createdAt)
-            .setColor(AMBIENT_COLOR)
+            .setColor(AmbientColors.REMINDER)
             .build();
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/reminder/ReminderCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/reminder/ReminderCommand.java
@@ -27,6 +27,7 @@ import org.togetherjava.tjbot.db.Database;
 import org.togetherjava.tjbot.db.generated.tables.records.PendingRemindersRecord;
 import org.togetherjava.tjbot.features.CommandVisibility;
 import org.togetherjava.tjbot.features.SlashCommandAdapter;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 import org.togetherjava.tjbot.features.utils.MessageUtils;
 import org.togetherjava.tjbot.features.utils.StringDistances;
 
@@ -223,8 +224,8 @@ public final class ReminderCommand extends SlashCommandAdapter {
 
         pageToShow = Math.clamp(pageToShow, 1, totalPages);
 
-        EmbedBuilder remindersEmbed = new EmbedBuilder().setTitle("Pending reminders")
-            .setColor(RemindRoutine.AMBIENT_COLOR);
+        EmbedBuilder remindersEmbed =
+                new EmbedBuilder().setTitle("Pending reminders").setColor(AmbientColors.REMINDER);
         MessageCreateBuilder pendingRemindersPage = new MessageCreateBuilder();
 
         if (pendingReminders.isEmpty()) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/roleapplication/CreateRoleApplicationCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/roleapplication/CreateRoleApplicationCommand.java
@@ -28,10 +28,10 @@ import org.togetherjava.tjbot.config.RoleApplicationSystemConfig;
 import org.togetherjava.tjbot.features.CommandVisibility;
 import org.togetherjava.tjbot.features.SlashCommandAdapter;
 import org.togetherjava.tjbot.features.componentids.Lifespan;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 
 import javax.annotation.Nullable;
 
-import java.awt.Color;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +44,6 @@ import java.util.stream.IntStream;
  * guild.
  */
 public class CreateRoleApplicationCommand extends SlashCommandAdapter {
-    protected static final Color AMBIENT_COLOR = new Color(24, 221, 136, 255);
     private static final int OPTIONAL_ROLES_AMOUNT = 5;
     private static final String ROLE_COMPONENT_ID_HEADER = "application-create";
     private static final String OPTION_PARAM_ID_DELIMITER = "_";
@@ -260,7 +259,7 @@ public class CreateRoleApplicationCommand extends SlashCommandAdapter {
                     """
                             We are always looking for community members that want to contribute to our community \
                             and take charge. If you are interested, you can apply for various positions here! 😎""")
-            .setColor(AMBIENT_COLOR)
+            .setColor(AmbientColors.ROLE_MANAGEMENT)
             .build();
     }
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/roleapplication/RoleApplicationHandler.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/roleapplication/RoleApplicationHandler.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.togetherjava.tjbot.config.RoleApplicationSystemConfig;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -94,7 +95,7 @@ public final class RoleApplicationHandler {
         String authorWithId = String.format("%s (id: %s)", applicant.getName(), applicant.getId());
         EmbedBuilder embed =
                 new EmbedBuilder().setAuthor(authorWithId, null, applicant.getAvatarUrl())
-                    .setColor(CreateRoleApplicationCommand.AMBIENT_COLOR)
+                    .setColor(AmbientColors.ROLE_MANAGEMENT)
                     .setFooter("Submitted at")
                     .setTimestamp(Instant.now());
 

--- a/application/src/main/java/org/togetherjava/tjbot/features/tags/TagCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tags/TagCommand.java
@@ -19,6 +19,7 @@ import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
 import org.togetherjava.tjbot.features.CommandVisibility;
 import org.togetherjava.tjbot.features.SlashCommandAdapter;
 import org.togetherjava.tjbot.features.analytics.Metrics;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 import org.togetherjava.tjbot.features.utils.LinkDetection;
 import org.togetherjava.tjbot.features.utils.LinkPreview;
 import org.togetherjava.tjbot.features.utils.LinkPreviews;
@@ -99,7 +100,7 @@ public final class TagCommand extends SlashCommandAdapter {
         MessageEmbed contentEmbed = new EmbedBuilder().setDescription(tagContent)
             .setFooter(event.getUser().getName() + " • used " + event.getCommandString())
             .setTimestamp(Instant.now())
-            .setColor(TagSystem.AMBIENT_COLOR)
+            .setColor(AmbientColors.TAGS)
             .build();
 
         Optional<String> replyToUserMention = Optional.ofNullable(replyToUserOption)

--- a/application/src/main/java/org/togetherjava/tjbot/features/tags/TagManageCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tags/TagManageCommand.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.features.CommandVisibility;
 import org.togetherjava.tjbot.features.SlashCommandAdapter;
 import org.togetherjava.tjbot.features.moderation.audit.ModAuditLogWriter;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 
 import javax.annotation.Nullable;
 
@@ -112,7 +113,7 @@ public final class TagManageCommand extends SlashCommandAdapter {
         event
             .replyEmbeds(new EmbedBuilder().setTitle("Success")
                 .setDescription("Successfully %s tag '%s'.".formatted(actionVerb, id))
-                .setColor(TagSystem.AMBIENT_COLOR)
+                .setColor(AmbientColors.TAGS)
                 .build())
             .queue();
     }

--- a/application/src/main/java/org/togetherjava/tjbot/features/tags/TagSystem.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tags/TagSystem.java
@@ -10,7 +10,6 @@ import org.togetherjava.tjbot.db.generated.tables.Tags;
 import org.togetherjava.tjbot.db.generated.tables.records.TagsRecord;
 import org.togetherjava.tjbot.features.utils.StringDistances;
 
-import java.awt.Color;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -20,11 +19,6 @@ import java.util.stream.Collectors;
  * underlying database.
  */
 public final class TagSystem {
-    /**
-     * The ambient color to use for tag system related messages.
-     */
-    static final Color AMBIENT_COLOR = Color.decode("#FA8072");
-
     private final Database database;
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/features/tags/TagsCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/tags/TagsCommand.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 
 import org.togetherjava.tjbot.features.CommandVisibility;
 import org.togetherjava.tjbot.features.SlashCommandAdapter;
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -57,7 +58,7 @@ public final class TagsCommand extends SlashCommandAdapter {
         event
             .replyEmbeds(new EmbedBuilder().setTitle("All available tags")
                 .setDescription(tagListText)
-                .setColor(TagSystem.AMBIENT_COLOR)
+                .setColor(AmbientColors.TAGS)
                 .build())
             .setEphemeral(true)
             .queue();

--- a/application/src/main/java/org/togetherjava/tjbot/features/utils/AmbientColors.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/utils/AmbientColors.java
@@ -1,0 +1,42 @@
+package org.togetherjava.tjbot.features.utils;
+
+import java.awt.Color;
+
+/**
+ * Provides ambient colors used to visually group Discord embeds by feature.
+ */
+public final class AmbientColors {
+    private AmbientColors() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static final Color BOOKMARK_SUCCESS = Color.decode("#A6DA95");
+    public static final Color BOOKMARK_WARNING = Color.decode("#F5A97F");
+    public static final Color BOOKMARK_FAILURE = Color.decode("#EE99A0");
+    public static final Color CHAT_GPT_PROGRESS = Color.GRAY;
+    public static final Color CODE = Color.decode("#FDFD96");
+    public static final Color HELP = Color.decode("#FFFFA5");
+    public static final Color HELP_CHAT_GPT_RESPONSE = Color.PINK;
+    public static final Color JSHELL_RENDER_FAILURE = Color.RED;
+    public static final Color MEDIA_WARNING = Color.ORANGE;
+    public static final Color MESSAGE_MANAGEMENT = Color.decode("#186DDD");
+    public static final Color MODERATION = Color.decode("#895FE8");
+    public static final Color MODERATION_AUDIT_ACTION = Color.decode("#4FC3F7");
+    public static final Color MODERATION_AUDIT_LOG = Color.decode("#3788AC");
+    public static final Color MODMAIL = Color.BLACK;
+    public static final Color PURGE_CONFIRMATION = Color.RED;
+    public static final Color QUESTION_TRANSFER = Color.decode("#32A4A8");
+    public static final Color REMINDER = Color.decode("#F7F492");
+    public static final Color ROLE_MANAGEMENT = Color.decode("#18DD88");
+    public static final Color SCAM_BLOCKER = Color.decode("#CFBFF5");
+    public static final Color TAGS = Color.decode("#FA8072");
+    public static final Color WOLFRAM_ALPHA = Color.decode("#4290F5");
+
+    // Discord webhook embeds expect raw RGB integers instead of Color instances.
+    public static final int LOG_RAW_TRACE = 0x00B362;
+    public static final int LOG_RAW_DEBUG = 0x00A5CE;
+    public static final int LOG_RAW_INFO = 0xAC59FF;
+    public static final int LOG_RAW_WARN = 0xDFDF00;
+    public static final int LOG_RAW_ERROR = 0xBF2200;
+    public static final int LOG_RAW_FATAL = 0xFF8484;
+}

--- a/application/src/main/java/org/togetherjava/tjbot/logging/discord/DiscordLogForwarder.java
+++ b/application/src/main/java/org/togetherjava/tjbot/logging/discord/DiscordLogForwarder.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.togetherjava.tjbot.features.utils.AmbientColors;
 import org.togetherjava.tjbot.features.utils.MessageUtils;
 import org.togetherjava.tjbot.logging.LogMarkers;
 
@@ -72,9 +73,10 @@ final class DiscordLogForwarder {
      */
     private static final int MAX_EMBED_DESCRIPTION_SHORT = 400;
 
-    private static final Map<Level, Integer> LEVEL_TO_AMBIENT_COLOR =
-            Map.of(Level.TRACE, 0x00B362, Level.DEBUG, 0x00A5CE, Level.INFO, 0xAC59FF, Level.WARN,
-                    0xDFDF00, Level.ERROR, 0xBF2200, Level.FATAL, 0xFF8484);
+    private static final Map<Level, Integer> LEVEL_TO_LOG_COLOR = Map.of(Level.TRACE,
+            AmbientColors.LOG_RAW_TRACE, Level.DEBUG, AmbientColors.LOG_RAW_DEBUG, Level.INFO,
+            AmbientColors.LOG_RAW_INFO, Level.WARN, AmbientColors.LOG_RAW_WARN, Level.ERROR,
+            AmbientColors.LOG_RAW_ERROR, Level.FATAL, AmbientColors.LOG_RAW_FATAL);
 
     private final WebhookClient webhookClient;
     private final String sourceCodeBaseUrl;
@@ -180,7 +182,7 @@ final class DiscordLogForwarder {
             String authorName = event.getLoggerName();
             String authorUrl = linkToSource(event.getSource(), sourceCodeBaseUrl).orElse(null);
             String title = event.getLevel().name();
-            int colorDecimal = Objects.requireNonNull(LEVEL_TO_AMBIENT_COLOR.get(event.getLevel()));
+            int colorDecimal = Objects.requireNonNull(LEVEL_TO_LOG_COLOR.get(event.getLevel()));
             String description =
                     MessageUtils.abbreviate(describeLogEvent(event), MAX_EMBED_DESCRIPTION);
             Instant timestamp = Instant.ofEpochMilli(event.getInstant().getEpochMillisecond());

--- a/formatter/src/test/java/org/togetherjava/tjbot/formatter/FormatterTest.java
+++ b/formatter/src/test/java/org/togetherjava/tjbot/formatter/FormatterTest.java
@@ -116,7 +116,7 @@ final class FormatterTest {
                                 public MessageEmbed apply(CodeFence codeFence){String formattedCode=formatCode(codeFence.code()); \
                                 CodeFence formattedCodeFence=new CodeFence(codeFence.language(),formattedCode); \
                                 return new EmbedBuilder().setTitle("Formatted code").setDescription(formattedCodeFence.toMarkdown()) \
-                                .setColor(CodeMessageHandler.AMBIENT_COLOR).build();}
+                                .setColor(AmbientColors.CODE).build();}
                                 private String formatCode(String code){for(SnippetFormatter.SnippetKind snippetKind: \
                                 SnippetFormatter.SnippetKind.values()){try{List<Replacement>replacements= \
                                 formatter.format(snippetKind,code,List.of(Range.closedOpen(0,code.length())),2,false); \
@@ -145,7 +145,7 @@ final class FormatterTest {
                                   public MessageEmbed apply(CodeFence codeFence) {
                                     String formattedCode = formatCode(codeFence.code());
                                     CodeFence formattedCodeFence = new CodeFence(codeFence.language(), formattedCode);
-                                    return new EmbedBuilder().setTitle("Formatted code").setDescription(formattedCodeFence.toMarkdown()).setColor(CodeMessageHandler.AMBIENT_COLOR).build();
+                                    return new EmbedBuilder().setTitle("Formatted code").setDescription(formattedCodeFence.toMarkdown()).setColor(AmbientColors.CODE).build();
                                   }
                                   private String formatCode(String code) {
                                     for (SnippetFormatter.SnippetKind snippetKind : SnippetFormatter.SnippetKind.values()) {


### PR DESCRIPTION
Closes #1506

## Summary
- Add `AmbientColors` as a central place for Discord embed accent colors
- Replace scattered feature-specific color constants with named shared colors
- Reuse matching colors across related features, such as role management and moderation embeds

## Testing
- `./gradlew.bat spotlessCheck test`