### PR TITLE
Add feature to support 14 days and 1 year bans. fixes: #1527

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/BanCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/BanCommand.java
@@ -50,7 +50,7 @@ public final class BanCommand extends SlashCommandAdapter {
     private static final String ACTION_TITLE = "Ban";
     @SuppressWarnings("StaticCollection")
     private static final List<String> DURATIONS = List.of(ModerationUtils.PERMANENT_DURATION,
-            "1 hour", "3 hours", "1 day", "2 days", "3 days", "7 days", "30 days");
+            "1 hour", "3 hours", "1 day", "2 days", "3 days", "7 days", "14 days", "30 days", "365 days");
     private final ModerationActionsStore actionsStore;
 
     /**

--- a/application/src/main/java/org/togetherjava/tjbot/features/moderation/BanCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/moderation/BanCommand.java
@@ -49,8 +49,9 @@ public final class BanCommand extends SlashCommandAdapter {
     private static final String ACTION_VERB = "ban";
     private static final String ACTION_TITLE = "Ban";
     @SuppressWarnings("StaticCollection")
-    private static final List<String> DURATIONS = List.of(ModerationUtils.PERMANENT_DURATION,
-            "1 hour", "3 hours", "1 day", "2 days", "3 days", "7 days", "14 days", "30 days", "365 days");
+    private static final List<String> DURATIONS =
+            List.of(ModerationUtils.PERMANENT_DURATION, "1 hour", "3 hours", "1 day", "2 days",
+                    "3 days", "7 days", "14 days", "30 days", "365 days");
     private final ModerationActionsStore actionsStore;
 
     /**


### PR DESCRIPTION
fixes: #1527
New feature was added for admins. Admins can now also ban with durations 14 days or 1 year.

The following now looks like this:
<img width="1132" height="642" alt="image" src="https://github.com/user-attachments/assets/43b05712-bcb5-46f2-8c89-c3c34abd9a44" />

Testing was done manually. I invited my friend into my test server and banned him for 14 days and 1 year. He was banned and then I have advanced system time further than 14 days and 1 year. Ban was revoked and after routine run he was unbanned.

```
15:35:28.878 [pool-4-thread-4] WARN  org.togetherjava.tjbot.features.help.HelpThreadActivityUpdater - Unable to update help thread activities, did not find a help forum matching the configured pattern 'questions' for guild 'Mama africa's server'
15:38:32.984 [ForkJoinPool.commonPool-worker-2] INFO  org.togetherjava.tjbot.features.moderation.BanCommand - 'kosta4115' (1021391825677860975) banned the user 'antiriad7' (488754445673431042) for 14 days from guild 'Mama africa's server' and deleted their message history of the last 0 days, for reason 'kkk'.
15:39:28.131 [ForkJoinPool.commonPool-worker-3] INFO  org.togetherjava.tjbot.features.moderation.temp.TemporaryModerationRoutine - Revoked temporary action BAN against user 'antiriad7' (488754445673431042).
```

Note that logs are within the same console since, I have just reloaded the project with Intellij devtools feature since I had  problems with certificate when running app from scratch. 


EDIT:
I have made changes as @Zabuzard and @Alathreon suggested. Since `.plus(...)` method doesn't support years, I had to convert number of years into number of days and use unit of `DAYS` to calculate ban period.

EDIT 2:
We have decided just to have 365 days option inserted instead of one 1 year.