### PR TITLE
chore: update channel used in `ThisIsScamCommand` to `modmail` instead of `mod-audit-logs`

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
@@ -66,7 +66,7 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
 
     private final Config config;
     private final ModerationActionsStore actionsStore;
-    private final Predicate<String> isModAuditLogChannel;
+    private final Predicate<String> isModMailChannel;
 
     private final Cache<Long, Instant> reportedMessageToTimestamp =
             Caffeine.newBuilder().maximumSize(10_000).expireAfterWrite(Duration.ofDays(1)).build();
@@ -86,8 +86,7 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
 
         this.config = Objects.requireNonNull(config);
         this.actionsStore = Objects.requireNonNull(actionsStore);
-        isModAuditLogChannel =
-                Pattern.compile(config.getModAuditLogChannelPattern()).asMatchPredicate();
+        isModMailChannel = Pattern.compile(config.getModMailChannelPattern()).asMatchPredicate();
     }
 
     @Override
@@ -152,8 +151,7 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
 
     private Optional<TextChannel> findModAuditLogChannel(MessageContextInteractionEvent event) {
         Guild guild = Objects.requireNonNull(event.getGuild());
-        Optional<TextChannel> modAuditLogChannel =
-                Guilds.findTextChannel(guild, isModAuditLogChannel);
+        Optional<TextChannel> modAuditLogChannel = Guilds.findTextChannel(guild, isModMailChannel);
         if (modAuditLogChannel.isEmpty()) {
             logger.warn(
                     "Cannot find the designated mod audit log channel in guild '{}' with the pattern '{}'",

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
@@ -98,7 +98,7 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
             return;
         }
 
-        Optional<TextChannel> modAuditLog = findModAuditLogChannel(event);
+        Optional<TextChannel> modAuditLog = findModMailChannel(event);
         if (modAuditLog.isEmpty()) {
             event.reply(FAILED_MESSAGE).setEphemeral(true).queue();
             return;
@@ -149,7 +149,7 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
         return false;
     }
 
-    private Optional<TextChannel> findModAuditLogChannel(MessageContextInteractionEvent event) {
+    private Optional<TextChannel> findModMailChannel(MessageContextInteractionEvent event) {
         Guild guild = Objects.requireNonNull(event.getGuild());
         Optional<TextChannel> modMailChannel = Guilds.findTextChannel(guild, isModMailChannel);
         if (modMailChannel.isEmpty()) {

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/ThisIsScamCommand.java
@@ -151,13 +151,13 @@ public final class ThisIsScamCommand extends BotCommandAdapter implements Messag
 
     private Optional<TextChannel> findModAuditLogChannel(MessageContextInteractionEvent event) {
         Guild guild = Objects.requireNonNull(event.getGuild());
-        Optional<TextChannel> modAuditLogChannel = Guilds.findTextChannel(guild, isModMailChannel);
-        if (modAuditLogChannel.isEmpty()) {
+        Optional<TextChannel> modMailChannel = Guilds.findTextChannel(guild, isModMailChannel);
+        if (modMailChannel.isEmpty()) {
             logger.warn(
                     "Cannot find the designated mod audit log channel in guild '{}' with the pattern '{}'",
                     guild.getId(), config.getModAuditLogChannelPattern());
         }
-        return modAuditLogChannel;
+        return modMailChannel;
     }
 
     private MessageCreateAction reportToMods(Message message, TextChannel auditChannel) {


### PR DESCRIPTION
The mod-audit-logs channel is very spammy and most staff have this muted. Switched to use the modmail channel as that is actively used for viewing user reports.