### PR TITLE
fix(purge): fetch using target member instead of reading the member cache

### DIFF
--- a/application/src/main/java/org/togetherjava/tjbot/features/purge/PurgeMessagesByUserCommand.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/purge/PurgeMessagesByUserCommand.java
@@ -79,12 +79,13 @@ public class PurgeMessagesByUserCommand extends SlashCommandAdapter {
     @Override
     public void onSlashCommand(SlashCommandInteractionEvent event) {
         Guild guild = Objects.requireNonNull(event.getGuild());
-        User targetUser = Objects.requireNonNull(event.getOption(USER_OPTION)).getAsUser();
+        OptionMapping targetOption = Objects.requireNonNull(event.getOption(USER_OPTION));
+        User targetUser = targetOption.getAsUser();
         int minutes = Objects.requireNonNull(event.getOption(MINUTES_OPTION)).getAsInt();
         OptionMapping amountOption = event.getOption(AMOUNT_OPTION);
         int amount = amountOption == null ? Integer.MAX_VALUE : amountOption.getAsInt();
 
-        Member targetMember = guild.getMember(targetUser);
+        Member targetMember = targetOption.getAsMember();
         if (targetMember == null) {
             event.reply("That user is not a member of this guild.").setEphemeral(true).queue();
             return;
@@ -137,26 +138,34 @@ public class PurgeMessagesByUserCommand extends SlashCommandAdapter {
         int amount = Integer.parseInt(args.get(3));
 
         Guild guild = Objects.requireNonNull(event.getGuild());
-        Member targetMember = guild.getMemberById(targetUserId);
-        if (targetMember == null) {
-            event.editMessage("That user is no longer a member of this guild.")
-                .setEmbeds()
-                .setComponents()
-                .queue();
-            return;
-        }
+
+        event.deferEdit().queue();
+
+        guild.retrieveMemberById(targetUserId)
+            .queue(targetMember -> startPurge(event, guild, targetMember, anchorSnowflake, amount),
+                    _ -> event.getHook()
+                        .editOriginal("That user is no longer a member of this guild.")
+                        .setEmbeds()
+                        .setComponents()
+                        .queue());
+    }
+
+    private void startPurge(ButtonInteractionEvent event, Guild guild, Member targetMember,
+            String anchorSnowflake, int amount) {
+        long targetUserId = targetMember.getIdLong();
 
         List<GuildMessageChannel> candidates = collectCandidateChannels(guild, targetMember);
         if (candidates.isEmpty()) {
-            event.editMessage("No accessible channels remain to scan.")
+            event.getHook()
+                .editOriginal("No accessible channels remain to scan.")
                 .setEmbeds()
                 .setComponents()
                 .queue();
             return;
         }
 
-        event
-            .editMessage("Purging across %d channels... this may take a while."
+        event.getHook()
+            .editOriginal("Purging across %d channels... this may take a while."
                 .formatted(candidates.size()))
             .setEmbeds()
             .setComponents()


### PR DESCRIPTION
[contributing]: https://github.com/Together-Java/TJ-Bot/wiki/Contributing
[code_guidelines]: https://github.com/Together-Java/TJ-Bot/wiki/Code-Guidelines
[new_issue]: https://github.com/Together-Java/TJ-Bot/issues/new/choose

## Pull-request

- [X] I have read the [contributing guidelines][contributing].
- [X] I have read the [code guidelines][code_guidelines].
- [ ] I have created a relating [issue][new_issue].

### Changes

- [X] Existing code
- [ ] New feature

<!--
While an issue isn't required, this is preferred for most changes.
It helps make it maintainable for us, and will save you from possibly recoding everything :p
If there's no relating issue, keep it NaN
-->

Closes Issue: NaN

## Description

The `/purge-messages-by-user` slash command always failed with the error message "That user is not a member of this guild." because it looked the target up via `Guild#getMember`. This is a cache-only lookup. 

Now the slash command takes the member from OptionMapping#getAsMember, which JDA builds from the interaction's resolved payload and therefore works for uncached members at no extra REST cost.

The confirm button has no resolved data, so it fetches via Guild#retrieveMemberById, deferring the edit first so the fetch cannot blow the interaction ack window, and the follow-up edits go through the interaction hook.
