### PR TITLE
Fixes race condition in QuoteBoardForwarder

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/basic/QuoteBoardForwarder.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/basic/QuoteBoardForwarder.java
@@ -4,9 +4,10 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageReaction;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
-import net.dv8tion.jda.api.entities.emoji.EmojiUnion;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.requests.RestAction;
 import org.slf4j.Logger;
@@ -15,9 +16,13 @@ import org.slf4j.LoggerFactory;
 import org.togetherjava.tjbot.config.Config;
 import org.togetherjava.tjbot.config.QuoteBoardConfig;
 import org.togetherjava.tjbot.features.MessageReceiverAdapter;
+import org.togetherjava.tjbot.features.Routine;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -34,12 +39,19 @@ import java.util.regex.Pattern;
  * Key points: - Trigger emoji, minimum vote count and quote-board channel pattern are supplied via
  * {@code QuoteBoardConfig}.
  */
-public final class QuoteBoardForwarder extends MessageReceiverAdapter {
+public final class QuoteBoardForwarder extends MessageReceiverAdapter implements Routine {
 
     private static final Logger logger = LoggerFactory.getLogger(QuoteBoardForwarder.class);
-    private final Emoji botEmoji;
+
+    private record ReactedMessage(long guildId, long channelId, long messageId) {
+    }
+
+    private final Emoji messageForwardedEmojiMarker;
     private final Predicate<String> isQuoteBoardChannelName;
     private final QuoteBoardConfig config;
+
+    private final Object reactedMessagesLock = new Object();
+    private Set<ReactedMessage> reactedMessages = new HashSet<>();
 
     /**
      * Constructs a new instance of QuoteBoardForwarder.
@@ -49,7 +61,7 @@ public final class QuoteBoardForwarder extends MessageReceiverAdapter {
      */
     public QuoteBoardForwarder(Config config) {
         this.config = config.getQuoteBoardConfig();
-        this.botEmoji = Emoji.fromUnicode(this.config.botEmoji());
+        this.messageForwardedEmojiMarker = Emoji.fromUnicode(this.config.botEmoji());
 
         this.isQuoteBoardChannelName = Pattern.compile(this.config.channel()).asMatchPredicate();
     }
@@ -64,59 +76,76 @@ public final class QuoteBoardForwarder extends MessageReceiverAdapter {
             return;
         }
 
-        final long guildId = event.getGuild().getIdLong();
+        if (event.getChannelType() != ChannelType.TEXT) {
+            logger.debug("Skipping reaction as only text-channels are supported");
+            return;
+        }
 
-        Optional<TextChannel> boardChannelOptional = findQuoteBoardChannel(event.getJDA(), guildId);
+        synchronized (reactedMessagesLock) {
+            reactedMessages.add(new ReactedMessage(event.getGuild().getIdLong(),
+                    event.getChannel().getIdLong(), event.getMessageIdLong()));
+        }
+    }
 
+    @Override
+    public Schedule createSchedule() {
+        return new Schedule(ScheduleMode.FIXED_DELAY, 1, 1, TimeUnit.MINUTES);
+    }
+
+    @Override
+    public void runRoutine(JDA jda) {
+        Set<ReactedMessage> messagesToProcess;
+        synchronized (reactedMessagesLock) {
+            messagesToProcess = reactedMessages;
+            reactedMessages = new HashSet<>();
+        }
+
+        messagesToProcess.forEach(message -> {
+            try {
+                processMessage(jda, message);
+            } catch (Exception e) {
+                logger.warn(
+                        "Failed to process message ({}) for potentially forwarding it to the quote-board.",
+                        message, e);
+            }
+        });
+    }
+
+    private void processMessage(JDA jda, ReactedMessage reactedMessage) {
+        Optional<TextChannel> boardChannelOptional =
+                findQuoteBoardChannel(jda, reactedMessage.guildId);
         if (boardChannelOptional.isEmpty()) {
             logger.warn(
                     "Could not find board channel with pattern '{}' in server with ID '{}'. Skipping reaction handling...",
-                    this.config.channel(), guildId);
+                    config.channel(), reactedMessage.guildId);
             return;
         }
 
         TextChannel boardChannel = boardChannelOptional.orElseThrow();
-
-        if (boardChannel.getId().equals(event.getChannel().getId())) {
-            logger.debug("Someone tried to react with the react emoji to the quotes channel.");
+        if (boardChannel.getIdLong() == reactedMessage.channelId) {
+            logger.debug(
+                    "Someone tried to react with the react emoji to the quotes channel, ignoring.");
             return;
         }
 
-        event.retrieveMessage().queue(message -> {
-            if (hasAlreadyForwardedMessage(message)) {
-                logger.debug("Message has already been forwarded by the bot. Skipping.");
-                return;
-            }
+        jda.getGuildById(reactedMessage.guildId)
+            .getTextChannelById(reactedMessage.channelId)
+            .retrieveMessageById(reactedMessage.messageId)
+            .queue(message -> {
+                if (hasAlreadyForwardedMessage(message)) {
+                    logger.debug("Message has already been forwarded by the bot. Skipping.");
+                    return;
+                }
 
-            float emojiScore = calculateMessageScore(message.getReactions());
+                double emojiScore = calculateMessageScore(message.getReactions());
+                if (emojiScore < config.minimumScoreToTrigger()) {
+                    return;
+                }
 
-            if (emojiScore < config.minimumScoreToTrigger()) {
-                return;
-            }
-
-            logger.debug("Attempting to forward message to quote board channel: {}",
-                    boardChannel.getName());
-
-            markAsProcessed(message).flatMap(_ -> message.forwardTo(boardChannel))
-                .queue(_ -> logger.debug("Message forwarded to quote board channel: {}",
-                        boardChannel.getName()),
-                        e -> logger.warn(
-                                "Unknown error while attempting to retrieve and forward message for quote-board, message is ignored.",
-                                e));
-        });
+                forwardMessage(message, boardChannel);
+            });
     }
 
-    private RestAction<Void> markAsProcessed(Message message) {
-        return message.addReaction(botEmoji);
-    }
-
-    /**
-     * Gets the board text channel where the quotes go to, wrapped in an optional.
-     *
-     * @param jda the JDA
-     * @param guildId the guild ID
-     * @return the board text channel
-     */
     private Optional<TextChannel> findQuoteBoardChannel(JDA jda, long guildId) {
         Guild guild = jda.getGuildById(guildId);
 
@@ -139,26 +168,38 @@ public final class QuoteBoardForwarder extends MessageReceiverAdapter {
         return matchingChannels.stream().findFirst();
     }
 
-    /**
-     * Checks whether the bot has already reacted to the given message with its marker emoji.
-     */
     private boolean hasAlreadyForwardedMessage(Message message) {
         return message.getReactions()
             .stream()
-            .filter(reaction -> botEmoji.equals(reaction.getEmoji()))
+            .filter(reaction -> messageForwardedEmojiMarker.equals(reaction.getEmoji()))
             .anyMatch(MessageReaction::isSelf);
     }
 
-    private float calculateMessageScore(List<MessageReaction> reactions) {
-        return (float) reactions.stream()
+    private double calculateMessageScore(List<MessageReaction> reactions) {
+        return reactions.stream()
             .mapToDouble(reaction -> reaction.getCount() * getEmojiScore(reaction.getEmoji()))
             .sum();
     }
 
-    private float getEmojiScore(EmojiUnion emoji) {
+    private float getEmojiScore(Emoji emoji) {
         float defaultScore = config.defaultEmojiScore();
         String reactionCode = emoji.getAsReactionCode();
 
         return config.emojiScores().getOrDefault(reactionCode, defaultScore);
+    }
+
+    private void forwardMessage(Message message, MessageChannel boardChannel) {
+        logger.debug("Attempting to forward message to quote board channel: {}",
+                boardChannel.getName());
+
+        markMessageAsForwarded(message).flatMap(_ -> message.forwardTo(boardChannel))
+            .queue(_ -> logger.debug("Message forwarded to quote board channel: {}", boardChannel
+                .getName()), e -> logger.warn(
+                        "Unknown error while attempting to retrieve and forward message for quote-board, message is ignored.",
+                        e));
+    }
+
+    private RestAction<Void> markMessageAsForwarded(Message message) {
+        return message.addReaction(messageForwardedEmojiMarker);
     }
 }


### PR DESCRIPTION
## Overview

`QuoteBoardForwarder` has a race condition that causes a message to be forwarded multiple times to `#quotes` if multiple users reacted to a message within short time. (This was already attempted with #1523 previously)

This PR fixes the problem by slightly redesigning the logic-flow in a way that the race condition cannot occur anymore by design.

## Details

Previously, the `onMessageReactionAdd` handler decided whether a message will be forwarded or not. But this method is called concurrently by JDA on each reaction. So, by design, this is rather unsafe.

The change introduced in this PR is conceptionally simple. `onMessageReactionAdd` now only adds the message to a `Set<ReactedMessage>`, aka "messages to process" (like a `Queue`, but no duplicates).

From there, it is then picked up by a `Routine` once a minute and the decision and handling is now done there instead. The routine is set to `ScheduleMode.FIXED_DELAY` instead of `FIXED_RATE`, so by design it can only run **after** the previous routine run is done, not concurrently anymore. This fixes the underlying problem by design.

The rest of the changes are just cosmetic and code-style improvements without any logic changes.

## Remarks

### Checks

Originally I wanted to do more of the early-outs already in `onMessageReactionAdd`, so the messages ending up in the task-queue (`Set<ReactedMessage>`) are only messages that actually need to be forwarded to `#quotes`.

Like, ideally `onMessageReactionAdd` would already check:
* does the message still exist?
* was it already forwarded previously?
* does it even have a high enough emoji-count?

But sadly, due to JDA shenanigans, that isnt really possible. Well, it is possible, but it wouldnt yield any performance boost. The problem is that the `MessageReactionAddEvent event` does not provide a handle to the message yet. Accessing the message (to check if it exists, if it was already forwarded, or to compute its emoji scores) requires an `event.retrieveMessage()` there already, i.e. a Rest-Api call.

So doing these checks in the reaction-handler already would not save us anything and would actually lead to us having to do two API calls per message - not good.

Because of that those checks are all moved to the `Routine` and the reaction-handler itself only does the checks it can do right away without any API calls.

### Lock

I would love to have avoided that `private final Object lock` around the set. Unfortunately, there is no better way to do an atomic "fetch and remove".

Like, we either need to do `getAll-and-clear` (`drain`) or `getOne-and-remove` (`poll`). `Set` doesnt offer this natively. `Queue` does, but that allows duplicates and we really dont want duplicates in this (since reactions usually come in waves).

There are of course also other workarounds, but I ultimately decided to add a small lock instead.